### PR TITLE
Refactor canonical edit surface and migrate ADRs to v3

### DIFF
--- a/.claude/agents/adr-reviewer.md
+++ b/.claude/agents/adr-reviewer.md
@@ -30,6 +30,7 @@ When invoked:
 ### Decision Clarity
 
 - [ ] Leads with a clear action: "We will **X**"
+- [ ] `selected_option` is explicit for accepted-ready ADRs and matches the chosen path described in the Decision section
 - [ ] Reasons are numbered and specific — not "because it's better"
 - [ ] Decision is concrete enough to guide implementation without turning into a work-item execution log
 - [ ] Decision is proportional to the problem (not over-engineered)

--- a/.claude/skills/adr-writer/SKILL.md
+++ b/.claude/skills/adr-writer/SKILL.md
@@ -29,9 +29,10 @@ EOF
 govctl adr set <ADR-ID> decision --stdin <<'EOF'
 decision text
 EOF
-govctl adr set <ADR-ID> consequences --stdin <<'EOF'
-consequences text
-EOF
+govctl adr set <ADR-ID> selected_option "Option A"
+govctl adr edit <ADR-ID> content.consequences.positive --add "Benefit"
+govctl adr edit <ADR-ID> content.consequences.negative --add "Trade-off"
+govctl adr edit <ADR-ID> content.consequences.negative[0].mitigations --add "Mitigation"
 govctl adr add <ADR-ID> alternatives "Option: Description"
 govctl adr add <ADR-ID> refs RFC-NNNN
 ```
@@ -87,22 +88,13 @@ Specific guardrails for implementing this decision, not a task checklist.
 
 Honest accounting of trade-offs. Structure:
 
-> **Do NOT include `## Consequences` heading** — the renderer adds it automatically.
+Use structured fields, not a single prose blob:
 
-```markdown
-### Positive
-
-- Benefit one
-- Benefit two
-
-### Negative
-
-- Trade-off one (mitigation: ...)
-- Trade-off two (mitigation: ...)
-
-### Neutral
-
-- Side effect that is neither positive nor negative
+```bash
+govctl adr edit <ADR-ID> content.consequences.positive --add "Benefit one"
+govctl adr edit <ADR-ID> content.consequences.negative --add "Trade-off one"
+govctl adr edit <ADR-ID> content.consequences.negative[0].mitigations --add "Mitigation step"
+govctl adr edit <ADR-ID> content.consequences.neutral --add "Side effect"
 ```
 
 **Key principle:** Every decision has downsides. If your Negative section is empty, you haven't thought hard enough.
@@ -111,11 +103,15 @@ Honest accounting of trade-offs. Structure:
 
 Document options considered. Future readers need to know what was _not_ chosen and why.
 
-**Extended structure per ADR-0027:**
+**Chosen option vs alternatives:**
+
+- `selected_option`: the path that was chosen
+- `alternatives[]`: options that were **not** chosen
+
+**Current structure:**
 
     [[content.alternatives]]
     text = "Option A: Description"
-    status = "rejected"
     pros = ["Advantage 1", "Advantage 2"]
     cons = ["Disadvantage 1"]
     rejection_reason = "Why this was not chosen"
@@ -123,25 +119,23 @@ Document options considered. Future readers need to know what was _not_ chosen a
 **Field semantics:**
 
 - `text` (required): Description of the alternative
-- `status`: `considered` (default) | `accepted` | `rejected`
 - `pros`: List of advantages
 - `cons`: List of disadvantages
-- `rejection_reason`: If rejected, explains why
+- `rejection_reason`: Why this alternative was not chosen
 
 **CLI commands:**
 
 ```bash
-# Simple alternative
-govctl adr add <ADR-ID> alternatives "Option A: Use PostgreSQL"
+# Chosen option
+govctl adr set <ADR-ID> selected_option "Use PostgreSQL"
 
-# With pros, cons, and rejection reason
-govctl adr add <ADR-ID> alternatives "Option B: Use Redis" \
+# Rejected alternative with trade-offs
+govctl adr add <ADR-ID> alternatives "Use Redis" \
   --pro "Fast caching" --pro "Simple API" \
   --con "Additional infrastructure" \
   --reject-reason "Overkill for our scale"
 
 # Edit nested fields after creation
-govctl adr tick <ADR-ID> alternatives --at 0 -s rejected
 govctl adr add <ADR-ID> alt[0].pros "New advantage"
 govctl adr remove <ADR-ID> alt[0].cons "Outdated disadvantage"
 ```
@@ -183,7 +177,8 @@ Link to artifacts that constrained or informed the decision. Use plain IDs (not 
 
 - The problem that required a decision
 - Constraints and decision drivers
-- Alternatives considered and why they were accepted or rejected
+- The chosen option and why it was selected
+- Alternatives considered and why they were rejected
 - The chosen approach
 - Positive, negative, and neutral consequences
 
@@ -211,7 +206,7 @@ The renderer auto-generates structural elements from TOML metadata. **Do NOT inc
 
 - `## Context`, `## Decision`, `## Consequences` headings — auto-generated for each section
 - `## Alternatives Considered` heading — auto-generated if alternatives exist
-- `### Option Name (status)` headings — auto-generated from `alternatives[].text` + `status`
+- `### Option Name` headings — auto-generated from `alternatives[].text`
 - `- **Pros:**`, `- **Cons:**`, `- **Rejected because:**` — auto-generated from structured fields
 - ADR title (`# ADR-NNNN: Title`) — auto-generated from metadata
 

--- a/.claude/skills/discuss/SKILL.md
+++ b/.claude/skills/discuss/SKILL.md
@@ -28,7 +28,7 @@ govctl adr list                           # List all ADRs
 # RFC drafting
 govctl rfc new "<title>"                  # Create RFC (auto-assigns ID)
 govctl clause new <RFC-ID>:C-<NAME> "<title>" -s "<section>" -k <kind>
-govctl clause edit <RFC-ID>:C-<NAME> --stdin <<'EOF'
+govctl clause edit <RFC-ID>:C-<NAME> text --stdin <<'EOF'
 clause text here
 EOF
 
@@ -36,8 +36,10 @@ EOF
 govctl adr new "<title>"                  # Create ADR
 govctl adr set <ADR-ID> context "..." --stdin
 govctl adr set <ADR-ID> decision "..." --stdin
-govctl adr set <ADR-ID> consequences "..." --stdin
-govctl adr add <ADR-ID> alternatives "Option: Description"
+govctl adr set <ADR-ID> selected_option "Option A"
+govctl adr edit <ADR-ID> content.consequences.positive --add "Benefit"
+govctl adr edit <ADR-ID> content.consequences.negative --add "Trade-off"
+govctl adr add <ADR-ID> alternatives "Rejected option"
 govctl adr add <ADR-ID> refs RFC-0001
 
 # Validation
@@ -151,7 +153,7 @@ For structure, templates, and quality guidelines, follow the **rfc-writer** skil
 ```bash
 govctl rfc new "<title>"
 govctl clause new <RFC-ID>:C-<NAME> "<title>" -s "<section>" -k <kind>
-govctl clause edit <RFC-ID>:C-<NAME> --stdin <<'EOF'
+govctl clause edit <RFC-ID>:C-<NAME> text --stdin <<'EOF'
 clause text
 EOF
 ```
@@ -177,7 +179,7 @@ govctl adr add <ADR-ID> refs RFC-NNNN
 
 ```bash
 # Edit the clause content
-govctl clause edit <RFC-ID>:C-<NAME> --stdin <<'EOF'
+govctl clause edit <RFC-ID>:C-<NAME> text --stdin <<'EOF'
 Updated specification text.
 EOF
 

--- a/.claude/skills/discuss/SKILL.md
+++ b/.claude/skills/discuss/SKILL.md
@@ -164,8 +164,10 @@ For structure, templates, and quality guidelines, follow the **adr-writer** skil
 govctl adr new "<title>"
 govctl adr set <ADR-ID> context --stdin <<'EOF' ... EOF
 govctl adr set <ADR-ID> decision --stdin <<'EOF' ... EOF
-govctl adr set <ADR-ID> consequences --stdin <<'EOF' ... EOF
-govctl adr add <ADR-ID> alternatives "Option: Description"
+govctl adr set <ADR-ID> selected_option "Option A"
+govctl adr edit <ADR-ID> content.consequences.positive --add "Benefit"
+govctl adr edit <ADR-ID> content.consequences.negative --add "Trade-off"
+govctl adr add <ADR-ID> alternatives "Rejected: Option B"
 govctl adr add <ADR-ID> refs RFC-NNNN
 ```
 

--- a/.claude/skills/migrate/SKILL.md
+++ b/.claude/skills/migrate/SKILL.md
@@ -41,7 +41,9 @@ govctl status                             # Verify setup
 govctl adr new "<decision title>"
 govctl adr set <ADR-ID> context --stdin <<'EOF' ... EOF
 govctl adr set <ADR-ID> decision --stdin <<'EOF' ... EOF
-govctl adr set <ADR-ID> consequences --stdin <<'EOF' ... EOF
+govctl adr set <ADR-ID> selected_option "<what was adopted>"
+govctl adr edit <ADR-ID> content.consequences.positive --add "<observed benefit>"
+govctl adr edit <ADR-ID> content.consequences.negative --add "<observed downside>"
 govctl adr add <ADR-ID> alternatives "Option: ..." --pro "..." --con "..." --reject-reason "..."
 govctl adr accept <ADR-ID>
 
@@ -194,30 +196,20 @@ We will [what was decided].
 [Rationale — why this was chosen]
 EOF
 
-govctl adr set <ADR-ID> consequences --stdin <<'EOF'
-### Positive
-- [Observed benefits]
-
-### Negative
-- [Observed downsides or trade-offs]
-
-### Neutral
-- [Side effects]
-EOF
+govctl adr set <ADR-ID> selected_option "[what was adopted]"
+govctl adr edit <ADR-ID> content.consequences.positive --add "[Observed benefit]"
+govctl adr edit <ADR-ID> content.consequences.negative --add "[Observed downside or trade-off]"
+govctl adr edit <ADR-ID> content.consequences.neutral --add "[Side effect]"
 ```
 
 ### 2.3 Add Alternatives (if known)
 
 ```bash
-govctl adr add <ADR-ID> alternatives "Chosen: <what was adopted>" \
-  --pro "..." --con "..."
-govctl adr tick <ADR-ID> alternatives --at 0 -s accepted
-
-govctl adr add <ADR-ID> alternatives "Rejected: <what was not chosen>" \
+govctl adr add <ADR-ID> alternatives "<what was not chosen>" \
   --pro "..." --con "..." --reject-reason "..."
 ```
 
-If rejected alternatives are unknown, it is acceptable to have only the accepted option.
+If rejected alternatives are unknown, it is acceptable to omit `alternatives` entirely and rely on `selected_option` plus the decision rationale.
 When that happens, say so explicitly in the ADR context. Historical backfills may not be able to reconstruct rejected options, and reviewers should evaluate them with that limitation in mind.
 
 ### 2.4 Review Backfilled ADRs
@@ -400,7 +392,7 @@ Skip trivial decisions (indentation style, variable naming) — those belong in 
 When discovering decisions:
 
 - If you can identify the decision but not the rationale → say so in the context. "The rationale is not documented; this ADR records the current state."
-- If alternatives are unknown → create only the accepted alternative.
+- If alternatives are unknown → set `selected_option` and omit rejected alternatives.
 - If consequences are unclear → document what you can observe. "The negative consequences of this decision have not been formally evaluated."
 
 ### Incremental Migration

--- a/.claude/skills/migrate/SKILL.md
+++ b/.claude/skills/migrate/SKILL.md
@@ -50,7 +50,7 @@ govctl adr accept <ADR-ID>
 # Backfill RFCs (optional)
 govctl rfc new "<spec title>"
 govctl clause new <RFC-ID>:C-<NAME> "<title>" -s "Specification" -k normative
-govctl clause edit <RFC-ID>:C-<NAME> --stdin <<'EOF' ... EOF
+govctl clause edit <RFC-ID>:C-<NAME> text --stdin <<'EOF' ... EOF
 govctl rfc finalize <RFC-ID> normative
 govctl rfc advance <RFC-ID> impl
 govctl rfc advance <RFC-ID> test
@@ -251,7 +251,7 @@ For each requirement in the existing specification:
 
 ```bash
 govctl clause new <RFC-ID>:C-<NAME> "<title>" -s "Specification" -k normative
-govctl clause edit <RFC-ID>:C-<NAME> --stdin <<'EOF'
+govctl clause edit <RFC-ID>:C-<NAME> text --stdin <<'EOF'
 [Clause text extracted from existing spec, rewritten with RFC 2119 keywords]
 EOF
 ```

--- a/.claude/skills/rfc-writer/SKILL.md
+++ b/.claude/skills/rfc-writer/SKILL.md
@@ -24,7 +24,7 @@ They are normative artifacts, not design diaries, code sketches, or task plans.
 ```bash
 govctl rfc new "<title>"
 govctl clause new <RFC-ID>:C-<NAME> "<title>" -s "<section>" -k <kind>
-govctl clause edit <RFC-ID>:C-<NAME> --stdin <<'EOF'
+govctl clause edit <RFC-ID>:C-<NAME> text --stdin <<'EOF'
 clause text
 EOF
 ```
@@ -41,7 +41,7 @@ Every RFC should have:
 
 ```bash
 govctl clause new <RFC-ID>:C-SUMMARY "Summary" -s "Summary" -k informative
-govctl clause edit <RFC-ID>:C-SUMMARY --stdin <<'EOF'
+govctl clause edit <RFC-ID>:C-SUMMARY text --stdin <<'EOF'
 Brief overview of what this RFC specifies and why.
 
 **Scope:** What is covered and what is not.
@@ -54,7 +54,7 @@ EOF
 
 ```bash
 govctl clause new <RFC-ID>:C-<NAME> "<Title>" -s "Specification" -k normative
-govctl clause edit <RFC-ID>:C-<NAME> --stdin <<'EOF'
+govctl clause edit <RFC-ID>:C-<NAME> text --stdin <<'EOF'
 The system MUST ...
 The system SHOULD ...
 The system MAY ...

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -38,8 +38,10 @@ govctl adr show <ADR-ID>
 
 govctl adr set <ADR-ID> context --stdin <<'EOF' ... EOF
 govctl adr set <ADR-ID> decision --stdin <<'EOF' ... EOF
-govctl adr set <ADR-ID> consequences --stdin <<'EOF' ... EOF
-govctl adr add <ADR-ID> alternatives "Option: ..."
+govctl adr set <ADR-ID> selected_option "Option A"
+govctl adr edit <ADR-ID> content.consequences.positive --add "Benefit"
+govctl adr edit <ADR-ID> content.consequences.negative --add "Trade-off"
+govctl adr add <ADR-ID> alternatives "Rejected option"
 govctl adr accept <ADR-ID>
 
 govctl clause edit <RFC-ID>:C-<NAME> --stdin <<'EOF' ... EOF

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -44,7 +44,7 @@ govctl adr edit <ADR-ID> content.consequences.negative --add "Trade-off"
 govctl adr add <ADR-ID> alternatives "Rejected option"
 govctl adr accept <ADR-ID>
 
-govctl clause edit <RFC-ID>:C-<NAME> --stdin <<'EOF' ... EOF
+govctl clause edit <RFC-ID>:C-<NAME> text --stdin <<'EOF' ... EOF
 govctl rfc bump <RFC-ID> --patch -m "Clarify clause wording"
 govctl rfc finalize <RFC-ID> normative
 
@@ -96,7 +96,7 @@ For ADR work:
 
 For RFC work:
 
-- Edit clauses with `govctl clause edit`
+- Edit clauses with `govctl clause edit <RFC-ID>:C-<NAME> text --stdin`
 - If the RFC is draft and ready to become normative, ask permission before `govctl rfc finalize <RFC-ID> normative`
 - If amending an existing normative RFC, ask permission before `govctl rfc bump`
 
@@ -156,7 +156,7 @@ If the task grows into implementation work, stop here and hand off to `/gov`.
 
 ### Clarify an RFC without changing behavior
 
-1. Edit the clause text with `govctl clause edit`
+1. Edit the clause text with `govctl clause edit <RFC-ID>:C-<NAME> text --stdin`
 2. Run **rfc-reviewer**
 3. Ask permission, then run `govctl rfc bump <RFC-ID> --patch -m "Clarify wording"`
 4. Run `govctl check` and `govctl render`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - diagnostics for the converted paths use explicit DiagnosticCode values and preserve stable formatting for automation (WI-2026-04-06-004)
 - cargo test -q and cargo run --quiet -- check pass after the diagnostic cleanup (WI-2026-04-06-004)
 - direct CLI command paths no longer emit uncoded anyhow temporary errors for expected user-facing failures (WI-2026-04-06-004)
+- add regression coverage for canonical edit/runtime/router branches introduced by ADR-0037 (WI-2026-04-06-005)
+- add regression coverage for ADR v3 migration edge cases and structured consequence parsing (WI-2026-04-06-005)
+- cargo test -q and cargo run --quiet -- check pass after the coverage-focused regression additions (WI-2026-04-06-005)
+- regression tests cover prose-plus-code-block migration and mitigation attachment semantics (WI-2026-04-06-006)
+- currently affected migrated ADRs are normalized and cargo run --quiet -- check passes (WI-2026-04-06-006)
+- legacy ADR markdown consequence blocks migrate into single semantic entries instead of per-line fragments (WI-2026-04-06-006)
 
 ## [0.7.7] - 2026-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generalize nested edit resolution so object and array paths work at arbitrary supported depth (WI-2026-04-06-002)
 - Introduce canonical <resource> edit <ID> <path> --set/--add/--remove/--tick CLI entrypoints (WI-2026-04-06-002)
 
+### Fixed
+
+- clause canonical edit routing preserves existing behavior while removing the duplicate argument parser (WI-2026-04-06-003)
+- cargo clippy --all-targets --all-features -- -D warnings passes (WI-2026-04-06-003)
+- diagnostics for the converted paths use explicit DiagnosticCode values and preserve stable formatting for automation (WI-2026-04-06-004)
+- cargo test -q and cargo run --quiet -- check pass after the diagnostic cleanup (WI-2026-04-06-004)
+- direct CLI command paths no longer emit uncoded anyhow temporary errors for expected user-facing failures (WI-2026-04-06-004)
+
 ## [0.7.7] - 2026-04-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Define and accept an ADR for the redesigned ADR model and migration behavior (WI-2026-04-06-001)
+- Add a versioned migration step that rewrites legacy ADRs into the new renderable model (WI-2026-04-06-001)
+- Implement the new ADR schema, render path, and check warnings for migration-review states (WI-2026-04-06-001)
+- Route existing set/add/remove/tick verbs through the same canonical edit planning path (WI-2026-04-06-002)
+- Generalize nested edit resolution so object and array paths work at arbitrary supported depth (WI-2026-04-06-002)
+- Introduce canonical <resource> edit <ID> <path> --set/--add/--remove/--tick CLI entrypoints (WI-2026-04-06-002)
+
 ## [0.7.7] - 2026-04-04
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +986,7 @@ dependencies = [
  "jsonschema",
  "markdown-to-ansi",
  "owo-colors",
+ "pulldown-cmark",
  "rand 0.10.0",
  "ratatui",
  "regex",
@@ -1985,9 +1995,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
  "bitflags 2.11.0",
+ "getopts",
  "memchr",
+ "pulldown-cmark-escape",
  "unicase",
 ]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ regex = "1"
 slug = "0.1"
 strum = { version = "0.28", features = ["derive"] }
 winnow = "0.7"
+pulldown-cmark = "0.13"
 
 # File system traversal
 walkdir = "2"

--- a/build.rs
+++ b/build.rs
@@ -33,17 +33,31 @@ struct NestedRootRule {
     artifact: String,
     root: String,
     content_path: Vec<String>,
-    text_key: Option<String>,
-    requires_index: bool,
-    max_depth: usize,
-    fields: Vec<NestedFieldRule>,
+    node: NestedNodeRule,
 }
 
 #[derive(Debug, Deserialize)]
 struct NestedFieldRule {
     name: String,
-    kind: String,
-    verbs: Vec<String>,
+    node: NestedNodeRule,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum NestedNodeRule {
+    Scalar {
+        verbs: Vec<String>,
+        set_mode: Option<RuntimeSetMode>,
+    },
+    Object {
+        verbs: Vec<String>,
+        fields: Vec<NestedFieldRule>,
+    },
+    List {
+        verbs: Vec<String>,
+        text_key: Option<String>,
+        item: Box<NestedNodeRule>,
+    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -255,48 +269,29 @@ fn render_edit_rules(spec: &EditOpsSpec) -> Result<String, Box<dyn Error>> {
     }
     out.push_str("];\n\n");
 
-    out.push_str("pub const NESTED_RULES: &[NestedRootRule] = &[\n");
+    let mut nested_defs = String::new();
+    let mut nested_roots = String::new();
     for root in &spec.nested_rules {
-        out.push_str("    NestedRootRule {\n");
-        out.push_str(&format!("        artifact: {:?},\n", root.artifact));
-        out.push_str(&format!("        root: {:?},\n", root.root));
-        out.push_str(&format!(
+        let const_name = format!(
+            "NESTED_NODE_{}_{}_ROOT",
+            root.artifact.to_uppercase(),
+            sanitize_const_fragment(&root.root)
+        );
+        render_nested_node_defs(&mut nested_defs, &const_name, &root.node)?;
+        nested_roots.push_str("    NestedRootRule {\n");
+        nested_roots.push_str(&format!("        artifact: {:?},\n", root.artifact));
+        nested_roots.push_str(&format!("        root: {:?},\n", root.root));
+        nested_roots.push_str(&format!(
             "        content_path: {},\n",
             runtime_path_expr(&root.content_path)
         ));
-        out.push_str(&format!(
-            "        text_key: {},\n",
-            match &root.text_key {
-                Some(k) => format!("Some({k:?})"),
-                None => "None".to_string(),
-            }
-        ));
-        out.push_str(&format!(
-            "        requires_index: {},\n",
-            root.requires_index
-        ));
-        out.push_str(&format!("        max_depth: {},\n", root.max_depth));
-        out.push_str("        fields: &[\n");
-        for field in &root.fields {
-            let kind = match field.kind.as_str() {
-                "scalar" => "Scalar",
-                "list" => "List",
-                other => return Err(format!("unknown field kind in SSOT: {other}").into()),
-            };
-
-            out.push_str("            NestedFieldRule {\n");
-            out.push_str(&format!("                name: {:?},\n", field.name));
-            out.push_str(&format!("                kind: FieldKind::{kind},\n"));
-            out.push_str("                verbs: &[\n");
-            for verb in &field.verbs {
-                out.push_str(&format!("                    {verb:?},\n"));
-            }
-            out.push_str("                ],\n");
-            out.push_str("            },\n");
-        }
-        out.push_str("        ],\n");
-        out.push_str("    },\n");
+        nested_roots.push_str(&format!("        node: &{},\n", const_name));
+        nested_roots.push_str("    },\n");
     }
+
+    out.push_str(&nested_defs);
+    out.push_str("pub const NESTED_RULES: &[NestedRootRule] = &[\n");
+    out.push_str(&nested_roots);
     out.push_str("];\n");
 
     out.push('\n');
@@ -318,6 +313,148 @@ fn render_edit_rules(spec: &EditOpsSpec) -> Result<String, Box<dyn Error>> {
     out.push_str("];\n");
 
     Ok(out)
+}
+
+fn sanitize_const_fragment(name: &str) -> String {
+    name.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn render_nested_node_defs(
+    out: &mut String,
+    const_name: &str,
+    node: &NestedNodeRule,
+) -> Result<(), Box<dyn Error>> {
+    match node {
+        NestedNodeRule::Scalar { verbs, set_mode } => {
+            out.push_str(&format!(
+                "const {const_name}: NestedNodeRule = NestedNodeRule {{\n"
+            ));
+            out.push_str("    kind: NestedNodeKind::Scalar,\n");
+            out.push_str(&format!("    verbs: {},\n", render_verbs_expr(verbs)));
+            out.push_str("    text_key: None,\n");
+            out.push_str(&format!(
+                "    set_mode: {},\n",
+                render_nested_scalar_mode_expr(set_mode.as_ref())?
+            ));
+            out.push_str("    item: None,\n");
+            out.push_str("    fields: &[],\n");
+            out.push_str("};\n\n");
+        }
+        NestedNodeRule::Object { verbs, fields } => {
+            for field in fields {
+                let child_const = format!("{const_name}_{}", sanitize_const_fragment(&field.name));
+                render_nested_node_defs(out, &child_const, &field.node)?;
+            }
+            let fields_const = format!("{const_name}_FIELDS");
+            out.push_str(&format!("const {fields_const}: &[NestedChildRule] = &[\n"));
+            for field in fields {
+                let child_const = format!("{const_name}_{}", sanitize_const_fragment(&field.name));
+                out.push_str("    NestedChildRule {\n");
+                out.push_str(&format!("        name: {:?},\n", field.name));
+                out.push_str(&format!("        node: &{},\n", child_const));
+                out.push_str("    },\n");
+            }
+            out.push_str("];\n");
+            out.push_str(&format!(
+                "const {const_name}: NestedNodeRule = NestedNodeRule {{\n"
+            ));
+            out.push_str("    kind: NestedNodeKind::Object,\n");
+            out.push_str(&format!("    verbs: {},\n", render_verbs_expr(verbs)));
+            out.push_str("    text_key: None,\n");
+            out.push_str("    set_mode: None,\n");
+            out.push_str("    item: None,\n");
+            out.push_str(&format!("    fields: {},\n", fields_const));
+            out.push_str("};\n\n");
+        }
+        NestedNodeRule::List {
+            verbs,
+            text_key,
+            item,
+        } => {
+            let item_const = format!("{const_name}_ITEM");
+            render_nested_node_defs(out, &item_const, item)?;
+            out.push_str(&format!(
+                "const {const_name}: NestedNodeRule = NestedNodeRule {{\n"
+            ));
+            out.push_str("    kind: NestedNodeKind::List,\n");
+            out.push_str(&format!("    verbs: {},\n", render_verbs_expr(verbs)));
+            out.push_str(&format!(
+                "    text_key: {},\n",
+                match text_key {
+                    Some(key) => format!("Some({key:?})"),
+                    None => "None".to_string(),
+                }
+            ));
+            out.push_str("    set_mode: None,\n");
+            out.push_str(&format!("    item: Some(&{}),\n", item_const));
+            out.push_str("    fields: &[],\n");
+            out.push_str("};\n\n");
+        }
+    }
+    Ok(())
+}
+
+fn render_verbs_expr(verbs: &[String]) -> String {
+    let mut out = String::from("&[");
+    for (idx, verb) in verbs.iter().enumerate() {
+        if idx > 0 {
+            out.push_str(", ");
+        }
+        out.push_str(&format!("{verb:?}"));
+    }
+    out.push(']');
+    out
+}
+
+fn render_nested_scalar_mode_expr(mode: Option<&RuntimeSetMode>) -> Result<String, Box<dyn Error>> {
+    match mode {
+        None => Ok("None".to_string()),
+        Some(RuntimeSetMode::String) => Ok("Some(NestedScalarMode::String)".to_string()),
+        Some(RuntimeSetMode::Integer) => Ok("Some(NestedScalarMode::Integer)".to_string()),
+        Some(RuntimeSetMode::OptionalString { empty_as_null }) => Ok(format!(
+            "Some(NestedScalarMode::OptionalString {{ empty_as_null: {} }})",
+            empty_as_null
+        )),
+        Some(RuntimeSetMode::Enum {
+            allowed,
+            invalid_msg,
+            code,
+        }) => {
+            let allowed_expr = {
+                let mut expr = String::from("&[");
+                for (idx, value) in allowed.iter().enumerate() {
+                    if idx > 0 {
+                        expr.push_str(", ");
+                    }
+                    expr.push_str(&format!("{value:?}"));
+                }
+                expr.push(']');
+                expr
+            };
+            let code_expr = match code {
+                Some(code) => format!("Some(DiagnosticCode::{})", diagnostic_code_variant(code)?),
+                None => "None".to_string(),
+            };
+            Ok(format!(
+                "Some(NestedScalarMode::Enum {{ allowed: {}, invalid_msg: {:?}, code: {} }})",
+                allowed_expr, invalid_msg, code_expr
+            ))
+        }
+    }
+}
+
+fn diagnostic_code_variant(code: &str) -> Result<&str, Box<dyn Error>> {
+    code.strip_prefix('E')
+        .map(|_| code)
+        .ok_or_else(|| format!("invalid diagnostic code in SSOT: {code}").into())
 }
 
 fn render_edit_runtime(spec: &EditOpsSpec) -> Result<String, Box<dyn Error>> {
@@ -388,6 +525,12 @@ fn runtime_get_expr(get: Option<&RuntimeGetRule>) -> Result<String, Box<dyn Erro
         "scalar" => "RenderMode::Scalar".to_string(),
         "csv_strings" => "RenderMode::CsvStrings".to_string(),
         "line_strings" => "RenderMode::LineStrings".to_string(),
+        "text_lines" => {
+            let text_key = get.text_key.as_ref().ok_or_else(|| {
+                "runtime get render=text_lines requires text_key in SSOT".to_string()
+            })?;
+            format!("RenderMode::TextLines {{ text_key: {:?} }}", text_key)
+        }
         "status_lines" => {
             let status_key = get.status_key.as_ref().ok_or_else(|| {
                 "runtime get render=status_lines requires status_key in SSOT".to_string()

--- a/docs/guide/adrs.md
+++ b/docs/guide/adrs.md
@@ -27,7 +27,15 @@ refs = ["RFC-0001"]
 [content]
 context = "We need a caching layer for..."
 decision = "We will use Redis because..."
-consequences = "Positive: faster reads. Negative: operational complexity."
+selected_option = "Redis"
+
+[content.consequences]
+positive = ["Faster reads"]
+neutral = ["Adds a dedicated cache tier"]
+
+[[content.consequences.negative]]
+text = "Operational complexity increases"
+mitigations = ["Use managed Redis with automated backups"]
 
 [[content.alternatives]]
 text = "Memcached"
@@ -39,35 +47,39 @@ rejection_reason = "Persistence is required for our use case"
 ADRs contain:
 
 - **Context** — The situation requiring a decision
-- **Decision** — What was decided
-- **Consequences** — Expected outcomes (positive and negative)
-- **Alternatives** — Options considered with pros, cons, and rejection reasons (per [[ADR-0027]])
+- **Decision** — What was decided and why
+- **Selected option** — The chosen path recorded explicitly
+- **Consequences** — Expected outcomes grouped as positive, negative, and neutral
+- **Alternatives** — Non-selected options with pros, cons, and rejection reasons
 - **Status** — `proposed`, `accepted`, `rejected`, or `superseded`
 
 ## Editing ADRs
 
-Use govctl to get/set fields:
+Use canonical path-first edits for ADR content:
 
 ```bash
 # Get specific field
 govctl adr get ADR-0003 status
 
-# Set field value
-govctl adr set ADR-0003 status accepted
-
-# Set multi-line content from stdin
-govctl adr set ADR-0003 context --stdin <<'EOF'
+# Set multi-line context from stdin
+govctl adr edit ADR-0003 context --set --stdin <<'EOF'
 We need a caching layer that can handle
 10k requests per second with sub-millisecond latency.
 EOF
-```
 
-For alternatives (pros/cons/rejection reason), path-based edits are supported:
+# Record the chosen option explicitly
+govctl adr edit ADR-0003 selected_option --set "Redis"
 
-```bash
-# Direct nested edit
-govctl adr set ADR-0001 "alt[2].pros[0]" "Updated pro"
-govctl adr add ADR-0001 "alt[0].cons" "New disadvantage"
+# Add structured consequences
+govctl adr edit ADR-0003 consequences.positive --add "Faster reads"
+govctl adr edit ADR-0003 consequences.negative --add "Operational complexity increases"
+govctl adr edit ADR-0003 consequences.negative[0].mitigations --add "Use managed Redis"
+
+# Add rejected alternatives and rationale
+govctl adr edit ADR-0003 alternatives --add "Memcached"
+govctl adr edit ADR-0003 alternatives[0].pros --add "Simpler"
+govctl adr edit ADR-0003 alternatives[0].cons --add "No persistence"
+govctl adr edit ADR-0003 alternatives[0].rejection_reason --set "Persistence is required"
 ```
 
 ## Status Lifecycle
@@ -85,13 +97,7 @@ When consensus is reached:
 govctl adr accept ADR-0003
 ```
 
-### Deprecate
-
-When a decision is no longer relevant:
-
-```bash
-govctl adr deprecate ADR-0003
-```
+Accepted ADRs must record `selected_option` before they can be accepted.
 
 ### Supersede
 
@@ -102,6 +108,8 @@ govctl adr supersede ADR-0001 --by ADR-0005
 ```
 
 This marks ADR-0001 as superseded and records ADR-0005 as its replacement.
+
+ADRs are superseded rather than deprecated. If a decision is obsolete, create a replacement ADR and supersede the old one.
 
 ## Listing and Viewing
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -99,7 +99,7 @@ govctl clause new RFC-0000:C-SCOPE "Scope" -s "Specification" -k normative
 ## Edit Clause Content
 
 ```bash
-govctl clause edit RFC-0000:C-SCOPE --stdin <<'EOF'
+govctl clause edit RFC-0000:C-SCOPE text --stdin <<'EOF'
 The feature MUST do X.
 The feature SHOULD do Y.
 EOF

--- a/docs/guide/rfcs.md
+++ b/docs/guide/rfcs.md
@@ -72,16 +72,16 @@ The system MUST validate all inputs."""
 
 ```bash
 # From stdin (recommended for multi-line)
-govctl clause edit RFC-0010:C-SCOPE --stdin <<'EOF'
+govctl clause edit RFC-0010:C-SCOPE text --stdin <<'EOF'
 The system MUST validate all inputs.
 The system SHOULD log validation failures.
 EOF
 
 # Inline text
-govctl clause edit RFC-0010:C-SCOPE --text "The system MUST validate all inputs."
+govctl clause edit RFC-0010:C-SCOPE text --set "The system MUST validate all inputs."
 
 # From file
-govctl clause edit RFC-0010:C-SCOPE --text-file clause-text.md
+govctl clause edit RFC-0010:C-SCOPE text --stdin < clause-text.md
 ```
 
 ### Delete a Clause

--- a/docs/rfc/RFC-0000.md
+++ b/docs/rfc/RFC-0000.md
@@ -1,9 +1,9 @@
 <!-- GENERATED: do not edit. Source: RFC-0000 -->
-<!-- SIGNATURE: sha256:d05eb40d0eb61a843eb2b0279c290f3c9d5a16b17d97f88790b2f6466510190b -->
+<!-- SIGNATURE: sha256:972811229593a7f435a1ecf9cb0d1427adbbd0aef423771f71d0696dfc2b53ae -->
 
 # RFC-0000: govctl Governance Framework
 
-> **Version:** 1.1.1 | **Status:** normative | **Phase:** stable
+> **Version:** 1.1.2 | **Status:** normative | **Phase:** stable
 
 ---
 
@@ -170,8 +170,13 @@ An ADR (Architectural Decision Record) documents a significant design decision.
 
 Every ADR MUST be stored as a TOML file containing:
 - `[govctl]` section with: `id`, `title`, `status`, `date`, `refs`
-- optional `[govctl]` field: `superseded_by`
-- `[content]` section with: `context`, `decision`, `consequences`
+- optional `[govctl]` fields: `superseded_by`, `migration`
+- `[content]` section with: `context`, `decision`, `consequences`, `alternatives`
+- `content.selected_option` when the ADR status is `accepted` or `superseded`, unless the artifact is explicitly marked as a migration record still requiring review
+
+`content.consequences` MUST be structured as positive, negative, and neutral outcomes. Negative consequences MAY include mitigations.
+
+`content.alternatives` records non-selected options. Each alternative MUST include `text` and MAY include pros, cons, and a rejection reason.
 
 Format evolution is tracked by the project-level `[schema] version` in `gov/config.toml`, not per-artifact fields.
 
@@ -304,6 +309,10 @@ A guard check MUST pass only when the command exits successfully. If `pattern` i
 ---
 
 ## Changelog
+
+### v1.1.2 (2026-04-06)
+
+Clarify ADR v3 structure and selected option requirements
 
 ### v1.1.1 (2026-03-22)
 

--- a/gov/adr/ADR-0001-use-toml-for-adrs-and-work-items.toml
+++ b/gov/adr/ADR-0001-use-toml-for-adrs-and-work-items.toml
@@ -5,7 +5,13 @@ id = "ADR-0001"
 title = "Use TOML for ADRs and Work Items"
 status = "accepted"
 date = "2026-01-17"
-refs = ["RFC-0000:C-ADR-DEF", "RFC-0000:C-WORK-DEF"]
+refs = [
+    "RFC-0000:C-ADR-DEF",
+    "RFC-0000:C-WORK-DEF",
+]
+
+[govctl.migration]
+state = "verified"
 
 [content]
 context = """
@@ -16,7 +22,10 @@ decision = """
 Use TOML for ADRs and Work Items instead of JSON.
 Structure follows [govctl] metadata section and [content] body section.
 This aligns with Rust ecosystem conventions (Cargo.toml)."""
-consequences = """
+selected_option = "Use TOML for ADRs and Work Items"
+
+[content.consequences]
+neutral = ["""
 Positive: Easier manual editing, cleaner diffs, natural multiline support.
 Negative: Different format from RFC clauses (which remain JSON for richer structure).
-Migration: Existing JSON-based work items would need conversion."""
+Migration: Existing JSON-based work items would need conversion."""]

--- a/gov/adr/ADR-0002-fix-artifact-lifecycle-design-flaws.toml
+++ b/gov/adr/ADR-0002-fix-artifact-lifecycle-design-flaws.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-01-17"
 refs = ["RFC-0000"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 Analysis of the artifact lifecycle state machines revealed several design flaws:
@@ -38,7 +41,10 @@ We will fix all four lifecycle design flaws:
    Work can be abandoned at any stage.
 
 4. **Document RFC constraint rules**: Add explicit invariant rules to SCHEMA.md stating when status×phase combinations are forbidden."""
-consequences = """
+selected_option = "Fix artifact lifecycle design flaws"
+
+[content.consequences]
+neutral = ["""
 **Positive:**
 - Cleaner separation of concerns (kind = category, status = lifecycle)
 - Complete lifecycle coverage for all artifact types
@@ -50,4 +56,4 @@ consequences = """
 
 **Migration:**
 - Any clause with `kind: deprecated` should change to `kind: normative, status: deprecated`
-- Currently no such clauses exist in the codebase"""
+- Currently no such clauses exist in the codebase"""]

--- a/gov/adr/ADR-0003-deterministic-hash-signatures-for-rendered-projections.toml
+++ b/gov/adr/ADR-0003-deterministic-hash-signatures-for-rendered-projections.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-01-17"
 refs = ["RFC-0000"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 govctl renders markdown files from authoritative JSON/TOML sources (RFCs, ADRs, Work Items). These rendered markdown files are **projections** — read-only views intended for human consumption.
@@ -46,7 +49,10 @@ Implement deterministic hash signatures embedded in rendered markdown.
 - `govctl check` extracts signature from rendered markdown
 - Recomputes hash from current source files
 - Reports mismatch as a diagnostic error"""
-consequences = """
+selected_option = "Deterministic hash signatures for rendered projections"
+
+[content.consequences]
+neutral = ["""
 **Positive:**
 - Enforces "edit the source, not the projection" discipline
 - Tampered markdown is detected automatically by `govctl check`
@@ -60,4 +66,4 @@ consequences = """
 
 **Migration:**
 - Run `govctl render` to regenerate all markdown with signatures
-- Commit the updated files"""
+- Commit the updated files"""]

--- a/gov/adr/ADR-0004-adopt-keep-a-changelog-format-for-rfc-changelogs.toml
+++ b/gov/adr/ADR-0004-adopt-keep-a-changelog-format-for-rfc-changelogs.toml
@@ -7,7 +7,13 @@ status = "accepted"
 date = "2026-01-17"
 refs = ["RFC-0000"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = "RFC changelogs use a flat changes array. This makes it difficult to categorize changes by type (additions, fixes, removals). The Keep a Changelog format (keepachangelog.com) is a widely-adopted standard that organizes changes into semantic categories aligned with semver."
 decision = "Replace the flat changes array with categorized arrays: added, changed, deprecated, removed, fixed, security. Keep summary field as optional notes. Migrate existing RFC-0000 changelog (trivial: one entry)."
-consequences = "Positive: Standard format, better scanability, semver-aligned categories. Negative: More verbose schema, breaking change to ChangelogEntry model. Migration cost is minimal (RFC-0000 has only one entry)."
+selected_option = "Adopt Keep a Changelog format for RFC changelogs"
+
+[content.consequences]
+neutral = ["Positive: Standard format, better scanability, semver-aligned categories. Negative: More verbose schema, breaking change to ChangelogEntry model. Migration cost is minimal (RFC-0000 has only one entry)."]

--- a/gov/adr/ADR-0005-cli-output-color-scheme-and-formatting.toml
+++ b/gov/adr/ADR-0005-cli-output-color-scheme-and-formatting.toml
@@ -7,7 +7,13 @@ status = "accepted"
 date = "2026-01-17"
 refs = ["RFC-0000"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = "CLI output uses plain text with no visual hierarchy. Users cannot quickly distinguish success from failure, or identify important values. Status messages blend together making output hard to scan."
 decision = "Adopt semantic color scheme: Green for success, Red for errors, Yellow for warnings, Cyan for paths/IDs, Bold for emphasis. Use owo-colors crate (zero-cost, no deps). Auto-detect terminal color support. All output via ui module for consistency."
-consequences = "Positive: Better UX, faster scanning, clearer status. Negative: One new dependency (owo-colors). Migration: All eprintln! calls routed through ui module."
+selected_option = "Adopt semantic color scheme for CLI output"
+
+[content.consequences]
+neutral = ["Positive: Better UX, faster scanning, clearer status. Negative: One new dependency (owo-colors). Migration: All eprintln! calls routed through ui module."]

--- a/gov/adr/ADR-0006-global-dry-run-support-for-content-modifying-commands.toml
+++ b/gov/adr/ADR-0006-global-dry-run-support-for-content-modifying-commands.toml
@@ -7,7 +7,13 @@ status = "accepted"
 date = "2026-01-17"
 refs = ["RFC-0000:C-WORK-DEF"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = "All content-modifying commands (new, set, add, remove, edit, tick, bump, finalize, advance, accept, deprecate, supersede, move) write files immediately with no way to preview changes. Only render commands support --dry-run. Users and agents need a way to preview what changes will be made before committing to disk, especially for destructive or complex operations."
 decision = "Add global -n/--dry-run flag at CLI level. Create WriteOp enum with Preview/Execute variants in write.rs. All write functions accept WriteOp. In Preview mode: serialize, display via ui::dry_run_preview, skip fs::write. Read-only commands ignore the flag."
-consequences = "Positive: Unified dry-run UX, follows Unix -n convention, DRY write logic. Negative: Signature changes for write functions. Migration: Update all write callsites to use WriteOp."
+selected_option = "Add global --dry-run flag for content-modifying commands"
+
+[content.consequences]
+neutral = ["Positive: Unified dry-run UX, follows Unix -n convention, DRY write logic. Negative: Signature changes for write functions. Migration: Update all write callsites to use WriteOp."]

--- a/gov/adr/ADR-0007-ergonomic-array-field-matching-for-remove-and-tick-commands.toml
+++ b/gov/adr/ADR-0007-ergonomic-array-field-matching-for-remove-and-tick-commands.toml
@@ -5,9 +5,18 @@ id = "ADR-0007"
 title = "Ergonomic array field matching for remove and tick commands"
 status = "accepted"
 date = "2026-01-17"
-refs = ["RFC-0000:C-WORK-DEF", "RFC-0000:C-ADR-DEF"]
+refs = [
+    "RFC-0000:C-WORK-DEF",
+    "RFC-0000:C-ADR-DEF",
+]
+
+[govctl.migration]
+state = "verified"
 
 [content]
 context = "The remove command requires exact string match, which is fragile for long strings like URLs. The tick command uses substring matching but remove does not. Checklist fields (acceptance_criteria, decisions, alternatives) require separate semantics from string fields, leading to confusion about when to use remove vs tick."
 decision = "Unify matching semantics: (1) Default to case-insensitive substring matching for remove and tick. (2) Add --exact flag for exact matching. (3) Add `--at <index>` for positional removal. (4) Add --regex flag for pattern matching. (5) Add --all flag for bulk removal. (6) Single match proceeds; multiple matches error with guidance. (7) remove works on all array types including checklists; tick only changes status."
-consequences = "Positive: Ergonomic default matching, safe bulk operations, unified semantics. Negative: Breaking change for scripts relying on exact match. Migration: Existing exact-match callers should add --exact flag."
+selected_option = "Unify matching semantics for remove and tick commands"
+
+[content.consequences]
+neutral = ["Positive: Ergonomic default matching, safe bulk operations, unified semantics. Negative: Breaking change for scripts relying on exact match. Migration: Existing exact-match callers should add --exact flag."]

--- a/gov/adr/ADR-0008-add-refs-field-to-rfcspec-for-artifact-cross-referencing.toml
+++ b/gov/adr/ADR-0008-add-refs-field-to-rfcspec-for-artifact-cross-referencing.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-01-17"
 refs = ["RFC-0000"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 RFCs are the supreme governance documents in govctl, yet they cannot formally reference other artifacts (ADRs, other RFCs, work items). Meanwhile, ADRs and Work Items both have a refs field for cross-referencing.
@@ -28,7 +31,10 @@ Add refs field to RfcSpec following the same pattern as AdrMeta and WorkItemMeta
 5. Validate RFC supersedes field against known RFCs (currently unvalidated)
 
 This creates consistency across all artifact types and enables complete cross-reference tracking."""
-consequences = """
+selected_option = "Add refs field to RfcSpec"
+
+[content.consequences]
+neutral = ["""
 Positive:
 - RFCs can now reference ADRs, other RFCs, and work items
 - Complete artifact graph for impact analysis
@@ -40,4 +46,4 @@ Negative:
 - Slightly more validation overhead on check
 
 Neutral:
-- Existing RFCs do not need migration (empty default)"""
+- Existing RFCs do not need migration (empty default)"""]

--- a/gov/adr/ADR-0009-configurable-source-code-reference-scanning.toml
+++ b/gov/adr/ADR-0009-configurable-source-code-reference-scanning.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-01-17"
 refs = ["RFC-0000"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 Source code often contains references to governance artifacts (RFCs, clauses, ADRs) in comments. These references can become stale when artifacts are deprecated, superseded, or renamed.
@@ -30,7 +33,10 @@ Add configurable source code scanning with:
 4. New diagnostics: E0107SourceRefUnknown (error), W0107SourceRefOutdated (warning for deprecated/superseded)
 
 5. Scanner runs during 'govctl check' when source_scan.enabled = true"""
-consequences = """
+selected_option = "Add configurable source code scanning"
+
+[content.consequences]
+neutral = ["""
 Positive:
 - Dead link detection in source code comments
 - Configurable pattern supports different project conventions
@@ -43,4 +49,4 @@ Negative:
 
 Neutral:
 - Pattern configuration requires regex knowledge
-- Projects must explicitly enable and configure"""
+- Projects must explicitly enable and configure"""]

--- a/gov/adr/ADR-0010-validate-work-item-descriptions-for-placeholder-content.toml
+++ b/gov/adr/ADR-0010-validate-work-item-descriptions-for-placeholder-content.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-01-17"
 refs = ["RFC-0000:C-WORK-DEF"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 Work items are created with a placeholder description template: "Describe the work to be done. What is the goal? What are the acceptance criteria?" This placeholder is meant to be replaced with actual content, but 21 of 24 existing work items still have this placeholder text.
@@ -24,7 +27,10 @@ This is a warning (not error) because:
 - Existing work items should not block `govctl check`
 - It's advisory during development, not a hard gate
 - Users can address warnings incrementally"""
-consequences = """
+selected_option = "Add warning diagnostic for placeholder work item descriptions"
+
+[content.consequences]
+neutral = ["""
 Positive:
 - Encourages meaningful documentation of completed work
 - Improves audit trail quality
@@ -34,4 +40,4 @@ Negative:
 - Existing 21 work items will trigger warnings until fixed
 - Minor noise during `govctl check` until addressed
 
-Migration: Fix existing work items by adding meaningful descriptions based on their titles and acceptance criteria."""
+Migration: Fix existing work items by adding meaningful descriptions based on their titles and acceptance criteria."""]

--- a/gov/adr/ADR-0011-inline-reference-expansion-in-rendered-content.toml
+++ b/gov/adr/ADR-0011-inline-reference-expansion-in-rendered-content.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-01-17"
 refs = ["RFC-0000"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 Content fields (description, context, decision, consequences) are rendered as-is with no link expansion. The `refs` field gets expanded to markdown links, but inline references like `[[RFC-0000]]` in text remain as literal strings.
@@ -26,7 +29,10 @@ Add inline reference expansion to content fields during rendering:
 4. Pattern is evaluated at render time, so config changes apply on next render
 
 This creates consistency between source code scanning and content rendering — the same reference format works everywhere."""
-consequences = """
+selected_option = "Add inline reference expansion to content fields during rendering"
+
+[content.consequences]
+neutral = ["""
 Positive:
 - Inline references in content become clickable links
 - Consistent with `source_scan` pattern format
@@ -37,4 +43,4 @@ Negative:
 - Couples rendering to source_scan config (even if source_scan.enabled is false)
 - Literal `[[text]]` in content will be matched if it looks like an artifact ID
 
-Migration: Existing content with literal `[[...]]` that happens to match artifact patterns will now become links. This is likely the desired behavior."""
+Migration: Existing content with literal `[[...]]` that happens to match artifact patterns will now become links. This is likely the desired behavior."""]

--- a/gov/adr/ADR-0012-prefix-based-changelog-category-parsing.toml
+++ b/gov/adr/ADR-0012-prefix-based-changelog-category-parsing.toml
@@ -7,10 +7,16 @@ status = "accepted"
 date = "2026-01-17"
 refs = ["ADR-0013"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = "The `govctl bump` command supports adding changelog entries via `-c` flags, but all changes are hardcoded to the `added` category. The `ChangelogEntry` model supports 6 categories (added, changed, deprecated, removed, fixed, security) per Keep a Changelog format, but users must manually edit JSON to use any category other than `added`."
 decision = """
 Parse conventional-commit-style prefixes from change strings to route to the correct changelog category. Supported prefixes: `add:`, `fix:`, `changed:`, `deprecated:`, `removed:`, `security:`. Unknown prefixes produce a validation error. No prefix defaults to `added` for backward compatibility.
 
 Example: `govctl bump RFC-0001 --patch -m "Bug fixes" -c "fix: memory leak" -c "security: patched CVE"`"""
-consequences = "Users can populate all changelog categories via CLI without JSON editing. The prefix syntax follows conventional commits, reducing learning curve. Invalid prefixes are caught early with helpful error messages listing valid options."
+selected_option = "Prefix-based changelog category parsing"
+
+[content.consequences]
+neutral = ["Users can populate all changelog categories via CLI without JSON editing. The prefix syntax follows conventional commits, reducing learning curve. Invalid prefixes are caught early with helpful error messages listing valid options."]

--- a/gov/adr/ADR-0013-add-category-field-to-work-items-for-changelog-generation.toml
+++ b/gov/adr/ADR-0013-add-category-field-to-work-items-for-changelog-generation.toml
@@ -7,16 +7,17 @@ status = "accepted"
 date = "2026-01-17"
 refs = ["ADR-0012"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = "Work items track implementation work (features, fixes, refactoring), but lack categorization that maps to Keep a Changelog format. RFC changelog entries already use Keep a Changelog categories (Added, Changed, Deprecated, Removed, Fixed, Security). To generate a repo-level CHANGELOG.md from completed work items, we need the same categorization. Acceptance criteria are the natural atomic unit for changelog entries - each criterion represents one deliverable."
-decision = """
-Add a `category` field to `ChecklistItem` (acceptance criteria) using the existing `ChangelogCategory` enum (added, changed, deprecated, removed, fixed, security). Default to `added` for backward compatibility. Reuse [[ADR-0012]] prefix parsing: `govctl add WI-xxx acceptance_criteria "fix: memory leak"` parses to `category=fixed`, `text="memory leak"`. This consolidates `ChangelogCategory` from `write.rs` into `model.rs` for reuse across RFC changelogs and work item criteria."""
-consequences = "Acceptance criteria can be grouped by category when rendering CHANGELOG.md. Each criterion becomes one changelog entry. Work items can span multiple categories without being split. Existing work items remain valid (criteria default to `added`). Single `ChangelogCategory` enum used for both RFC changelog entries and work item criteria."
+decision = 'Add a `category` field to `ChecklistItem` (acceptance criteria) using the existing `ChangelogCategory` enum (added, changed, deprecated, removed, fixed, security). Default to `added` for backward compatibility. Reuse [[ADR-0012]] prefix parsing: `govctl add WI-xxx acceptance_criteria "fix: memory leak"` parses to `category=fixed`, `text="memory leak"`. This consolidates `ChangelogCategory` from `write.rs` into `model.rs` for reuse across RFC changelogs and work item criteria.'
+selected_option = "Add category field to ChecklistItem (criterion level) with prefix parsing"
+
+[content.consequences]
+neutral = ["Acceptance criteria can be grouped by category when rendering CHANGELOG.md. Each criterion becomes one changelog entry. Work items can span multiple categories without being split. Existing work items remain valid (criteria default to `added`). Single `ChangelogCategory` enum used for both RFC changelog entries and work item criteria."]
 
 [[content.alternatives]]
 text = "Add category field to WorkItemMeta (work-item level)"
-status = "rejected"
-
-[[content.alternatives]]
-text = "Add category field to ChecklistItem (criterion level) with prefix parsing"
-status = "accepted"
+rejection_reason = "Work items can span multiple changelog categories, so category must live on each acceptance criterion rather than the work item as a whole."

--- a/gov/adr/ADR-0014-release-management-with-releases-toml.toml
+++ b/gov/adr/ADR-0014-release-management-with-releases-toml.toml
@@ -5,7 +5,13 @@ id = "ADR-0014"
 title = "Release management with releases.toml"
 status = "accepted"
 date = "2026-01-17"
-refs = ["ADR-0013", "RFC-0000:C-WORK-DEF"]
+refs = [
+    "ADR-0013",
+    "RFC-0000:C-WORK-DEF",
+]
+
+[govctl.migration]
+state = "verified"
 
 [content]
 context = "To generate a CHANGELOG.md from work items, we need version information. Work items have `completed` dates but no version. Version is a release-time concept, not a work-time concept. We need a way to track which work items belong to which release without mutating completed work items."
@@ -20,12 +26,11 @@ refs = ["WI-2026-01-17-029", "WI-2026-01-17-008"]
 ```
 
 The `govctl release <version>` command collects all done work items not yet in any release and adds them to a new release entry. The `govctl render changelog` command generates CHANGELOG.md grouped by release version and category."""
-consequences = "Completed work items remain immutable. Explicit refs list eliminates ambiguity about release membership. Single file is simpler than per-release artifacts. Unreleased work items appear under `[Unreleased]` section in changelog."
+selected_option = "Store releases in single `gov/releases.toml` with explicit refs"
+
+[content.consequences]
+neutral = ["Completed work items remain immutable. Explicit refs list eliminates ambiguity about release membership. Single file is simpler than per-release artifacts. Unreleased work items appear under `[Unreleased]` section in changelog."]
 
 [[content.alternatives]]
 text = "Add version field to work items after release"
-status = "rejected"
-
-[[content.alternatives]]
-text = "Store releases in single `gov/releases.toml` with explicit refs"
-status = "accepted"
+rejection_reason = "Release version is determined at release time; mutating completed work items afterward would blur work execution history and break immutability."

--- a/gov/adr/ADR-0015-context-aware-self-describing-cli-for-agent-discoverability.toml
+++ b/gov/adr/ADR-0015-context-aware-self-describing-cli-for-agent-discoverability.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-01-18"
 refs = ["RFC-0000"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 AI coding agents (Claude, Cursor, Codex, etc.) can invoke shell commands, making govctl immediately usable. However, agents lack semantic understanding of *when* to use which command and *why*.
@@ -55,7 +58,10 @@ Reads current project state and outputs:
 - Semantic guidance (`when_to_use`) defined as static data
 - Context mode reuses `status` and `list` logic for project state
 - Output format follows JSON Schema for predictable parsing"""
-consequences = """
+selected_option = "Add a context-aware govctl describe command"
+
+[content.consequences]
+neutral = ["""
 **Positive:**
 - Agents gain semantic understanding without MCP complexity
 - Single interface (CLI) — no parallel implementation to maintain
@@ -82,4 +88,4 @@ consequences = """
 | Agent compatibility | Any shell-capable agent  | MCP-compatible agents only   |
 | Maintenance         | Single codebase          | CLI + MCP server             |
 | Context awareness   | Built-in                 | Separate implementation      |
-| Works offline       | Yes                      | Depends                      |"""
+| Works offline       | Yes                      | Depends                      |"""]

--- a/gov/adr/ADR-0016-allow-rfc-amendments-via-versioning-during-implementation.toml
+++ b/gov/adr/ADR-0016-allow-rfc-amendments-via-versioning-during-implementation.toml
@@ -10,6 +10,9 @@ refs = [
     "ADR-0004",
 ]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 Real-world governance experience from the neotex-v2 project shows that RFCs often need amendments during implementation. This conflicts with the current govctl mental model that treats `normative` status as "frozen" — the documentation (CLAUDE.md:79) states "normative: Frozen. Implementation MUST conform."
@@ -37,7 +40,10 @@ decision = """
    - Rationale and audit trail live in git/jj history
 
 **Precedent:** Linux kernel APIs are both binding (drivers must conform) and evolving (with deprecation, versioning, compatibility) simultaneously."""
-consequences = """
+selected_option = "Allow normative RFC amendments via version bumping during implementation"
+
+[content.consequences]
+neutral = ["""
 **Easier:**
 - Amending RFCs during implementation (matches real workflow)
 - Iterative spec refinement (discover-fix-document cycle)
@@ -50,4 +56,4 @@ consequences = """
 **No breaking changes:**
 - Existing RFCs remain valid
 - No data model changes required
-- Validation rules simplified (remove frozen assumption)"""
+- Validation rules simplified (remove frozen assumption)"""]

--- a/gov/adr/ADR-0017-cli-command-implementation-details.toml
+++ b/gov/adr/ADR-0017-cli-command-implementation-details.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-01-19"
 refs = ["RFC-0002"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 [[RFC-0002]] defines the structural contract for govctl CLI commands: resource-first organization, universal CRUD verbs, lifecycle operations, and output format control. However, RFC-0002 intentionally defers implementation details to preserve flexibility while maintaining a stable interface contract.
@@ -237,7 +240,10 @@ Global commands remain at top level.
 
 **Backward compatibility aliases:**
 Emit deprecation warning when old verb-first commands are used."""
-consequences = """
+selected_option = "Adopt the documented CLI command implementation conventions"
+
+[content.consequences]
+neutral = ["""
 **Positive:**
 
 1. **Consistent UX:** All commands follow the same patterns. Users learn once, apply everywhere.
@@ -264,4 +270,4 @@ consequences = """
 
 - **Discoverability over uniformity:** Four clear verbs are better than one verb with special syntax that requires documentation.
 
-- **Safety over speed:** Confirmation prompts slow down destructive operations. This is intentional to prevent accidents."""
+- **Safety over speed:** Confirmation prompts slow down destructive operations. This is intentional to prevent accidents."""]

--- a/gov/adr/ADR-0018-global-command-shortcuts-vs-strict-resource-first-syntax.toml
+++ b/gov/adr/ADR-0018-global-command-shortcuts-vs-strict-resource-first-syntax.toml
@@ -10,6 +10,9 @@ refs = [
     "ADR-0017",
 ]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 During implementation of [[RFC-0002]], we successfully built the resource-first command structure (`govctl <resource> <verb>`). However, a design question emerged about backward compatibility with existing verb-first shortcuts.
@@ -103,73 +106,128 @@ We could keep shortcuts with deprecation warnings (Option 3), but this:
 - Delays the inevitable
 
 Given pre-1.0 status, clean break is preferable."""
-consequences = """
-### Positive
+selected_option = "Remove verb-first global shortcuts and enforce strict resource-first syntax"
 
-- **Single Canonical Syntax**: Only one way to invoke commands reduces confusion
-- **RFC Compliance**: Aligns perfectly with [[RFC-0002:C-GLOBAL-COMMANDS]]
-- **Simpler Codebase**: ~40 fewer lines of delegation logic to maintain
-- **Clearer Documentation**: Examples show only one pattern, easier to teach
-- **Predictable**: `govctl <resource> <verb>` works for all operations without exceptions
-- **Tab Completion**: Clearer completion tree (type `govctl ` → see resources, not mix of resources + verbs)
+[content.consequences]
+positive = [
+    "**Single Canonical Syntax**: Only one way to invoke commands reduces confusion",
+    "**RFC Compliance**: Aligns perfectly with [[RFC-0002:C-GLOBAL-COMMANDS]]",
+    "**Simpler Codebase**: ~40 fewer lines of delegation logic to maintain",
+    "**Clearer Documentation**: Examples show only one pattern, easier to teach",
+    "**Predictable**: `govctl <resource> <verb>` works for all operations without exceptions",
+    "**Tab Completion**: Clearer completion tree (type `govctl ` → see resources, not mix of resources + verbs)",
+]
 
-### Negative
+[[content.consequences.negative]]
+text = "**Breaking Change**: Existing scripts using `govctl list` or `govctl new` will break"
 
-- **Breaking Change**: Existing scripts using `govctl list` or `govctl new` will break
-  - Mitigation: We're pre-1.0, document in CHANGELOG
-- **More Keystrokes**: `govctl rfc list` is longer than `govctl list rfc`
-  - Mitigation: Shell aliases for personal shortcuts
-- **Learning Curve**: Users familiar with old syntax need to adjust
-  - Mitigation: Clear error messages suggesting correct syntax
+[[content.consequences.negative]]
+text = "Mitigation: We're pre-1.0, document in CHANGELOG"
 
-### Migration Required
+[[content.consequences.negative]]
+text = "**More Keystrokes**: `govctl rfc list` is longer than `govctl list rfc`"
 
-Users need to update:
-```bash
-# Old → New
-govctl list rfc        → govctl rfc list
-govctl list adr        → govctl adr list
-govctl list work       → govctl work list
-govctl list clause     → govctl clause list
-govctl new rfc "..."   → govctl rfc new "..."
-govctl new adr "..."   → govctl adr new "..."
-govctl new work "..."  → govctl work new "..."
-govctl new clause ...  → govctl clause new ...
-```
+[[content.consequences.negative]]
+text = "Mitigation: Shell aliases for personal shortcuts"
 
-### Future Extension
+[[content.consequences.negative]]
+text = "**Learning Curve**: Users familiar with old syntax need to adjust"
 
-This decision does NOT prevent adding convenience aliases later if user demand warrants it. However, any such addition would require an RFC amendment to [[RFC-0002:C-GLOBAL-COMMANDS]].
+[[content.consequences.negative]]
+text = "Mitigation: Clear error messages suggesting correct syntax"
 
-### Recommendation for Users
+[[content.consequences.negative]]
+text = "### Migration Required"
 
-Add personal shell aliases for frequently used commands:
-```bash
-# In ~/.bashrc or ~/.zshrc
-alias gr='govctl rfc'
-alias ga='govctl adr'
-alias gw='govctl work'
-alias gc='govctl clause'
+[[content.consequences.negative]]
+text = "Users need to update:"
 
-# Usage becomes:
-gr list        # govctl rfc list
-gw new "task"  # govctl work new "task"
-```
+[[content.consequences.negative]]
+text = "```bash"
 
-This provides the convenience without coupling it to the tool."""
+[[content.consequences.negative]]
+text = "# Old → New"
+
+[[content.consequences.negative]]
+text = "govctl list rfc        → govctl rfc list"
+
+[[content.consequences.negative]]
+text = "govctl list adr        → govctl adr list"
+
+[[content.consequences.negative]]
+text = "govctl list work       → govctl work list"
+
+[[content.consequences.negative]]
+text = "govctl list clause     → govctl clause list"
+
+[[content.consequences.negative]]
+text = 'govctl new rfc "..."   → govctl rfc new "..."'
+
+[[content.consequences.negative]]
+text = 'govctl new adr "..."   → govctl adr new "..."'
+
+[[content.consequences.negative]]
+text = 'govctl new work "..."  → govctl work new "..."'
+
+[[content.consequences.negative]]
+text = "govctl new clause ...  → govctl clause new ..."
+
+[[content.consequences.negative]]
+text = "```"
+
+[[content.consequences.negative]]
+text = "### Future Extension"
+
+[[content.consequences.negative]]
+text = "This decision does NOT prevent adding convenience aliases later if user demand warrants it. However, any such addition would require an RFC amendment to [[RFC-0002:C-GLOBAL-COMMANDS]]."
+
+[[content.consequences.negative]]
+text = "### Recommendation for Users"
+
+[[content.consequences.negative]]
+text = "Add personal shell aliases for frequently used commands:"
+
+[[content.consequences.negative]]
+text = "```bash"
+
+[[content.consequences.negative]]
+text = "# In ~/.bashrc or ~/.zshrc"
+
+[[content.consequences.negative]]
+text = "alias gr='govctl rfc'"
+
+[[content.consequences.negative]]
+text = "alias ga='govctl adr'"
+
+[[content.consequences.negative]]
+text = "alias gw='govctl work'"
+
+[[content.consequences.negative]]
+text = "alias gc='govctl clause'"
+
+[[content.consequences.negative]]
+text = "# Usage becomes:"
+
+[[content.consequences.negative]]
+text = "gr list        # govctl rfc list"
+
+[[content.consequences.negative]]
+text = 'gw new "task"  # govctl work new "task"'
+
+[[content.consequences.negative]]
+text = "```"
+
+[[content.consequences.negative]]
+text = "This provides the convenience without coupling it to the tool."
 
 [[content.alternatives]]
 text = "Keep both syntaxes permanently"
-status = "considered"
-
-[[content.alternatives]]
-text = "Remove shortcuts immediately (strict RFC-0002)"
-status = "considered"
+rejection_reason = "Keeping both syntaxes permanently preserves dual-path complexity and weakens the resource-first model."
 
 [[content.alternatives]]
 text = "Phased deprecation (warnings now, remove in 1.0)"
-status = "considered"
+rejection_reason = "A phased deprecation prolongs the transition period and keeps unnecessary shortcut machinery in the codebase."
 
 [[content.alternatives]]
 text = "Expand shortcuts to all common operations"
-status = "considered"
+rejection_reason = "Expanding shortcuts would make the exception surface larger and further undermine the one-obvious-way command model."

--- a/gov/adr/ADR-0018-global-command-shortcuts-vs-strict-resource-first-syntax.toml
+++ b/gov/adr/ADR-0018-global-command-shortcuts-vs-strict-resource-first-syntax.toml
@@ -137,88 +137,42 @@ text = "**Learning Curve**: Users familiar with old syntax need to adjust"
 text = "Mitigation: Clear error messages suggesting correct syntax"
 
 [[content.consequences.negative]]
-text = "### Migration Required"
+text = """### Migration Required
+Users need to update:
+
+```bash
+# Old → New
+govctl list rfc        → govctl rfc list
+govctl list adr        → govctl adr list
+govctl list work       → govctl work list
+govctl list clause     → govctl clause list
+govctl new rfc "..."   → govctl rfc new "..."
+govctl new adr "..."   → govctl adr new "..."
+govctl new work "..."  → govctl work new "..."
+govctl new clause ...  → govctl clause new ...
+```"""
 
 [[content.consequences.negative]]
-text = "Users need to update:"
+text = """### Future Extension
+This decision does NOT prevent adding convenience aliases later if user demand warrants it. However, any such addition would require an RFC amendment to [[RFC-0002:C-GLOBAL-COMMANDS]]."""
 
 [[content.consequences.negative]]
-text = "```bash"
+text = """### Recommendation for Users
+Add personal shell aliases for frequently used commands:
 
-[[content.consequences.negative]]
-text = "# Old → New"
+```bash
+# In ~/.bashrc or ~/.zshrc
+alias gr='govctl rfc'
+alias ga='govctl adr'
+alias gw='govctl work'
+alias gc='govctl clause'
 
-[[content.consequences.negative]]
-text = "govctl list rfc        → govctl rfc list"
+# Usage becomes:
+gr list        # govctl rfc list
+gw new "task"  # govctl work new "task"
+```
 
-[[content.consequences.negative]]
-text = "govctl list adr        → govctl adr list"
-
-[[content.consequences.negative]]
-text = "govctl list work       → govctl work list"
-
-[[content.consequences.negative]]
-text = "govctl list clause     → govctl clause list"
-
-[[content.consequences.negative]]
-text = 'govctl new rfc "..."   → govctl rfc new "..."'
-
-[[content.consequences.negative]]
-text = 'govctl new adr "..."   → govctl adr new "..."'
-
-[[content.consequences.negative]]
-text = 'govctl new work "..."  → govctl work new "..."'
-
-[[content.consequences.negative]]
-text = "govctl new clause ...  → govctl clause new ..."
-
-[[content.consequences.negative]]
-text = "```"
-
-[[content.consequences.negative]]
-text = "### Future Extension"
-
-[[content.consequences.negative]]
-text = "This decision does NOT prevent adding convenience aliases later if user demand warrants it. However, any such addition would require an RFC amendment to [[RFC-0002:C-GLOBAL-COMMANDS]]."
-
-[[content.consequences.negative]]
-text = "### Recommendation for Users"
-
-[[content.consequences.negative]]
-text = "Add personal shell aliases for frequently used commands:"
-
-[[content.consequences.negative]]
-text = "```bash"
-
-[[content.consequences.negative]]
-text = "# In ~/.bashrc or ~/.zshrc"
-
-[[content.consequences.negative]]
-text = "alias gr='govctl rfc'"
-
-[[content.consequences.negative]]
-text = "alias ga='govctl adr'"
-
-[[content.consequences.negative]]
-text = "alias gw='govctl work'"
-
-[[content.consequences.negative]]
-text = "alias gc='govctl clause'"
-
-[[content.consequences.negative]]
-text = "# Usage becomes:"
-
-[[content.consequences.negative]]
-text = "gr list        # govctl rfc list"
-
-[[content.consequences.negative]]
-text = 'gw new "task"  # govctl work new "task"'
-
-[[content.consequences.negative]]
-text = "```"
-
-[[content.consequences.negative]]
-text = "This provides the convenience without coupling it to the tool."
+This provides the convenience without coupling it to the tool."""
 
 [[content.alternatives]]
 text = "Keep both syntaxes permanently"

--- a/gov/adr/ADR-0019-change-n-from-dry-run-to-limit-for-better-unix-convention-alignment.toml
+++ b/gov/adr/ADR-0019-change-n-from-dry-run-to-limit-for-better-unix-convention-alignment.toml
@@ -10,6 +10,9 @@ refs = [
     "ADR-0017",
 ]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 ADR-0006 and ADR-0017 assigned `-n` as the short flag for `--dry-run`, following rsync's convention. However, this conflicts with the more universal Unix convention where `-n` means "number" or "limit":
@@ -55,7 +58,10 @@ decision = """
 - **Safety**: Dry-run benefits from being explicit (`--dry-run`)
 - **Pre-1.0 window**: Breaking changes are acceptable now
 - **Consistency**: Follows head/tail patterns users know"""
-consequences = """
+selected_option = "Reassign -n from dry-run to limit"
+
+[content.consequences]
+neutral = ["""
 **Positive:**
 - Natural `-n` for limit matches Unix expectations
 - More ergonomic interactive use: `govctl work list -n 5`
@@ -75,4 +81,4 @@ consequences = """
 
 **Affected ADRs:**
 - [[ADR-0006]]: Originally defined `-n` for dry-run
-- [[ADR-0017]]: Documents `-n` as global dry-run flag"""
+- [[ADR-0017]]: Documents `-n` as global dry-run flag"""]

--- a/gov/adr/ADR-0020-configurable-work-item-id-strategies-for-multi-person-collaboration.toml
+++ b/gov/adr/ADR-0020-configurable-work-item-id-strategies-for-multi-person-collaboration.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-01-26"
 refs = ["RFC-0000"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 The current work item ID format (`WI-YYYY-MM-DD-NNN`) uses local sequential numbering. The `govctl work new` command scans `gov/work/` to find the max sequence number for today's date, then increments by 1.
@@ -65,7 +68,10 @@ id_strategy = "author-hash"  # or "sequential" (default), "random"
 - Teams explicitly opt-in to collision-safe strategy
 - `author-hash` is recommended because it preserves sequential numbering within author namespace
 - Uses git identity (already required for commits) — zero additional config"""
-consequences = """
+selected_option = "Add opt-in work item ID strategies"
+
+[content.consequences]
+neutral = ["""
 **Positive:**
 - Multi-person teams can adopt govctl without ID collision risk
 - Existing single-contributor projects unchanged
@@ -86,4 +92,4 @@ consequences = """
 **Migration for teams:**
 1. Set `[work_item] id_strategy = "author-hash"` in `gov/config.toml`
 2. Existing work items retain their IDs (no renaming required)
-3. New work items use the new format"""
+3. New work items use the new format"""]

--- a/gov/adr/ADR-0021-resource-scoped-render-commands-for-single-item-rendering.toml
+++ b/gov/adr/ADR-0021-resource-scoped-render-commands-for-single-item-rendering.toml
@@ -10,6 +10,9 @@ refs = [
     "ADR-0018",
 ]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 
@@ -68,36 +71,53 @@ govctl render [rfc|adr|work|changelog|all]  # No --rfc-id flag
 - Resource-scoped `render` shares implementation with global render (just filters to single ID)
 - Error handling: if ID not found, return clear error message
 - Output: same format as bulk render, just for one item"""
-consequences = """
+selected_option = "Add resource-scoped render verbs and remove the global --rfc-id flag"
 
-### Positive
+[content.consequences]
+positive = [
+    "**Symmetric API**: All resource types support single-item render equally",
+    "**Cleaner global command**: No proliferation of `--*-id` flags",
+    '**Intuitive mental model**: "Work with RFC" → `govctl rfc render RFC-0001`',
+    "**Better discoverability**: `govctl rfc --help` shows all RFC operations including render",
+]
 
-- **Symmetric API**: All resource types support single-item render equally
-- **Cleaner global command**: No proliferation of `--*-id` flags
-- **Intuitive mental model**: "Work with RFC" → `govctl rfc render RFC-0001`
-- **Better discoverability**: `govctl rfc --help` shows all RFC operations including render
+[[content.consequences.negative]]
+text = "**Breaking change**: Scripts using `govctl render --rfc-id` must update"
 
-### Negative
+[[content.consequences.negative]]
+text = "Mitigation: Pre-1.0, document in CHANGELOG"
 
-- **Breaking change**: Scripts using `govctl render --rfc-id` must update
-  - Mitigation: Pre-1.0, document in CHANGELOG
-- **Two entry points for render**: Global (bulk) and resource-scoped (single)
-  - Mitigation: Clear purpose split makes this a feature, not a bug
+[[content.consequences.negative]]
+text = "**Two entry points for render**: Global (bulk) and resource-scoped (single)"
 
-### Migration
+[[content.consequences.negative]]
+text = "Mitigation: Clear purpose split makes this a feature, not a bug"
 
-```bash
-# Old syntax (removed)
-govctl render rfc --rfc-id RFC-0001
+[[content.consequences.negative]]
+text = "### Migration"
 
-# New syntax
-govctl rfc render RFC-0001
-```"""
+[[content.consequences.negative]]
+text = "```bash"
+
+[[content.consequences.negative]]
+text = "# Old syntax (removed)"
+
+[[content.consequences.negative]]
+text = "govctl render rfc --rfc-id RFC-0001"
+
+[[content.consequences.negative]]
+text = "# New syntax"
+
+[[content.consequences.negative]]
+text = "govctl rfc render RFC-0001"
+
+[[content.consequences.negative]]
+text = "```"
 
 [[content.alternatives]]
 text = "Add --adr-id and --work-id flags to global render: Proliferates flags, violates 'one way' principle"
-status = "considered"
+rejection_reason = "Adding more --*-id flags to the global render command proliferates special cases and violates the one-way command model."
 
 [[content.alternatives]]
 text = "Leave as-is with only --rfc-id: Asymmetric, inconsistent UX"
-status = "considered"
+rejection_reason = "Leaving single-item render support only for RFCs preserves an asymmetric and inconsistent UX across artifact types."

--- a/gov/adr/ADR-0021-resource-scoped-render-commands-for-single-item-rendering.toml
+++ b/gov/adr/ADR-0021-resource-scoped-render-commands-for-single-item-rendering.toml
@@ -94,25 +94,15 @@ text = "**Two entry points for render**: Global (bulk) and resource-scoped (sing
 text = "Mitigation: Clear purpose split makes this a feature, not a bug"
 
 [[content.consequences.negative]]
-text = "### Migration"
+text = """**Migration**: Users must update any scripts that still use the removed global `--rfc-id` form.
 
-[[content.consequences.negative]]
-text = "```bash"
+```bash
+# Old syntax (removed)
+govctl render rfc --rfc-id RFC-0001
 
-[[content.consequences.negative]]
-text = "# Old syntax (removed)"
-
-[[content.consequences.negative]]
-text = "govctl render rfc --rfc-id RFC-0001"
-
-[[content.consequences.negative]]
-text = "# New syntax"
-
-[[content.consequences.negative]]
-text = "govctl rfc render RFC-0001"
-
-[[content.consequences.negative]]
-text = "```"
+# New syntax
+govctl rfc render RFC-0001
+```"""
 
 [[content.alternatives]]
 text = "Add --adr-id and --work-id flags to global render: Proliferates flags, violates 'one way' principle"

--- a/gov/adr/ADR-0022-add-show-command-for-stdout-rendering.toml
+++ b/gov/adr/ADR-0022-add-show-command-for-stdout-rendering.toml
@@ -10,6 +10,9 @@ refs = [
     "ADR-0021",
 ]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 Agents (Claude, Cursor, etc.) intuitively try `govctl rfc show RFC-0001` to read an RFC's rendered content, but this command doesn't exist. The error `unrecognized subcommand 'show'` is a recurring failure mode.
@@ -75,33 +78,37 @@ govctl clause show <CLAUSE-ID> # Print clause content to stdout
 3. **Minimal implementation:** Reuses existing render logic, just changes output target
 4. **Symmetric with render:** `show` is to `render` as `cat` is to `cp`
 5. **Format flexibility:** `--output json` gives structured access when needed"""
-consequences = """
-### Positive
+selected_option = "Add a show verb for stdout rendering of governance artifacts"
 
-- **Fixes agent failures:** `govctl rfc show RFC-0001` will work as expected
-- **Cleaner semantics:** Clear separation between read (show) and write (render)
-- **Pipeable:** `govctl rfc show RFC-0002 | less` or `| grep pattern` just works
-- **Consistent UX:** All renderable resources get the same `show` verb
+[content.consequences]
+positive = [
+    "**Fixes agent failures:** `govctl rfc show RFC-0001` will work as expected",
+    "**Cleaner semantics:** Clear separation between read (show) and write (render)",
+    "**Pipeable:** `govctl rfc show RFC-0002 | less` or `| grep pattern` just works",
+    "**Consistent UX:** All renderable resources get the same `show` verb",
+]
+neutral = ["`--output json` on `show` is functionally equivalent to `get` with no field argument — this redundancy is acceptable for discoverability"]
 
-### Negative
+[[content.consequences.negative]]
+text = "**New verb to learn:** Users must understand show vs render distinction"
 
-- **New verb to learn:** Users must understand show vs render distinction
-  - Mitigation: Intuitive naming makes this self-evident
-- **Slight command surface growth:** 4 new subcommands
-  - Mitigation: Natural extension of existing pattern, improves discoverability
+[[content.consequences.negative]]
+text = "Mitigation: Intuitive naming makes this self-evident"
 
-### Neutral
+[[content.consequences.negative]]
+text = "**Slight command surface growth:** 4 new subcommands"
 
-- `--output json` on `show` is functionally equivalent to `get` with no field argument — this redundancy is acceptable for discoverability"""
+[[content.consequences.negative]]
+text = "Mitigation: Natural extension of existing pattern, improves discoverability"
 
 [[content.alternatives]]
 text = "Extend get with --rendered flag: Overloads get semantics, less discoverable"
-status = "considered"
+rejection_reason = "A --rendered flag overloads get semantics and is less discoverable than a dedicated read verb."
 
 [[content.alternatives]]
 text = "Use view instead of show: Equally valid, but show is more common in CLIs (docker inspect, kubectl describe)"
-status = "considered"
+rejection_reason = "show is the more common CLI verb for displaying a rendered artifact; view adds no semantic advantage."
 
 [[content.alternatives]]
 text = "Use cat as the verb: Unix-y but loses semantic meaning (cat is for concatenation)"
-status = "considered"
+rejection_reason = "cat is Unix-flavored but semantically misleading because these commands render artifact views rather than concatenate files."

--- a/gov/adr/ADR-0023-organize-assets-into-commands-skills-and-agents-subdirectories.toml
+++ b/gov/adr/ADR-0023-organize-assets-into-commands-skills-and-agents-subdirectories.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-02-11"
 refs = ["ADR-0024"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 The `assets/` directory currently contains a flat mix of files: four command workflow definitions (`gov.md`, `quick.md`, `discuss.md`, `status.md`) and four logo SVGs. As we prepare to add **skill definitions** (specialized AI agent capabilities) and **agent definitions** (agent role/behavior configurations), the flat structure becomes ambiguous — it conflates three distinct categories of assets.
@@ -37,23 +40,26 @@ All compile-time paths (`include_str!`), build system paths (`build.rs`), and sc
 1. **Semantic clarity** — the directory name tells you what kind of asset it is
 2. **Minimal blast radius** — logos stay put, only command `.md` files move one level deeper
 3. **Future-proof** — skills and agents get their own home from day one"""
-consequences = """
-### Positive
-- Clear separation of concerns for three distinct asset categories
-- New skills/agents have a designated location from the start
-- Scripts and tooling can target specific subdirectories
+selected_option = "Organize assets into commands, skills, and agents subdirectories"
 
-### Negative
-- One-time update to all paths referencing command assets (4 files)
-- Test snapshots that reference output paths may need updating
+[content.consequences]
+positive = [
+    "Clear separation of concerns for three distinct asset categories",
+    "New skills/agents have a designated location from the start",
+    "Scripts and tooling can target specific subdirectories",
+]
+neutral = ["Logo SVGs stay at `assets/` root — no change to README references"]
 
-### Neutral
-- Logo SVGs stay at `assets/` root — no change to README references"""
+[[content.consequences.negative]]
+text = "One-time update to all paths referencing command assets (4 files)"
+
+[[content.consequences.negative]]
+text = "Test snapshots that reference output paths may need updating"
 
 [[content.alternatives]]
 text = "Flat with naming conventions: Keep flat assets/ and use prefixes like cmd-gov.md, skill-foo.md. Rejected: naming conventions are fragile and don't scale."
-status = "considered"
+rejection_reason = "Relying on filename prefixes keeps the directory semantically flat and creates fragile naming conventions that do not scale."
 
 [[content.alternatives]]
 text = "Separate top-level directories: commands/ skills/ agents/ at repo root. Rejected: over-scatters related assets."
-status = "considered"
+rejection_reason = "Moving commands, skills, and agents to separate top-level directories scatters closely related assets more than necessary."

--- a/gov/adr/ADR-0024-writers-as-skills-reviewers-as-agents-for-governance-artifacts.toml
+++ b/gov/adr/ADR-0024-writers-as-skills-reviewers-as-agents-for-governance-artifacts.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-02-11"
 refs = ["ADR-0023"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 govctl manages three governance artifact types — RFCs, ADRs, and work items. We need to add AI-assisted capabilities for both *creating* (writing) and *reviewing* these artifacts.
@@ -64,37 +67,46 @@ decision = """
 - Review agents can be invoked at quality gates (e.g., after drafting, before finalization)
 - `compliance-checker` can be invoked during `/gov` Phase 4 (testing) or on demand
 - `sync-assets.sh` already syncs both `skills/` and `agents/` directories"""
-consequences = """
-### Positive
-- Writers augment the main agent with domain knowledge while preserving conversation context
-- Reviewers provide unbiased quality checks through cognitive isolation
-- Compliance checker catches spec violations that `govctl check` cannot (it validates references exist; the agent validates semantic conformance)
-- Seven focused items follow "one skill, one capability" — each stays under 250 lines
-- Future artifact types get their own skill + agent pair without touching existing files
-- `sync-assets.sh` already supports the directory structure ([[ADR-0023]])
+selected_option = "Use skills for writers and agents for reviewers and auditors"
 
-### Negative
-- 7 files to maintain (mitigation: each is small and focused, changes are rare)
-- ~15% knowledge duplication across items (mitigation: 3-5 lines per file, not worth abstracting)
-- Review/audit agents lack conversation context (mitigation: they evaluate on merit, which is the point)
-- Compliance checking is inherently imprecise — agent may flag false positives (mitigation: output is advisory, not blocking)
+[content.consequences]
+positive = [
+    "Writers augment the main agent with domain knowledge while preserving conversation context",
+    "Reviewers provide unbiased quality checks through cognitive isolation",
+    "Compliance checker catches spec violations that `govctl check` cannot (it validates references exist; the agent validates semantic conformance)",
+    'Seven focused items follow "one skill, one capability" — each stays under 250 lines',
+    "Future artifact types get their own skill + agent pair without touching existing files",
+    "`sync-assets.sh` already supports the directory structure ([[ADR-0023]])",
+]
+neutral = [
+    "Existing `/discuss` and `/gov` commands continue to work unchanged initially; skills/agents integration is additive",
+    "`govctl check` continues to handle structural validation; `compliance-checker` handles semantic validation — complementary, not competing",
+]
 
-### Neutral
-- Existing `/discuss` and `/gov` commands continue to work unchanged initially; skills/agents integration is additive
-- `govctl check` continues to handle structural validation; `compliance-checker` handles semantic validation — complementary, not competing"""
+[[content.consequences.negative]]
+text = "7 files to maintain (mitigation: each is small and focused, changes are rare)"
+
+[[content.consequences.negative]]
+text = "~15% knowledge duplication across items (mitigation: 3-5 lines per file, not worth abstracting)"
+
+[[content.consequences.negative]]
+text = "Review/audit agents lack conversation context (mitigation: they evaluate on merit, which is the point)"
+
+[[content.consequences.negative]]
+text = "Compliance checking is inherently imprecise — agent may flag false positives (mitigation: output is advisory, not blocking)"
 
 [[content.alternatives]]
 text = "All skills: Make both writers and reviewers skills. Rejected: reviewers lose cognitive isolation, confirmation bias when main agent reviews its own work."
-status = "considered"
+rejection_reason = "If reviewers run as skills, the authoring agent reviews its own work and loses the cognitive isolation needed for honest quality checks."
 
 [[content.alternatives]]
 text = "All agents: Make both writers and reviewers agents. Rejected: writers lose conversation context, cannot access why the user is creating the artifact."
-status = "considered"
+rejection_reason = "If writers run as isolated agents, they lose the conversation context needed to draft governance artifacts accurately."
 
 [[content.alternatives]]
 text = "4 consolidated items (governance-writer + wi-writer, governance-reviewer + wi-reviewer): Rejected: RFC and ADR capabilities are genuinely different, merging creates a skill that branches on artifact type — special cases we want to eliminate."
-status = "considered"
+rejection_reason = "A combined governance-writer/reviewer shape forces branching on artifact type and couples distinct RFC, ADR, and work-item concerns."
 
 [[content.alternatives]]
 text = "2 consolidated items (one writer, one reviewer): Rejected: work items differ fundamentally from RFCs/ADRs, no shared domain knowledge worth coupling."
-status = "considered"
+rejection_reason = "A single writer and single reviewer collapse fundamentally different artifact domains into abstractions with little real shared value."

--- a/gov/adr/ADR-0025-concurrent-write-safety-for-agent-driven-parallel-tasks.toml
+++ b/gov/adr/ADR-0025-concurrent-write-safety-for-agent-driven-parallel-tasks.toml
@@ -10,6 +10,9 @@ refs = [
     "ADR-0020",
 ]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 When an agent (e.g. Cursor, Claude Code) runs multiple tasks in parallel that each invoke govctl to create or modify RFCs, ADRs, or work items, concurrent writes to the same files or to the same directory can cause:
@@ -37,7 +40,10 @@ decision = """
 3. **Granularity**
    - Coarse-grained (one lock per gov root) is chosen over per-artifact or per-directory locks to avoid deadlock and to keep implementation and behavior simple. Parallel agents serialize at the gov root; throughput is traded for correctness and simplicity.
 """
-consequences = """
+selected_option = "Use a single gov-root filesystem lock for all mutating commands"
+
+[content.consequences]
+neutral = ["""
 **Positive**
 - Prevents file corruption and ID collision under concurrent agent tasks.
 - Single lock file: no deadlock, no lock ordering, easy to reason about.
@@ -49,25 +55,20 @@ consequences = """
 - Slight complexity in CLI entrypoint: acquire lock early for write commands, release on all exit paths.
 
 **Neutral**
-- Render (writing to docs/) is included in the lock scope so that render + new/edit from two processes do not interleave.
-"""
-
-[[content.alternatives]]
-text = "File lock (gov-root): One exclusive lock for entire gov/ tree. Blocks concurrent writers until release. Chosen for simplicity and no deadlock."
-status = "considered"
+- Render (writing to docs/) is included in the lock scope so that render + new/edit from two processes do not interleave."""]
 
 [[content.alternatives]]
 text = "Per-artifact lock: Lock only the file or directory being written. Rejected: deadlock risk (e.g. A holds rfc/ B holds adr/; A needs adr/ B needs rfc/), more complex lock ordering."
-status = "considered"
+rejection_reason = "Per-artifact locks introduce lock-ordering complexity and deadlock risk for marginal concurrency gains."
 
 [[content.alternatives]]
 text = "Write queue / single-writer daemon: One process accepts write requests over a socket or FIFO. Rejected: requires a long-running daemon, contradicts CLI-only design."
-status = "considered"
+rejection_reason = "A write queue or daemon contradicts the CLI-only architecture and adds unnecessary long-running infrastructure."
 
 [[content.alternatives]]
 text = "Documentation-only: Tell users/agents not to run write commands in parallel. Rejected: does not prevent races; agents and scripts often parallelize by default."
-status = "considered"
+rejection_reason = "Documentation alone does not prevent races in scripts or agent-driven parallel execution."
 
 [[content.alternatives]]
 text = "Atomic write + retry: Write to temp then rename; for work item ID, retry on collision. Rejected: avoids partial writes but does not fix read-modify-write races or deterministic ID collision from find_max_sequence."
-status = "considered"
+rejection_reason = "Atomic write plus retry avoids partial writes but still fails to prevent read-modify-write races and deterministic ID collisions."

--- a/gov/adr/ADR-0026-add-journal-field-to-workitem-for-execution-tracking.toml
+++ b/gov/adr/ADR-0026-add-journal-field-to-workitem-for-execution-tracking.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-02-22"
 refs = ["RFC-0000"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 During agent-driven governance workflows, agents naturally use work items as "working memory" to track execution progress. Currently, this working memory is stored in the `description` field, mixing multiple semantic purposes:
@@ -74,7 +77,10 @@ Each journal entry has three fields:
 2. Update `gov/schema/work.schema.toml`
 3. Update render logic in `src/render.rs` to include journal section
 4. Update wi-writer skill documentation"""
-consequences = """
+selected_option = "Add journal field to WorkItemContent"
+
+[content.consequences]
+neutral = ["""
 **What becomes easier:**
 
 - **Clear separation of concerns:** `description` stays focused on task scope; execution details go to `journal`
@@ -96,4 +102,4 @@ consequences = """
 
 - `wi-writer` skill updated with field usage guidelines
 - `work.schema.toml` updated with journal field definition
-- Rendered markdown includes "## Journal" section after description"""
+- Rendered markdown includes "## Journal" section after description"""]

--- a/gov/adr/ADR-0027-extend-alternative-structure-with-pros-cons-and-rejection-reason.toml
+++ b/gov/adr/ADR-0027-extend-alternative-structure-with-pros-cons-and-rejection-reason.toml
@@ -7,6 +7,9 @@ status = "accepted"
 date = "2026-02-22"
 refs = ["RFC-0000:C-ADR-DEF"]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 The current `Alternative` structure in ADRs only has two fields: `text` and `status`. This is insufficient for capturing structured decision rationale:
@@ -46,7 +49,10 @@ Extend the `Alternative` structure with three new optional fields:
 
 **Backward compatibility:**
 All new fields use `#[serde(default)]` and `skip_serializing_if_empty`, so existing ADRs remain valid without migration."""
-consequences = """
+selected_option = "Extend Alternative structure with pros, cons, and rejection_reason"
+
+[content.consequences]
+neutral = ["""
 **What becomes easier:**
 
 - **Structured comparison**: Each alternative has its own pros/cons attached
@@ -75,4 +81,4 @@ consequences = """
 
     ### Author hash namespace (accepted)
     - Pros: Auto isolation, Zero config
-    - Cons: Slightly less readable"""
+    - Cons: Slightly less readable"""]

--- a/gov/adr/ADR-0028-migrate-commands-to-skills-format-for-cross-platform-compatibility.toml
+++ b/gov/adr/ADR-0028-migrate-commands-to-skills-format-for-cross-platform-compatibility.toml
@@ -10,6 +10,9 @@ refs = [
     "ADR-0023",
 ]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 The project currently has two mechanisms for AI agent capabilities:
@@ -71,7 +74,10 @@ Extend skill frontmatter to include command-specific fields:
 - Very low usage frequency observed
 - Equivalent information available via `govctl status` CLI
 - Reduces maintenance burden"""
-consequences = """
+selected_option = "Migrate workflow commands to skills format"
+
+[content.consequences]
+neutral = ["""
 **Positive:**
 - Single unified format for all agent capabilities
 - Portable across Claude, Cursor, and Codex
@@ -103,5 +109,4 @@ consequences = """
     ├── adr-writer/
     │   └── SKILL.md
     └── wi-writer/
-        └── SKILL.md
-"""
+        └── SKILL.md"""]

--- a/gov/adr/ADR-0029-path-based-nested-field-addressing-for-artifact-edits.toml
+++ b/gov/adr/ADR-0029-path-based-nested-field-addressing-for-artifact-edits.toml
@@ -98,34 +98,60 @@ govctl adr set ADR-0001 alt[2].pro[0] "Updated pro"
 
 - Existing top-level field syntax remains valid.
 - Existing `adr add ... alternatives --pro/--con/--reject-reason` remains supported during migration.
-- Convergence plan: docs and examples immediately prefer path syntax; legacy alternative-specific flags receive deprecation warnings after rollout stabilizes (target: two minor releases), then are removed only in a major release."""
-consequences = """
-### Positive
+- Convergence plan: docs and examples immediately prefer path syntax; legacy alternative-specific flags receive deprecation warnings after rollout stabilizes (target: two minor releases), then are removed only in a major release.
 
-- Enables concise, direct nested edits such as `alt[2].pro[2]` without editing raw TOML.
-- Preserves current mental model (`set/add/remove/tick`) and command discoverability.
-- Reuses existing match semantics from [[ADR-0007]], reducing conceptual fragmentation.
-- Creates a reusable abstraction for nested fields across ADRs and work items.
+### Recovered Selected-Option Advantages
 
-### Negative
+- Compatible with existing command model
+- Directly solves nested edit ergonomics
+- Supports incremental rollout with low script breakage
+"""
+selected_option = "Option 3: Keep verbs and add path-based field addressing"
 
-- Adds parser and resolver complexity in the edit pipeline.
-  - Mitigation: strict grammar, bounded depth, and dedicated parser tests (including fuzz/property tests).
-- Requires broader validation and diagnostics coverage.
-  - Mitigation: explicit diagnostic matrix for parse/resolution/type errors and snapshot tests for representative failures.
-- Dual syntax during migration (`--pro/--con` and path syntax) can confuse users.
-  - Mitigation: docs prefer path syntax immediately, deprecation warnings for legacy flags after rollout, and a published convergence timeline.
-- Documentation and examples require coordinated updates across guides and help text.
-  - Mitigation: track doc updates in implementation work items and gate release on docs parity checks.
+[content.consequences]
+positive = [
+    "Enables concise, direct nested edits such as `alt[2].pro[2]` without editing raw TOML.",
+    "Preserves current mental model (`set/add/remove/tick`) and command discoverability.",
+    "Reuses existing match semantics from [[ADR-0007]], reducing conceptual fragmentation.",
+    "Creates a reusable abstraction for nested fields across ADRs and work items.",
+]
+neutral = [
+    "No data migration is required for existing ADR files; the change is CLI-surface and parser behavior.",
+    "Alias set is intentionally small and closed (`alt`, `pro`, `con`, `reason`); future alias additions require explicit schema/governance update to avoid accidental drift.",
+]
 
-### Neutral
+[[content.consequences.negative]]
+text = "Adds parser and resolver complexity in the edit pipeline."
 
-- No data migration is required for existing ADR files; the change is CLI-surface and parser behavior.
-- Alias set is intentionally small and closed (`alt`, `pro`, `con`, `reason`); future alias additions require explicit schema/governance update to avoid accidental drift."""
+[[content.consequences.negative]]
+text = "Mitigation: strict grammar, bounded depth, and dedicated parser tests (including fuzz/property tests)."
+
+[[content.consequences.negative]]
+text = "Requires broader validation and diagnostics coverage."
+
+[[content.consequences.negative]]
+text = "Mitigation: explicit diagnostic matrix for parse/resolution/type errors and snapshot tests for representative failures."
+
+[[content.consequences.negative]]
+text = "Dual syntax during migration (`--pro/--con` and path syntax) can confuse users."
+
+[[content.consequences.negative]]
+text = "Mitigation: docs prefer path syntax immediately, deprecation warnings for legacy flags after rollout, and a published convergence timeline."
+
+[[content.consequences.negative]]
+text = "Documentation and examples require coordinated updates across guides and help text."
+
+[[content.consequences.negative]]
+text = "Mitigation: track doc updates in implementation work items and gate release on docs parity checks."
+
+[[content.consequences.negative]]
+text = "Introduces parser and resolver complexity"
+
+[[content.consequences.negative]]
+text = "Creates temporary dual-syntax cognitive load during migration"
 
 [[content.alternatives]]
 text = "Option 1: Keep current field-only operations and use manual TOML edits for nested changes"
-status = "rejected"
 pros = [
     "No new parser or resolver",
     "Lowest immediate implementation risk",
@@ -138,7 +164,6 @@ rejection_reason = "Does not address the primary usability gap"
 
 [[content.alternatives]]
 text = "Option 2: Add a universal edit verb with JSONPath-like expressions"
-status = "rejected"
 pros = [
     "Single conceptual mutation entry point",
     "Potentially expressive for advanced operations",
@@ -148,16 +173,3 @@ cons = [
     "Higher migration and discoverability cost",
 ]
 rejection_reason = "Overlaps existing verbs and weakens current command architecture"
-
-[[content.alternatives]]
-text = "Option 3: Keep verbs and add path-based field addressing"
-status = "accepted"
-pros = [
-    "Compatible with existing command model",
-    "Directly solves nested edit ergonomics",
-    "Supports incremental rollout with low script breakage",
-]
-cons = [
-    "Introduces parser and resolver complexity",
-    "Creates temporary dual-syntax cognitive load during migration",
-]

--- a/gov/adr/ADR-0030-parser-strategy-for-path-based-field-expressions.toml
+++ b/gov/adr/ADR-0030-parser-strategy-for-path-based-field-expressions.toml
@@ -86,31 +86,48 @@ Compatibility is preserved as a **normalization layer after parse, before resolu
 2. Keep current diagnostics mapping (`E0814`/`E0815`/`E0816`/`E0817`/`E0818`).
 3. Add golden tests for legacy compatibility inputs.
 4. Add negative tests for over-deep/over-specified paths and verb-shape violations.
-5. Remove old parser implementation after parity tests pass."""
-consequences = """
-### Positive
+5. Remove old parser implementation after parity tests pass.
 
-- Eliminates a class of silent-acceptance bugs via full-input consumption.
-- Makes grammar behavior explicit and easier to reason about during review.
-- Provides a stable foundation for future extensions without reintroducing ad-hoc state logic.
-- Improves confidence in diagnostics by separating parse/normalize/resolve phases.
+### Recovered Selected-Option Advantages
 
-### Negative
+- Strict grammar with full-input consumption
+- Rust-native and testable composition
+- Balanced complexity for small grammar
+"""
+selected_option = "Option 2: Use winnow parser combinators with typed AST"
 
-- Adds a third-party parsing dependency.
-  - Mitigation: keep dependency surface small and isolate parser module behind a narrow API.
-- Introduces a learning curve for maintainers unfamiliar with parser combinators.
-  - Mitigation: document grammar and parser module invariants with examples and tests.
-- Migration requires careful parity testing to avoid compatibility regressions.
-  - Mitigation: snapshot parity suite for legacy field forms and aliases before rollout.
+[content.consequences]
+positive = [
+    "Eliminates a class of silent-acceptance bugs via full-input consumption.",
+    "Makes grammar behavior explicit and easier to reason about during review.",
+    "Provides a stable foundation for future extensions without reintroducing ad-hoc state logic.",
+    "Improves confidence in diagnostics by separating parse/normalize/resolve phases.",
+]
+neutral = ["Runtime cost is expected to be negligible for CLI-scale path strings; this should be verified by micro-benchmarks in CI but is not expected to be user-visible."]
 
-### Neutral
+[[content.consequences.negative]]
+text = "Adds a third-party parsing dependency."
 
-- Runtime cost is expected to be negligible for CLI-scale path strings; this should be verified by micro-benchmarks in CI but is not expected to be user-visible."""
+[[content.consequences.negative]]
+text = "Mitigation: keep dependency surface small and isolate parser module behind a narrow API."
+
+[[content.consequences.negative]]
+text = "Introduces a learning curve for maintainers unfamiliar with parser combinators."
+
+[[content.consequences.negative]]
+text = "Mitigation: document grammar and parser module invariants with examples and tests."
+
+[[content.consequences.negative]]
+text = "Migration requires careful parity testing to avoid compatibility regressions."
+
+[[content.consequences.negative]]
+text = "Mitigation: snapshot parity suite for legacy field forms and aliases before rollout."
+
+[[content.consequences.negative]]
+text = "Adds dependency and parser-combinator learning curve"
 
 [[content.alternatives]]
 text = "Option 1: Keep manual parser and harden it"
-status = "rejected"
 pros = [
     "No new dependencies",
     "Minimal refactor scope",
@@ -122,18 +139,7 @@ cons = [
 rejection_reason = "Recent review findings indicate brittle behavior under malformed or over-specified paths"
 
 [[content.alternatives]]
-text = "Option 2: Use winnow parser combinators with typed AST"
-status = "accepted"
-pros = [
-    "Strict grammar with full-input consumption",
-    "Rust-native and testable composition",
-    "Balanced complexity for small grammar",
-]
-cons = ["Adds dependency and parser-combinator learning curve"]
-
-[[content.alternatives]]
 text = "Option 3: Use PEG/grammar generator approach"
-status = "rejected"
 pros = [
     "Clear formal grammar artifacts",
     "Good for larger language evolution",

--- a/gov/adr/ADR-0031-unified-artifact-edit-engine-with-ssot-and-format-adapters.toml
+++ b/gov/adr/ADR-0031-unified-artifact-edit-engine-with-ssot-and-format-adapters.toml
@@ -89,33 +89,56 @@ Field-token acceptance is strict:
 V2 is considered complete only when:
 - adding a new editable field requires SSOT changes only (no manual dispatch branching)
 - JSON and TOML share one semantic engine
-- compatibility test suite for legacy paths passes in V2 mode"""
-consequences = """
-### Positive
+- compatibility test suite for legacy paths passes in V2 mode
 
-- Reduces long-term maintenance cost by centralizing edit semantics in one engine.
-- Eliminates JSON/TOML behavioral drift risk by sharing the same plan/validation pipeline.
-- Makes parser and resolver behavior auditable through SSOT and generated tables.
-- Improves extensibility: new fields and verbs are primarily SSOT additions.
+### Recovered Selected-Option Advantages
 
-### Negative
+- Preserves storage-format independence while unifying semantic behavior
+- Enables SSOT-driven extensibility with lower long-term maintenance cost
+"""
+selected_option = "Option C: SSOT-driven semantic engine with explicit JSON/TOML adapters"
 
-- **Migration complexity is significant** because V1 and V2 must coexist temporarily.
-  - Mitigation: enforce a bounded coexistence window (max two releases) with explicit phase exit criteria and deletion checklist.
-- **Generator/SSOT errors can affect many paths at once**.
-  - Mitigation: schema validation at build-time, generated-table snapshot tests, and golden command fixtures per artifact/verb.
-- **Temporary dual operation styles** (legacy vs canonical path forms) can confuse users.
-  - Mitigation: docs prefer canonical syntax immediately; legacy usage prints guidance warnings after V2 parity milestone.
-- **Documentation and contributor onboarding work increases initially**.
-  - Mitigation: track docs updates as required migration work items and block V2 cutover completion until docs/tests are updated.
+[content.consequences]
+positive = [
+    "Reduces long-term maintenance cost by centralizing edit semantics in one engine.",
+    "Eliminates JSON/TOML behavioral drift risk by sharing the same plan/validation pipeline.",
+    "Makes parser and resolver behavior auditable through SSOT and generated tables.",
+    "Improves extensibility: new fields and verbs are primarily SSOT additions.",
+]
+neutral = ["Runtime overhead should remain negligible for CLI-scale paths, but this will be measured with parser and end-to-end micro-benchmarks before finalizing ADR status."]
 
-### Neutral
+[[content.consequences.negative]]
+text = "**Migration complexity is significant** because V1 and V2 must coexist temporarily."
 
-- Runtime overhead should remain negligible for CLI-scale paths, but this will be measured with parser and end-to-end micro-benchmarks before finalizing ADR status."""
+[[content.consequences.negative]]
+text = "Mitigation: enforce a bounded coexistence window (max two releases) with explicit phase exit criteria and deletion checklist."
+
+[[content.consequences.negative]]
+text = "**Generator/SSOT errors can affect many paths at once**."
+
+[[content.consequences.negative]]
+text = "Mitigation: schema validation at build-time, generated-table snapshot tests, and golden command fixtures per artifact/verb."
+
+[[content.consequences.negative]]
+text = "**Temporary dual operation styles** (legacy vs canonical path forms) can confuse users."
+
+[[content.consequences.negative]]
+text = "Mitigation: docs prefer canonical syntax immediately; legacy usage prints guidance warnings after V2 parity milestone."
+
+[[content.consequences.negative]]
+text = "**Documentation and contributor onboarding work increases initially**."
+
+[[content.consequences.negative]]
+text = "Mitigation: track docs updates as required migration work items and block V2 cutover completion until docs/tests are updated."
+
+[[content.consequences.negative]]
+text = "Requires staged migration and temporary dual-path operation"
+
+[[content.consequences.negative]]
+text = "Demands high-quality generator and parity tests to avoid systemic regressions"
 
 [[content.alternatives]]
 text = "Option A: Continue incremental cleanup on current architecture"
-status = "rejected"
 pros = [
     "Lowest immediate implementation risk",
     "No major migration event required",
@@ -128,7 +151,6 @@ rejection_reason = "It optimizes short-term churn but leaves the root architectu
 
 [[content.alternatives]]
 text = "Option B: Standardize internal editing on JSON only"
-status = "rejected"
 pros = [
     "Maximizes reuse of mature JSON tooling and standards",
     "Simplifies internal document mutation mechanics",
@@ -138,15 +160,3 @@ cons = [
     "Weakens direct TOML-at-rest operational clarity established by ADR-0001",
 ]
 rejection_reason = "It shifts complexity to conversion boundaries and does not provide a first-class TOML contract."
-
-[[content.alternatives]]
-text = "Option C: SSOT-driven semantic engine with explicit JSON/TOML adapters"
-status = "accepted"
-pros = [
-    "Preserves storage-format independence while unifying semantic behavior",
-    "Enables SSOT-driven extensibility with lower long-term maintenance cost",
-]
-cons = [
-    "Requires staged migration and temporary dual-path operation",
-    "Demands high-quality generator and parity tests to avoid systemic regressions",
-]

--- a/gov/adr/ADR-0032-migration-skill-for-adopting-govctl-in-existing-projects.toml
+++ b/gov/adr/ADR-0032-migration-skill-for-adopting-govctl-in-existing-projects.toml
@@ -76,41 +76,50 @@ We will create a **migrate skill** (`.claude/skills/migrate/SKILL.md`) that guid
 - **Interactive:** The skill prompts the user at each phase to confirm discoveries and prioritize what to backfill
 - **Incremental:** Each phase can be run independently; partial migration is valid
 - **Non-destructive:** Never overwrites existing files; only adds governance artifacts alongside existing content
-- **Idempotent:** Running the skill again skips already-created artifacts"""
-consequences = """
-### Positive
+- **Idempotent:** Running the skill again skips already-created artifacts
 
-- **Lowers adoption barrier** — Existing projects can adopt govctl without starting from scratch.
-- **Preserves institutional knowledge** — Undocumented decisions get codified as searchable, cross-referenced ADRs.
-- **Gradual onboarding** — Teams can migrate incrementally, one module or decision at a time.
-- **Agent-native** — The skill leverages Claude Code's ability to read codebases and synthesize decisions, making backfill practical.
+### Recovered Selected-Option Advantages
 
-### Negative
+- Zero new CLI code needed
+- Ships immediately as a bundled skill
+"""
+selected_option = "Agent-assisted skill using existing govctl commands"
 
-- **Quality depends on agent understanding** — Auto-discovered decisions may be incomplete or inaccurately described.
-  - Mitigation: Interactive confirmation at each step; user reviews all generated artifacts.
-- **Source annotation churn** — Adding `[[...]]` references to existing code creates a large diff.
-  - Mitigation: Phase 4 is optional and can be done incrementally per-module.
-- **Historical ADRs may lack alternatives** — Old decisions often don't have documented rejected options.
-  - Mitigation: The skill accepts "considered" as the only alternative when history is unclear.
-
-### Neutral
-
-- No new govctl CLI commands are needed — the skill composes existing commands.
-- The skill is bundled with govctl and installed via `govctl sync`, like other skills."""
-
-[[content.alternatives]]
-text = "Agent-assisted skill using existing govctl commands"
-status = "accepted"
-pros = [
-    "Zero new CLI code needed",
-    "Ships immediately as a bundled skill",
+[content.consequences]
+positive = [
+    "**Lowers adoption barrier** — Existing projects can adopt govctl without starting from scratch.",
+    "**Preserves institutional knowledge** — Undocumented decisions get codified as searchable, cross-referenced ADRs.",
+    "**Gradual onboarding** — Teams can migrate incrementally, one module or decision at a time.",
+    "**Agent-native** — The skill leverages Claude Code's ability to read codebases and synthesize decisions, making backfill practical.",
 ]
-cons = ["Requires an AI agent to execute the workflow"]
+neutral = [
+    "No new govctl CLI commands are needed — the skill composes existing commands.",
+    "The skill is bundled with govctl and installed via `govctl sync`, like other skills.",
+]
+
+[[content.consequences.negative]]
+text = "**Quality depends on agent understanding** — Auto-discovered decisions may be incomplete or inaccurately described."
+
+[[content.consequences.negative]]
+text = "Mitigation: Interactive confirmation at each step; user reviews all generated artifacts."
+
+[[content.consequences.negative]]
+text = "**Source annotation churn** — Adding `[[...]]` references to existing code creates a large diff."
+
+[[content.consequences.negative]]
+text = "Mitigation: Phase 4 is optional and can be done incrementally per-module."
+
+[[content.consequences.negative]]
+text = "**Historical ADRs may lack alternatives** — Old decisions often don't have documented rejected options."
+
+[[content.consequences.negative]]
+text = 'Mitigation: The skill accepts "considered" as the only alternative when history is unclear.'
+
+[[content.consequences.negative]]
+text = "Requires an AI agent to execute the workflow"
 
 [[content.alternatives]]
 text = "New govctl migrate CLI command with auto-detection"
-status = "rejected"
 pros = [
     "Works without AI agent",
     "Deterministic output",

--- a/gov/adr/ADR-0033-distribute-govctl-agent-integration-as-claude-code-plugin.toml
+++ b/gov/adr/ADR-0033-distribute-govctl-agent-integration-as-claude-code-plugin.toml
@@ -11,6 +11,9 @@ refs = [
     "ADR-0028",
 ]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 govctl has a mature agent integration layer: 8 skills (gov, quick, discuss, commit, migrate, rfc-writer, adr-writer, wi-writer) and 4 agents (compliance-checker, adr-reviewer, wi-reviewer, rfc-reviewer) in `.claude/`. This works well for developing govctl itself, but creates a distribution problem for adopters.
@@ -76,33 +79,40 @@ cargo install govctl
 - **Zero duplication**: `.claude/` is the SSOT for skills, agents, and plugin content
 - **One `.claude-plugin/`**: marketplace.json at repo root, no nested manifest
 - **Versioning**: `just stamp-plugin-version` updates marketplace.json from Cargo.toml"""
-consequences = """
-### Positive
+selected_option = "Package govctl agent integration as a Claude Code plugin with enforcement hooks"
 
-- Zero duplication: `.claude/` is both the local dev config and the plugin content
-- One-step installation for adopters: `/plugin install govctl@govctl`
-- Automatic governance enforcement via hooks
-- No build step, no sync task, no symlinks — just files in `.claude/`
-- No MCP server complexity — single codebase, single distribution, per [[ADR-0015]]
-- Plugin format is the Claude Code standard — compatible with marketplace distribution
+[content.consequences]
+positive = [
+    "Zero duplication: `.claude/` is both the local dev config and the plugin content",
+    "One-step installation for adopters: `/plugin install govctl@govctl`",
+    "Automatic governance enforcement via hooks",
+    "No build step, no sync task, no symlinks — just files in `.claude/`",
+    "No MCP server complexity — single codebase, single distribution, per [[ADR-0015]]",
+    "Plugin format is the Claude Code standard — compatible with marketplace distribution",
+]
+neutral = [
+    "`govctl init` still works for non-Claude-Code users",
+    "Future MCP integration remains possible per [[ADR-0015]] — the plugin format supports `.mcp.json`",
+    "Developers working on govctl see `.claude/` as both their local config and the plugin source — this is a feature, not a bug",
+]
 
-### Negative
+[[content.consequences.negative]]
+text = "Plugin skills are namespaced (`/govctl:gov` vs `/gov`) when installed as plugin (mitigation: only affects plugin users, not in-repo developers)"
 
-- Plugin skills are namespaced (`/govctl:gov` vs `/gov`) when installed as plugin (mitigation: only affects plugin users, not in-repo developers)
-- Hook scripts are shell-only — Windows users need WSL or Git Bash (mitigation: hooks are additive enforcement, not required functionality)
-- Binary dependency: plugin requires `govctl` installed separately (mitigation: SessionStart hook checks and provides install instructions)
-- Plugin format is Claude Code-specific — non-Claude-Code agents cannot use hooks or plugin metadata (mitigation: skills and agents are plain markdown, usable by any agent)
-- `.claude/` directory gains additional files (hooks/, scripts/, .claude-plugin/) that are plugin-specific (mitigation: these are small, clearly organized, and don't interfere with local dev)
+[[content.consequences.negative]]
+text = "Hook scripts are shell-only — Windows users need WSL or Git Bash (mitigation: hooks are additive enforcement, not required functionality)"
 
-### Neutral
+[[content.consequences.negative]]
+text = "Binary dependency: plugin requires `govctl` installed separately (mitigation: SessionStart hook checks and provides install instructions)"
 
-- `govctl init` still works for non-Claude-Code users
-- Future MCP integration remains possible per [[ADR-0015]] — the plugin format supports `.mcp.json`
-- Developers working on govctl see `.claude/` as both their local config and the plugin source — this is a feature, not a bug"""
+[[content.consequences.negative]]
+text = "Plugin format is Claude Code-specific — non-Claude-Code agents cannot use hooks or plugin metadata (mitigation: skills and agents are plain markdown, usable by any agent)"
+
+[[content.consequences.negative]]
+text = "`.claude/` directory gains additional files (hooks/, scripts/, .claude-plugin/) that are plugin-specific (mitigation: these are small, clearly organized, and don't interfere with local dev)"
 
 [[content.alternatives]]
 text = "Option A — Thin Plugin (skills + agents only, no hooks): Simplest approach, zero new code, but no automatic enforcement. Agent must remember to run govctl check manually."
-status = "rejected"
 pros = [
     "Zero new code",
     "No shell scripts to maintain",
@@ -115,7 +125,6 @@ rejection_reason = "Hooks are the high-leverage differentiator between 'works wi
 
 [[content.alternatives]]
 text = "Option C — Plugin + MCP Server: Full structured integration wrapping govctl CLI as MCP tools. Richest agent experience but doubles the API surface."
-status = "rejected"
 pros = [
     "Structured tool interface with typed parameters",
     "Richer error handling",
@@ -129,7 +138,6 @@ rejection_reason = "Per ADR-0015, maintaining two interfaces is a maintenance ni
 
 [[content.alternatives]]
 text = "Option D — Separate repository (govctl-plugin): Independent repo with its own release cycle."
-status = "rejected"
 pros = [
     "Independent versioning",
     "Smaller repo for plugin contributors",
@@ -142,7 +150,6 @@ rejection_reason = "The skills and agents ARE the govctl agent layer. Splitting 
 
 [[content.alternatives]]
 text = "Separate plugin/ directory with symlinks or copied files: Duplicates .claude/ content or requires symlinks and build steps. Creates a maintenance burden solving a problem that doesn't need to exist — .claude/ already IS the plugin structure."
-status = "rejected"
 cons = [
     "File duplication or symlink fragility",
     "Requires build/sync step",

--- a/gov/adr/ADR-0034-use-toml-as-the-canonical-storage-format-for-all-governance-artifacts.toml
+++ b/gov/adr/ADR-0034-use-toml-as-the-canonical-storage-format-for-all-governance-artifacts.toml
@@ -55,31 +55,50 @@ We will **use TOML as the canonical on-disk source-of-truth format for governanc
 - Post-migration normal operation should not keep a permanent dual-read compatibility layer. Legacy JSON handling belongs in the migration path, not in every loader and writer.
 - Before migration, normal commands should fail with an explicit migration-required diagnostic rather than guessing or partially operating on mixed-format repositories.
 - The migration command should rewrite only govctl-managed storage references. Arbitrary repo docs, tests, and scripts remain user-owned follow-up changes.
-- If accepted, this decision supersedes the storage split recorded in [[ADR-0001]]."""
-consequences = """
-### Positive
+- If accepted, this decision supersedes the storage split recorded in [[ADR-0001]].
 
-- Removes the last major on-disk format split in governance artifacts.
-- Makes storage expectations easier to explain: governance artifacts are TOML, rendered docs are projections.
-- Creates a clean place to contain legacy JSON support instead of spreading it across the whole codebase.
-- Enables real schema validation for all TOML governance artifacts, including releases, using one existing validation technology (`jsonschema`) after TOML parsing.
+### Recovered Selected-Option Advantages
 
-### Negative
+- Eliminates the on-disk format split in normal operation
+- Keeps compatibility code confined to a single migration boundary
+"""
+selected_option = "Standardize all governance artifacts on TOML with explicit migration"
 
-- Existing repositories with JSON RFCs and clauses will require an explicit migration step before normal TOML-only operation. (mitigation: normal commands should emit a dedicated `govctl migrate` diagnostic instead of attempting mixed-format behavior.)
-- RFC and clause path conventions will change from `.json` to `.toml`, so docs, tests, and direct file-path tooling must be updated carefully. (mitigation: `govctl migrate` rewrites govctl-managed clause-path references, but user-maintained references remain explicit follow-up work.)
-- `gov/releases.toml` will need a small structural migration to add explicit metadata for schema validation. (mitigation: keep the release-entry payload shape stable and migrate the file automatically with deterministic rewrite rules.)
-- External scripts, CI glue, and older govctl versions that assume `.json` RFC paths will break after migration. (mitigation: this is an intentional compatibility drop that must be documented plainly in release notes and migration docs.)
-- A broad format migration touches foundational governance definitions, so review and rollout discipline matter. (mitigation: require draft review plus full `govctl check` validation before rollout.)
+[content.consequences]
+positive = [
+    "Removes the last major on-disk format split in governance artifacts.",
+    "Makes storage expectations easier to explain: governance artifacts are TOML, rendered docs are projections.",
+    "Creates a clean place to contain legacy JSON support instead of spreading it across the whole codebase.",
+    "Enables real schema validation for all TOML governance artifacts, including releases, using one existing validation technology (`jsonschema`) after TOML parsing.",
+]
+neutral = [
+    "This does not replace the broader project-adoption migration workflow in [[ADR-0032]]; it only adds a deterministic repository-format migration boundary.",
+    "The semantic meaning of RFCs, clauses, ADRs, and work items does not change. Only their canonical storage format and validation contract change.",
+]
 
-### Neutral
+[[content.consequences.negative]]
+text = "Existing repositories with JSON RFCs and clauses will require an explicit migration step before normal TOML-only operation. (mitigation: normal commands should emit a dedicated `govctl migrate` diagnostic instead of attempting mixed-format behavior.)"
 
-- This does not replace the broader project-adoption migration workflow in [[ADR-0032]]; it only adds a deterministic repository-format migration boundary.
-- The semantic meaning of RFCs, clauses, ADRs, and work items does not change. Only their canonical storage format and validation contract change."""
+[[content.consequences.negative]]
+text = "RFC and clause path conventions will change from `.json` to `.toml`, so docs, tests, and direct file-path tooling must be updated carefully. (mitigation: `govctl migrate` rewrites govctl-managed clause-path references, but user-maintained references remain explicit follow-up work.)"
+
+[[content.consequences.negative]]
+text = "`gov/releases.toml` will need a small structural migration to add explicit metadata for schema validation. (mitigation: keep the release-entry payload shape stable and migrate the file automatically with deterministic rewrite rules.)"
+
+[[content.consequences.negative]]
+text = "External scripts, CI glue, and older govctl versions that assume `.json` RFC paths will break after migration. (mitigation: this is an intentional compatibility drop that must be documented plainly in release notes and migration docs.)"
+
+[[content.consequences.negative]]
+text = "A broad format migration touches foundational governance definitions, so review and rollout discipline matter. (mitigation: require draft review plus full `govctl check` validation before rollout.)"
+
+[[content.consequences.negative]]
+text = "Requires a carefully specified migration command"
+
+[[content.consequences.negative]]
+text = "Creates one-time churn in paths, docs, and tests"
 
 [[content.alternatives]]
 text = "Keep mixed JSON/TOML storage with format adapters"
-status = "rejected"
 pros = [
     "Lowest immediate disruption to existing RFC storage",
     "Avoids a repo-wide format migration in the short term",
@@ -92,7 +111,6 @@ rejection_reason = "This keeps the special case alive instead of deleting it."
 
 [[content.alternatives]]
 text = "Standardize all governance artifacts on JSON"
-status = "rejected"
 pros = [
     "Would reuse the existing RFC and clause storage model",
     "Could lean on mature JSON tooling and schemas",
@@ -102,15 +120,3 @@ cons = [
     "Fights the existing TOML direction established across most governance artifacts",
 ]
 rejection_reason = "It optimizes around legacy RFC storage instead of the current human-facing workflow."
-
-[[content.alternatives]]
-text = "Standardize all governance artifacts on TOML with explicit migration"
-status = "accepted"
-pros = [
-    "Eliminates the on-disk format split in normal operation",
-    "Keeps compatibility code confined to a single migration boundary",
-]
-cons = [
-    "Requires a carefully specified migration command",
-    "Creates one-time churn in paths, docs, and tests",
-]

--- a/gov/adr/ADR-0035-decouple-skill-and-agent-installation-from-project-initialization.toml
+++ b/gov/adr/ADR-0035-decouple-skill-and-agent-installation-from-project-initialization.toml
@@ -11,6 +11,9 @@ refs = [
     "ADR-0028",
 ]
 
+[govctl.migration]
+state = "verified"
+
 [content]
 context = """
 `govctl init` currently bundles three concerns into one command: governance directory scaffolding (`gov/`), JSON Schema deployment, and agent asset installation (skills + agents to `.claude/`). [[ADR-0033]] introduced plugin distribution, giving users a second path to receive skills and agents — globally, via the Claude Code plugin system.
@@ -41,27 +44,28 @@ We will **separate the three concerns** as follows:
 - `init-skills` reuses the existing `sync_commands()` implementation unchanged.
 - `migrate` adds a schema-sync step that runs unconditionally (not gated by schema version), writing all `ARTIFACT_SCHEMA_TEMPLATES` entries to `config.schema_dir()`.
 - [[RFC-0002:C-GLOBAL-COMMANDS]] is amended to add `init-skills` and update the `init` and `migrate` descriptions."""
-consequences = """
-### Positive
+selected_option = "Decouple governance init, skill installation, and schema sync into separate commands"
 
-- Plugin users no longer get redundant local skill/agent copies from `init`
-- Old projects get working `#:schema` comments after running `govctl migrate`
-- Command names are self-documenting: `init` = governance, `init-skills` = agent assets
-- The hardcoded `.claude` path in `init` is eliminated; `init-skills` uses the configured `agent_dir`
+[content.consequences]
+positive = [
+    "Plugin users no longer get redundant local skill/agent copies from `init`",
+    "Old projects get working `#:schema` comments after running `govctl migrate`",
+    "Command names are self-documenting: `init` = governance, `init-skills` = agent assets",
+    "The hardcoded `.claude` path in `init` is eliminated; `init-skills` uses the configured `agent_dir`",
+]
+neutral = [
+    "`govctl sync` is removed as a command name; `init-skills` replaces it",
+    "Schema files are now overwritten on every `migrate` run, even if unchanged — this is safe since they are generated artifacts",
+]
 
-### Negative
+[[content.consequences.negative]]
+text = "Users who had `govctl init` in onboarding docs will find `.claude/` empty after upgrading (mitigation: `init` prints a hint, and the changelog documents the change)"
 
-- Users who had `govctl init` in onboarding docs will find `.claude/` empty after upgrading (mitigation: `init` prints a hint, and the changelog documents the change)
-- Two commands instead of one for full setup (mitigation: plugin users need zero commands for agent assets; CLI-only users run `init` then `init-skills`)
-
-### Neutral
-
-- `govctl sync` is removed as a command name; `init-skills` replaces it
-- Schema files are now overwritten on every `migrate` run, even if unchanged — this is safe since they are generated artifacts"""
+[[content.consequences.negative]]
+text = "Two commands instead of one for full setup (mitigation: plugin users need zero commands for agent assets; CLI-only users run `init` then `init-skills`)"
 
 [[content.alternatives]]
 text = "Keep init bundled: init continues to dump skills/agents alongside governance structure"
-status = "rejected"
 cons = [
     "Redundant for plugin users",
     "Hardcoded .claude path ignores agent_dir config",
@@ -70,7 +74,6 @@ rejection_reason = "Plugin distribution per ADR-0033 makes unconditional local d
 
 [[content.alternatives]]
 text = "Add --skills flag to init instead of separate command: govctl init --skills dumps agent assets"
-status = "rejected"
 cons = [
     "Discovery problem: users must know the flag exists",
     "Couples governance init with agent concerns",

--- a/gov/adr/ADR-0036-restructure-adr-chosen-option-and-migration-semantics.toml
+++ b/gov/adr/ADR-0036-restructure-adr-chosen-option-and-migration-semantics.toml
@@ -1,0 +1,94 @@
+#:schema ../schema/adr.schema.json
+
+[govctl]
+id = "ADR-0036"
+title = "Restructure ADR chosen-option and migration semantics"
+status = "accepted"
+date = "2026-04-06"
+refs = [
+    "ADR-0034",
+    "ADR-0031",
+    "ADR-0027",
+    "ADR-0032",
+]
+
+[content]
+context = """
+The current ADR model stores the chosen option as an `accepted` entry inside `content.alternatives[]`. That shape creates two related problems:
+
+1. It duplicates the decision itself. The chosen path is already described in `decision`, but tooling also expects an `accepted` alternative.
+2. It leaks checklist-style status semantics into decision options. `govctl adr tick` accepts `done|pending|cancelled`, which are internally mapped to `accepted|considered|rejected` for alternatives. This is implementation-centric rather than domain-centric and confuses both users and bundled skill examples.
+3. It makes migration and rendering harder. Historical ADRs may have incomplete alternative metadata, yet the current model has no explicit place to record migration gaps while keeping the artifact renderable.
+
+We need a cleaner ADR model that:
+- makes the chosen option explicit without duplicating it as an alternative,
+- keeps alternatives focused on non-selected options,
+- structures consequences so mitigations attach to negative outcomes,
+- allows migration to produce schema-valid, renderable ADRs even when some historical intent cannot be fully recovered."""
+decision = """
+We will redesign ADR storage around four principles:
+
+1. **Chosen option is first-class.** ADR content gains an explicit `selected_option` field. The chosen path is no longer represented as an `accepted` alternative.
+2. **Alternatives only model non-selected options.** `content.alternatives[]` remains for options that were not chosen. Each alternative may keep `pros`, `cons`, and `rejection_reason`, but no longer carries a `status` field.
+3. **Consequences become structured.** `content.consequences` becomes a structured object with `positive`, `neutral`, and `negative` entries. Negative consequences may include `mitigations`.
+4. **Migration state is explicit metadata.** `govctl.migration` records whether an ADR needs post-migration review and carries warning entries describing unresolved historical gaps.
+
+### Migration semantics
+
+- Legacy `accepted` alternatives migrate into `selected_option` and are removed from `alternatives`.
+- Legacy `rejected` alternatives remain alternatives.
+- Legacy `considered` alternatives in accepted or superseded ADRs are migrated into alternatives with synthesized rejection rationale and a migration warning.
+- If migration cannot determine the chosen option, the migrated ADR remains renderable and schema-valid, but `govctl.migration.state = "needs_review"` and `govctl check` emits warnings until a human resolves it.
+
+### CLI semantics
+
+`govctl adr tick ... alternatives ...` no longer participates in ADR option state. ADR editing uses direct field paths such as `selected_option` and `alternatives[0].rejection_reason`. `tick` remains checklist-oriented and continues to apply to work item acceptance criteria.
+
+### Recovered Selected-Option Advantages
+
+- Eliminates accepted-alternative duplication
+- Keeps unresolved migrations renderable
+"""
+selected_option = "Explicit selected_option field, structured consequences, and migration metadata"
+
+[content.consequences]
+positive = [
+    "The chosen option becomes explicit and no longer needs to be duplicated as an accepted alternative.",
+    "ADR CLI and skills can use domain language directly instead of checklist-style status remapping.",
+    "Migration gains a principled place to record unresolved historical gaps without breaking rendering.",
+    "Negative outcomes and mitigations become attachable data rather than prose hidden inside a markdown block.",
+]
+neutral = [
+    "`decision` remains a prose field; the redesign adds structure around it rather than replacing it with a fully object-shaped decision document.",
+    "The migration pipeline becomes responsible for one more schema step.",
+]
+
+[[content.consequences.negative]]
+text = "This is a breaking schema change for ADR files, renderer output, and edit semantics."
+
+[[content.consequences.negative]]
+text = "Existing ADRs require a versioned migration and some will still need manual follow-up."
+
+[[content.consequences.negative]]
+text = "Bundled skills, reviewer guidance, and examples all need coordinated updates."
+
+[[content.consequences.negative]]
+text = "Requires a schema migration"
+
+[[content.alternatives]]
+text = "Keep alternative status as considered/accepted/rejected"
+pros = ["Minimal data-model churn"]
+cons = [
+    "Preserves confusing tick-to-status mapping",
+    "Continues duplicating the chosen option inside alternatives",
+]
+rejection_reason = "Keeps the same semantic collision between checklist state and decision state."
+
+[[content.alternatives]]
+text = "Use a fully object-shaped decision document instead of keeping decision prose"
+pros = ["Captures rationale in more machine-readable form"]
+cons = [
+    "Much larger writer, renderer, and documentation rewrite",
+    "Makes the redesign harder to adopt in one migration step",
+]
+rejection_reason = "The immediate problem is chosen-option and migration semantics, not replacing ADR narrative writing with a new decision DSL."

--- a/gov/adr/ADR-0037-canonical-edit-surface-for-nested-artifact-mutation.toml
+++ b/gov/adr/ADR-0037-canonical-edit-surface-for-nested-artifact-mutation.toml
@@ -3,7 +3,7 @@
 [govctl]
 id = "ADR-0037"
 title = "Canonical edit surface for nested artifact mutation"
-status = "proposed"
+status = "accepted"
 date = "2026-04-06"
 refs = [
     "ADR-0031",

--- a/gov/adr/ADR-0037-canonical-edit-surface-for-nested-artifact-mutation.toml
+++ b/gov/adr/ADR-0037-canonical-edit-surface-for-nested-artifact-mutation.toml
@@ -1,0 +1,144 @@
+#:schema ../schema/adr.schema.json
+
+[govctl]
+id = "ADR-0037"
+title = "Canonical edit surface for nested artifact mutation"
+status = "proposed"
+date = "2026-04-06"
+refs = [
+    "ADR-0031",
+    "ADR-0029",
+    "ADR-0017",
+    "ADR-0030",
+    "ADR-0007",
+    "RFC-0002",
+]
+
+[content]
+context = """
+`govctl` currently exposes artifact mutation through resource-first verbs such as `set`, `add`, `remove`, and `tick`, with path-based field addressing layered in via [[ADR-0029]] and strict parsing via [[ADR-0030]]. The semantic engine behind those commands is being unified per [[ADR-0031]].
+
+### Problem Statement
+
+The current CLI surface is still too shape-dependent for reliable agent use:
+
+1. Whether an operation uses `set`, `add`, `remove`, or `tick` depends on the target field's storage shape rather than the user's intent alone.
+2. Nested editing support is asymmetric. Some paths behave like true field paths, while others still rely on special-case command semantics.
+3. The CLI surface leaks artifact-specific implementation details, which increases agent failure rates and makes help text harder to generalize.
+4. Upcoming schema work, including richer ADR structures, will increase nested object/array combinations and amplify the problem if the edit surface remains verb-fragmented.
+
+### Constraints
+
+- Preserve resource-first command organization from [[RFC-0002]].
+- Preserve the SSOT-driven engine direction from [[ADR-0031]].
+- Keep a stable migration path for existing human users and scripts.
+- Make the canonical mutation interface regular enough that agents can synthesize commands from field paths without artifact-specific guessing.
+- Avoid introducing a new batch-specific input language unless single-operation ergonomics prove insufficient.
+
+### Options Considered
+
+- Option A: Keep `set/add/remove/tick` as the only mutation interface and continue expanding path support.
+- Option B: Introduce a canonical `edit` command with path-first operation flags, and keep existing verbs as compatibility sugar.
+- Option C: Replace existing verbs completely with a JSONPatch-like or DSL-heavy mutation language."""
+decision = """
+We will introduce a **canonical path-oriented edit surface** for governed artifact mutation:
+
+```bash
+govctl <resource> edit <ID> <path> --set <value>
+govctl <resource> edit <ID> <path> --add <value>
+govctl <resource> edit <ID> <path> --remove <pattern>
+govctl <resource> edit <ID> <path> --tick <status>
+```
+
+where:
+- `<path>` is a canonical fully qualified field path
+- exactly one mutation flag is provided per invocation
+- existing resource-first verbs (`set`, `add`, `remove`, `tick`) remain available as human-friendly sugar that compile into the same semantic edit plan
+
+### Canonical Interface Rules
+
+1. **Canonical path syntax is fully regular.** It MUST support nested object and array traversal for arbitrary depth, subject to SSOT validation.
+2. **Canonical paths prefer explicit field names.** Aliases remain compatibility-only, but documentation and agent examples prefer full canonical paths.
+3. **`edit` is the authoritative mutation interface.** New nested-field capabilities are specified first against `edit`; shorthand verbs are layered on top.
+4. **`tick` remains checklist-oriented.** It stays available only where the schema marks a status-bearing checklist item. It is not the canonical mechanism for arbitrary state mutation.
+5. **Path semantics are SSOT-defined.** The engine resolves paths and operation legality from generated schema/rules, not from artifact-specific handwritten branching.
+6. **This ADR standardizes single-operation editing only.** Multi-step orchestration remains the responsibility of the calling agent or shell layer for now.
+
+### Compatibility Strategy
+
+- Existing commands such as `govctl adr set ...`, `govctl adr add ...`, and `govctl work tick ...` remain supported during migration.
+- Help text, docs, and agent-facing examples will progressively move to the canonical `edit` form.
+- Compatibility verbs are treated as sugar over the same `EditPlan`, not as separate semantic implementations.
+- No new YAML/JSON patch language is introduced in this phase.
+
+### Examples
+
+```bash
+govctl adr edit ADR-0001 content.decision --set "We will ..."
+govctl adr edit ADR-0001 content.alternatives --add "Option A"
+govctl adr edit ADR-0001 content.alternatives[0].pros --add "Readable"
+govctl work edit WI-2026-04-06-001 content.acceptance_criteria[0] --tick done
+```
+
+This keeps resource-first organization intact while giving both humans and agents a single canonical grammar for mutation.
+
+### Recovered Selected-Option Advantages
+
+- Gives humans and agents one stable canonical mutation grammar
+- Lets existing verbs converge onto the same EditPlan without immediate breakage
+- Keeps the target path visually primary when reading or typing commands
+"""
+selected_option = "Add a canonical edit command with path-first operation flags, while preserving current verbs as sugar"
+
+[content.consequences]
+positive = [
+    "Agents can synthesize mutation commands from one regular shape instead of guessing between multiple top-level verbs.",
+    "The CLI surface aligns with the SSOT edit engine in [[ADR-0031]], reducing semantic drift.",
+    "Nested object/array edits can be documented once and reused across ADRs, RFCs, work items, and future artifact types.",
+    "Existing human-friendly verbs can remain as convenience entrypoints without blocking engine regularization.",
+    "The design does not add a separate patch document format, so the CLI remains focused on a single mutation grammar.",
+]
+neutral = [
+    "Resource-first organization is unchanged; only the mutation entrypoint is normalized.",
+    "This ADR does not itself redesign artifact schemas such as ADR consequences or alternatives. It defines the edit surface that future schema work can rely on.",
+    "If transactional batch mutation becomes necessary later, it can be addressed in a separate ADR with clearer evidence of need.",
+]
+
+[[content.consequences.negative]]
+text = "The CLI surface grows: users must understand that `edit` is canonical even if shorthand verbs still exist."
+
+[[content.consequences.negative]]
+text = "Help text, docs, examples, and tests require a coordinated rewrite."
+
+[[content.consequences.negative]]
+text = "Compatibility layering adds temporary maintenance cost until sugar commands fully delegate to the canonical path."
+
+[[content.consequences.negative]]
+text = "Multi-step batch edits are not made atomic by this ADR; callers still need orchestration logic when applying a series of mutations."
+
+[[content.consequences.negative]]
+text = "Requires dual-surface docs during migration"
+
+[[content.consequences.negative]]
+text = "Adds temporary compatibility maintenance cost"
+
+[[content.alternatives]]
+text = "Keep set/add/remove/tick as the only mutation interface and continue expanding path support"
+pros = [
+    "Lowest immediate CLI churn",
+    "Keeps current verb-first UX intact",
+]
+cons = [
+    "Agents still need field-shape-specific verb selection",
+    "Does not establish a single canonical mutation grammar",
+]
+rejection_reason = "It fixes capability gaps incrementally but leaves the core ergonomics problem unresolved for automation."
+
+[[content.alternatives]]
+text = "Replace current verbs with a JSONPatch-like or DSL-heavy universal mutation language"
+pros = ["Maximum expressiveness in one command family"]
+cons = [
+    "Higher cognitive load for humans",
+    "Too large a break from current resource-first mutation ergonomics",
+]
+rejection_reason = "Over-corrects toward a mini language and sacrifices discoverability for power we do not currently need."

--- a/gov/config.toml
+++ b/gov/config.toml
@@ -6,7 +6,7 @@ default_owner = "@govctl-org"
 docs_output = "docs"
 
 [schema]
-version = 2
+version = 3
 
 [source_scan]
 enabled = true

--- a/gov/rfc/RFC-0000/clauses/C-ADR-DEF.toml
+++ b/gov/rfc/RFC-0000/clauses/C-ADR-DEF.toml
@@ -13,8 +13,13 @@ An ADR (Architectural Decision Record) documents a significant design decision.
 
 Every ADR MUST be stored as a TOML file containing:
 - `[govctl]` section with: `id`, `title`, `status`, `date`, `refs`
-- optional `[govctl]` field: `superseded_by`
-- `[content]` section with: `context`, `decision`, `consequences`
+- optional `[govctl]` fields: `superseded_by`, `migration`
+- `[content]` section with: `context`, `decision`, `consequences`, `alternatives`
+- `content.selected_option` when the ADR status is `accepted` or `superseded`, unless the artifact is explicitly marked as a migration record still requiring review
+
+`content.consequences` MUST be structured as positive, negative, and neutral outcomes. Negative consequences MAY include mitigations.
+
+`content.alternatives` records non-selected options. Each alternative MUST include `text` and MAY include pros, cons, and a rejection reason.
 
 Format evolution is tracked by the project-level `[schema] version` in `gov/config.toml`, not per-artifact fields.
 

--- a/gov/rfc/RFC-0000/rfc.toml
+++ b/gov/rfc/RFC-0000/rfc.toml
@@ -3,13 +3,13 @@
 [govctl]
 id = "RFC-0000"
 title = "govctl Governance Framework"
-version = "1.1.1"
+version = "1.1.2"
 status = "normative"
 phase = "stable"
 owners = ["@govctl-org"]
 created = "2026-01-17"
-updated = "2026-03-22"
-signature = "d05eb40d0eb61a843eb2b0279c290f3c9d5a16b17d97f88790b2f6466510190b"
+updated = "2026-04-06"
+signature = "972811229593a7f435a1ecf9cb0d1427adbbd0aef423771f71d0696dfc2b53ae"
 
 [[sections]]
 title = "Summary"
@@ -43,6 +43,11 @@ clauses = ["clauses/C-RELEASE-DEF.toml"]
 [[sections]]
 title = "Verification Guard Specification"
 clauses = ["clauses/C-GUARD-DEF.toml"]
+
+[[changelog]]
+version = "1.1.2"
+date = "2026-04-06"
+notes = "Clarify ADR v3 structure and selected option requirements"
 
 [[changelog]]
 version = "1.1.1"

--- a/gov/schema/SCHEMA.md
+++ b/gov/schema/SCHEMA.md
@@ -218,21 +218,26 @@ decision = """
 What was decided and why.
 """
 
-consequences = """
-Impact of the decision.
-"""
+selected_option = "Option B"
+
+[content.consequences]
+positive = ["Improves throughput"]
+neutral = ["Adds one more config knob"]
+
+[[content.consequences.negative]]
+text = "Requires a new dependency"
+mitigations = ["Document installation in onboarding guide"]
 
 [[content.alternatives]]
 text = "Option A"
-status = "rejected"
 rejection_reason = "Does not meet performance requirements"
 cons = ["Slow", "Hard to maintain"]
 
 [[content.alternatives]]
-text = "Option B"
-status = "accepted"
-pros = ["Fast", "Simple"]
-cons = ["Requires new dependency"]
+text = "Option C"
+pros = ["Simple"]
+cons = ["Insufficient scalability"]
+rejection_reason = "Does not support projected load"
 ```
 
 | Field                                     | Required | Type   | Description                                            |
@@ -245,13 +250,18 @@ cons = ["Requires new dependency"]
 | `govctl.refs`                             | no       | array  | Cross-references                                       |
 | `content.context`                         | yes      | string | Problem description                                    |
 | `content.decision`                        | yes      | string | Decision and rationale                                 |
-| `content.consequences`                    | yes      | string | Impact analysis                                        |
-| `content.alternatives`                    | no       | array  | Options considered                                     |
+| `content.selected_option`                 | no       | string | Chosen option once the decision is made                |
+| `content.consequences`                    | yes      | object | Structured impact analysis                             |
+| `content.consequences.positive[]`         | no       | array  | Positive outcomes                                      |
+| `content.consequences.negative[]`         | no       | array  | Negative outcomes with mitigations                     |
+| `content.consequences.negative[].text`    | yes      | string | Negative outcome text                                  |
+| `content.consequences.negative[].mitigations[]` | no | array | Mitigations for a negative outcome                     |
+| `content.consequences.neutral[]`          | no       | array  | Neutral side effects                                   |
+| `content.alternatives`                    | no       | array  | Non-selected options that were considered              |
 | `content.alternatives[].text`             | yes      | string | Option description                                     |
-| `content.alternatives[].status`           | no       | enum   | `considered` \| `rejected` \| `accepted`               |
 | `content.alternatives[].pros`             | no       | array  | Advantages (per [[ADR-0027]])                          |
 | `content.alternatives[].cons`             | no       | array  | Disadvantages (per [[ADR-0027]])                       |
-| `content.alternatives[].rejection_reason` | no       | string | Why rejected (per [[ADR-0027]])                        |
+| `content.alternatives[].rejection_reason` | no       | string | Why this option was not selected                       |
 
 ### Work Item (TOML)
 

--- a/gov/schema/SCHEMA.md
+++ b/gov/schema/SCHEMA.md
@@ -240,28 +240,28 @@ cons = ["Insufficient scalability"]
 rejection_reason = "Does not support projected load"
 ```
 
-| Field                                     | Required | Type   | Description                                            |
-| ----------------------------------------- | -------- | ------ | ------------------------------------------------------ |
-| `govctl.id`                               | yes      | string | Unique identifier `ADR-NNNN`                           |
-| `govctl.title`                            | yes      | string | Decision title                                         |
-| `govctl.status`                           | yes      | enum   | `proposed` \| `accepted` \| `rejected` \| `superseded` |
-| `govctl.date`                             | yes      | date   | Decision date                                          |
-| `govctl.superseded_by`                    | no       | string | ADR ID that replaces this                              |
-| `govctl.refs`                             | no       | array  | Cross-references                                       |
-| `content.context`                         | yes      | string | Problem description                                    |
-| `content.decision`                        | yes      | string | Decision and rationale                                 |
-| `content.selected_option`                 | no       | string | Chosen option once the decision is made                |
-| `content.consequences`                    | yes      | object | Structured impact analysis                             |
-| `content.consequences.positive[]`         | no       | array  | Positive outcomes                                      |
-| `content.consequences.negative[]`         | no       | array  | Negative outcomes with mitigations                     |
-| `content.consequences.negative[].text`    | yes      | string | Negative outcome text                                  |
-| `content.consequences.negative[].mitigations[]` | no | array | Mitigations for a negative outcome                     |
-| `content.consequences.neutral[]`          | no       | array  | Neutral side effects                                   |
-| `content.alternatives`                    | no       | array  | Non-selected options that were considered              |
-| `content.alternatives[].text`             | yes      | string | Option description                                     |
-| `content.alternatives[].pros`             | no       | array  | Advantages (per [[ADR-0027]])                          |
-| `content.alternatives[].cons`             | no       | array  | Disadvantages (per [[ADR-0027]])                       |
-| `content.alternatives[].rejection_reason` | no       | string | Why this option was not selected                       |
+| Field                                           | Required | Type   | Description                                            |
+| ----------------------------------------------- | -------- | ------ | ------------------------------------------------------ |
+| `govctl.id`                                     | yes      | string | Unique identifier `ADR-NNNN`                           |
+| `govctl.title`                                  | yes      | string | Decision title                                         |
+| `govctl.status`                                 | yes      | enum   | `proposed` \| `accepted` \| `rejected` \| `superseded` |
+| `govctl.date`                                   | yes      | date   | Decision date                                          |
+| `govctl.superseded_by`                          | no       | string | ADR ID that replaces this                              |
+| `govctl.refs`                                   | no       | array  | Cross-references                                       |
+| `content.context`                               | yes      | string | Problem description                                    |
+| `content.decision`                              | yes      | string | Decision and rationale                                 |
+| `content.selected_option`                       | no       | string | Chosen option once the decision is made                |
+| `content.consequences`                          | yes      | object | Structured impact analysis                             |
+| `content.consequences.positive[]`               | no       | array  | Positive outcomes                                      |
+| `content.consequences.negative[]`               | no       | array  | Negative outcomes with mitigations                     |
+| `content.consequences.negative[].text`          | yes      | string | Negative outcome text                                  |
+| `content.consequences.negative[].mitigations[]` | no       | array  | Mitigations for a negative outcome                     |
+| `content.consequences.neutral[]`                | no       | array  | Neutral side effects                                   |
+| `content.alternatives`                          | no       | array  | Non-selected options that were considered              |
+| `content.alternatives[].text`                   | yes      | string | Option description                                     |
+| `content.alternatives[].pros`                   | no       | array  | Advantages (per [[ADR-0027]])                          |
+| `content.alternatives[].cons`                   | no       | array  | Disadvantages (per [[ADR-0027]])                       |
+| `content.alternatives[].rejection_reason`       | no       | string | Why this option was not selected                       |
 
 ### Work Item (TOML)
 

--- a/gov/schema/adr.schema.json
+++ b/gov/schema/adr.schema.json
@@ -145,5 +145,49 @@
       "additionalProperties": false
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "govctl": {
+            "properties": {
+              "status": {
+                "enum": ["accepted", "superseded"]
+              }
+            },
+            "required": ["status"]
+          }
+        }
+      },
+      "then": {
+        "anyOf": [
+          {
+            "properties": {
+              "content": {
+                "required": ["selected_option"]
+              }
+            }
+          },
+          {
+            "properties": {
+              "govctl": {
+                "properties": {
+                  "migration": {
+                    "properties": {
+                      "state": {
+                        "const": "needs_review"
+                      }
+                    },
+                    "required": ["state"]
+                  }
+                },
+                "required": ["migration"]
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/gov/schema/adr.schema.json
+++ b/gov/schema/adr.schema.json
@@ -29,6 +29,30 @@
           "type": "string",
           "pattern": "^ADR-\\d{4}$"
         },
+        "migration": {
+          "type": "object",
+          "required": ["state"],
+          "properties": {
+            "state": {
+              "type": "string",
+              "enum": ["migrated", "needs_review", "verified"]
+            },
+            "warnings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["code", "message"],
+                "properties": {
+                  "code": { "type": "string", "minLength": 1 },
+                  "message": { "type": "string", "minLength": 1 },
+                  "path": { "type": "string", "minLength": 1 }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
         "refs": {
           "type": "array",
           "items": {
@@ -52,8 +76,41 @@
         "decision": {
           "type": "string"
         },
+        "selected_option": {
+          "type": "string",
+          "minLength": 1
+        },
         "consequences": {
-          "type": "string"
+          "type": "object",
+          "properties": {
+            "positive": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "negative": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["text"],
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "mitigations": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "neutral": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "additionalProperties": false
         },
         "alternatives": {
           "type": "array",
@@ -64,10 +121,6 @@
               "text": {
                 "type": "string",
                 "minLength": 1
-              },
-              "status": {
-                "type": "string",
-                "enum": ["considered", "rejected", "accepted"]
               },
               "pros": {
                 "type": "array",

--- a/gov/schema/edit-ops.json
+++ b/gov/schema/edit-ops.json
@@ -346,7 +346,7 @@
       "artifact": "clause",
       "name": "text",
       "get": { "path": ["text"], "render": "scalar" },
-      "set": null,
+      "set": { "path": ["text"], "mode": { "type": "string" } },
       "list_path": null
     },
     {

--- a/gov/schema/edit-ops.json
+++ b/gov/schema/edit-ops.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "aliases": [
     { "alias": "ac", "canonical": "acceptance_criteria" },
     { "alias": "alt", "canonical": "alternatives" },
@@ -14,6 +14,7 @@
       "allowed_fields": [
         "context",
         "decision",
+        "selected_option",
         "consequences",
         "description",
         "alternatives",
@@ -31,6 +32,7 @@
         "date",
         "refs",
         "superseded_by",
+        "migration",
         "started",
         "completed",
         "created",
@@ -183,7 +185,7 @@
     },
     {
       "artifact": "adr",
-      "name": "consequences",
+      "name": "selected_option",
       "kind": "scalar",
       "verbs": ["get", "set"]
     },
@@ -191,7 +193,7 @@
       "artifact": "adr",
       "name": "alternatives",
       "kind": "list",
-      "verbs": ["get", "add", "remove", "tick"]
+      "verbs": ["get", "add", "remove"]
     },
 
     {
@@ -449,10 +451,10 @@
     },
     {
       "artifact": "adr",
-      "name": "consequences",
-      "get": { "path": ["content", "consequences"], "render": "scalar" },
+      "name": "selected_option",
+      "get": { "path": ["content", "selected_option"], "render": "scalar" },
       "set": {
-        "path": ["content", "consequences"],
+        "path": ["content", "selected_option"],
         "mode": { "type": "string" }
       },
       "list_path": null
@@ -462,8 +464,7 @@
       "name": "alternatives",
       "get": {
         "path": ["content", "alternatives"],
-        "render": "status_lines",
-        "status_key": "status",
+        "render": "text_lines",
         "text_key": "text"
       },
       "set": null,
@@ -579,63 +580,318 @@
       "artifact": "adr",
       "root": "alternatives",
       "content_path": ["content", "alternatives"],
-      "text_key": "text",
-      "requires_index": true,
-      "max_depth": 2,
-      "fields": [
-        { "name": "text", "kind": "scalar", "verbs": ["get", "set"] },
-        { "name": "status", "kind": "scalar", "verbs": ["get"] },
-        {
-          "name": "rejection_reason",
-          "kind": "scalar",
-          "verbs": ["get", "set"]
-        },
-        {
-          "name": "pros",
-          "kind": "list",
-          "verbs": ["get", "set", "add", "remove"]
-        },
-        {
-          "name": "cons",
-          "kind": "list",
-          "verbs": ["get", "set", "add", "remove"]
+      "node": {
+        "kind": "list",
+        "verbs": ["get", "add", "remove"],
+        "text_key": "text",
+        "item": {
+          "kind": "object",
+          "verbs": ["get"],
+          "fields": [
+            {
+              "name": "text",
+              "node": {
+                "kind": "scalar",
+                "verbs": ["get", "set"],
+                "set_mode": { "type": "string" }
+              }
+            },
+            {
+              "name": "rejection_reason",
+              "node": {
+                "kind": "scalar",
+                "verbs": ["get", "set"],
+                "set_mode": { "type": "string" }
+              }
+            },
+            {
+              "name": "pros",
+              "node": {
+                "kind": "list",
+                "verbs": ["get", "set", "add", "remove"],
+                "text_key": null,
+                "item": {
+                  "kind": "scalar",
+                  "verbs": ["get", "set"],
+                  "set_mode": { "type": "string" }
+                }
+              }
+            },
+            {
+              "name": "cons",
+              "node": {
+                "kind": "list",
+                "verbs": ["get", "set", "add", "remove"],
+                "text_key": null,
+                "item": {
+                  "kind": "scalar",
+                  "verbs": ["get", "set"],
+                  "set_mode": { "type": "string" }
+                }
+              }
+            }
+          ]
         }
-      ]
+      }
+    },
+    {
+      "artifact": "adr",
+      "root": "consequences",
+      "content_path": ["content", "consequences"],
+      "node": {
+        "kind": "object",
+        "verbs": ["get"],
+        "fields": [
+          {
+            "name": "positive",
+            "node": {
+              "kind": "list",
+              "verbs": ["get", "add", "remove"],
+              "text_key": null,
+              "item": {
+                "kind": "scalar",
+                "verbs": ["get", "set"],
+                "set_mode": { "type": "string" }
+              }
+            }
+          },
+          {
+            "name": "negative",
+            "node": {
+              "kind": "list",
+              "verbs": ["get", "add", "remove"],
+              "text_key": "text",
+              "item": {
+                "kind": "object",
+                "verbs": ["get"],
+                "fields": [
+                  {
+                    "name": "text",
+                    "node": {
+                      "kind": "scalar",
+                      "verbs": ["get", "set"],
+                      "set_mode": { "type": "string" }
+                    }
+                  },
+                  {
+                    "name": "mitigations",
+                    "node": {
+                      "kind": "list",
+                      "verbs": ["get", "add", "remove"],
+                      "text_key": null,
+                      "item": {
+                        "kind": "scalar",
+                        "verbs": ["get", "set"],
+                        "set_mode": { "type": "string" }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "neutral",
+            "node": {
+              "kind": "list",
+              "verbs": ["get", "add", "remove"],
+              "text_key": null,
+              "item": {
+                "kind": "scalar",
+                "verbs": ["get", "set"],
+                "set_mode": { "type": "string" }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "artifact": "adr",
+      "root": "migration",
+      "content_path": ["govctl", "migration"],
+      "node": {
+        "kind": "object",
+        "verbs": ["get"],
+        "fields": [
+          {
+            "name": "state",
+            "node": {
+              "kind": "scalar",
+              "verbs": ["get", "set"],
+              "set_mode": { "type": "string" }
+            }
+          },
+          {
+            "name": "warnings",
+            "node": {
+              "kind": "list",
+              "verbs": ["get", "remove"],
+              "text_key": "message",
+              "item": {
+                "kind": "object",
+                "verbs": ["get"],
+                "fields": [
+                  {
+                    "name": "code",
+                    "node": {
+                      "kind": "scalar",
+                      "verbs": ["get", "set"],
+                      "set_mode": { "type": "string" }
+                    }
+                  },
+                  {
+                    "name": "message",
+                    "node": {
+                      "kind": "scalar",
+                      "verbs": ["get", "set"],
+                      "set_mode": { "type": "string" }
+                    }
+                  },
+                  {
+                    "name": "path",
+                    "node": {
+                      "kind": "scalar",
+                      "verbs": ["get", "set"],
+                      "set_mode": { "type": "string" }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
     },
     {
       "artifact": "work",
       "root": "journal",
       "content_path": ["content", "journal"],
-      "text_key": "content",
-      "requires_index": true,
-      "max_depth": 2,
-      "fields": [
-        { "name": "content", "kind": "scalar", "verbs": ["get", "set"] },
-        { "name": "date", "kind": "scalar", "verbs": ["get", "set"] },
-        { "name": "scope", "kind": "scalar", "verbs": ["get", "set"] }
-      ]
+      "node": {
+        "kind": "list",
+        "verbs": ["get", "add", "remove"],
+        "text_key": "content",
+        "item": {
+          "kind": "object",
+          "verbs": ["get"],
+          "fields": [
+            {
+              "name": "content",
+              "node": {
+                "kind": "scalar",
+                "verbs": ["get", "set"],
+                "set_mode": { "type": "string" }
+              }
+            },
+            {
+              "name": "date",
+              "node": {
+                "kind": "scalar",
+                "verbs": ["get", "set"],
+                "set_mode": { "type": "string" }
+              }
+            },
+            {
+              "name": "scope",
+              "node": {
+                "kind": "scalar",
+                "verbs": ["get", "set"],
+                "set_mode": { "type": "string" }
+              }
+            }
+          ]
+        }
+      }
     },
     {
       "artifact": "work",
       "root": "acceptance_criteria",
       "content_path": ["content", "acceptance_criteria"],
-      "text_key": "text",
-      "requires_index": true,
-      "max_depth": 2,
-      "fields": [
-        { "name": "text", "kind": "scalar", "verbs": ["get", "set"] },
-        { "name": "status", "kind": "scalar", "verbs": ["get"] },
-        { "name": "category", "kind": "scalar", "verbs": ["get", "set"] }
-      ]
+      "node": {
+        "kind": "list",
+        "verbs": ["get", "add", "remove", "tick"],
+        "text_key": "text",
+        "item": {
+          "kind": "object",
+          "verbs": ["get"],
+          "fields": [
+            {
+              "name": "text",
+              "node": {
+                "kind": "scalar",
+                "verbs": ["get", "set"],
+                "set_mode": { "type": "string" }
+              }
+            },
+            {
+              "name": "status",
+              "node": {
+                "kind": "scalar",
+                "verbs": ["get"],
+                "set_mode": null
+              }
+            },
+            {
+              "name": "category",
+              "node": {
+                "kind": "scalar",
+                "verbs": ["get", "set"],
+                "set_mode": { "type": "string" }
+              }
+            }
+          ]
+        }
+      }
     },
     {
       "artifact": "work",
       "root": "notes",
       "content_path": ["content", "notes"],
-      "text_key": null,
-      "requires_index": true,
-      "max_depth": 1,
-      "fields": []
+      "node": {
+        "kind": "list",
+        "verbs": ["get", "add", "remove"],
+        "text_key": null,
+        "item": {
+          "kind": "scalar",
+          "verbs": ["get", "set"],
+          "set_mode": { "type": "string" }
+        }
+      }
+    },
+    {
+      "artifact": "guard",
+      "root": "check",
+      "content_path": ["check"],
+      "node": {
+        "kind": "object",
+        "verbs": ["get"],
+        "fields": [
+          {
+            "name": "command",
+            "node": {
+              "kind": "scalar",
+              "verbs": ["get", "set"],
+              "set_mode": { "type": "string" }
+            }
+          },
+          {
+            "name": "timeout_secs",
+            "node": {
+              "kind": "scalar",
+              "verbs": ["get", "set"],
+              "set_mode": { "type": "integer" }
+            }
+          },
+          {
+            "name": "pattern",
+            "node": {
+              "kind": "scalar",
+              "verbs": ["get", "set"],
+              "set_mode": { "type": "string" }
+            }
+          }
+        ]
+      }
     }
   ],
   "validation_rules": [

--- a/gov/schema/edit-ops.schema.json
+++ b/gov/schema/edit-ops.schema.json
@@ -85,19 +85,11 @@
     },
     "nestedRootRule": {
       "type": "object",
-      "required": [
-        "artifact",
-        "root",
-        "content_path",
-        "text_key",
-        "requires_index",
-        "max_depth",
-        "fields"
-      ],
+      "required": ["artifact", "root", "content_path", "node"],
       "properties": {
         "artifact": {
           "type": "string",
-          "enum": ["adr", "work"]
+          "enum": ["adr", "work", "guard"]
         },
         "root": {
           "type": "string",
@@ -111,48 +103,90 @@
           },
           "minItems": 1
         },
-        "text_key": {
-          "oneOf": [
-            { "type": "string", "pattern": "^[a-z_][a-z0-9_]*$" },
-            { "type": "null" }
-          ]
-        },
-        "requires_index": {
-          "type": "boolean"
-        },
-        "max_depth": {
-          "type": "integer",
-          "minimum": 1
-        },
-        "fields": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/nestedFieldRule" }
-        }
+        "node": { "$ref": "#/definitions/nestedNodeRule" }
       },
       "additionalProperties": false
     },
     "nestedFieldRule": {
       "type": "object",
-      "required": ["name", "kind", "verbs"],
+      "required": ["name", "node"],
       "properties": {
         "name": {
           "type": "string",
           "pattern": "^[a-z_][a-z0-9_]*$"
         },
-        "kind": {
-          "type": "string",
-          "enum": ["scalar", "list"]
-        },
-        "verbs": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": ["get", "set", "add", "remove", "tick"]
-          },
-          "minItems": 1
-        }
+        "node": { "$ref": "#/definitions/nestedNodeRule" }
       },
       "additionalProperties": false
+    },
+    "nestedNodeRule": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "verbs"],
+          "properties": {
+            "kind": { "type": "string", "enum": ["scalar"] },
+            "verbs": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["get", "set", "add", "remove", "tick"]
+              },
+              "minItems": 1
+            },
+            "set_mode": {
+              "oneOf": [
+                { "$ref": "#/definitions/runtimeSetMode" },
+                { "type": "null" }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["kind", "verbs", "fields"],
+          "properties": {
+            "kind": { "type": "string", "enum": ["object"] },
+            "verbs": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["get", "set", "add", "remove", "tick"]
+              },
+              "minItems": 1
+            },
+            "fields": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/nestedFieldRule" }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["kind", "verbs", "item"],
+          "properties": {
+            "kind": { "type": "string", "enum": ["list"] },
+            "verbs": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["get", "set", "add", "remove", "tick"]
+              },
+              "minItems": 1
+            },
+            "text_key": {
+              "oneOf": [
+                { "type": "string", "pattern": "^[a-z_][a-z0-9_]*$" },
+                { "type": "null" }
+              ]
+            },
+            "item": { "$ref": "#/definitions/nestedNodeRule" }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "simpleFieldRule": {
       "type": "object",
@@ -235,7 +269,13 @@
         },
         "render": {
           "type": "string",
-          "enum": ["scalar", "csv_strings", "line_strings", "status_lines"]
+          "enum": [
+            "scalar",
+            "csv_strings",
+            "line_strings",
+            "text_lines",
+            "status_lines"
+          ]
         },
         "status_key": {
           "type": "string",

--- a/gov/work/2026-04-06-add-regression-test-for-concurrent-work-item-tick-persistence.toml
+++ b/gov/work/2026-04-06-add-regression-test-for-concurrent-work-item-tick-persistence.toml
@@ -1,0 +1,27 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-04-06-007"
+title = "Add regression test for concurrent work-item tick persistence"
+status = "done"
+created = "2026-04-06"
+started = "2026-04-06"
+completed = "2026-04-06"
+
+[content]
+description = "Scope: add a regression test that runs multiple independent work-item tick commands concurrently and verifies all acceptance criteria persist. Why: recent observed output showed three tick commands each reported success while only part of the final artifact state was updated."
+
+[[content.journal]]
+date = "2026-04-06"
+scope = "implementation"
+content = "Identified the root cause of concurrent tick loss: canonical edit commands were missing from CanonicalCommand::is_write_command(), so work edit/adr edit/rfc edit/guard edit and legacy clause text edit skipped the gov-root lock entirely. Added a failing concurrent work-item tick integration test, fixed the write-command classification, and confirmed cargo test -q --test test_lock plus cargo run --quiet -- check pass."
+
+[[content.acceptance_criteria]]
+text = "concurrent tick regression is covered by an integration test against real govctl processes"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "all canonical edit write variants are classified as write commands and protected by the gov-root lock"
+status = "done"
+category = "chore"

--- a/gov/work/2026-04-06-fix-clippy-warning-in-command-router.toml
+++ b/gov/work/2026-04-06-fix-clippy-warning-in-command-router.toml
@@ -1,0 +1,27 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-04-06-003"
+title = "Fix clippy warning in command router"
+status = "done"
+created = "2026-04-06"
+started = "2026-04-06"
+completed = "2026-04-06"
+
+[content]
+description = "Scope: eliminate clippy -D warnings in canonical command routing without changing command behavior. Why: keep the codebase warning-free under strict CI linting."
+
+[[content.journal]]
+date = "2026-04-06"
+scope = "command-router"
+content = "Refactored clause canonical edit routing to reuse EditActionArgs parsing; cargo clippy --all-targets --all-features -- -D warnings, cargo test -q, and govctl check all pass."
+
+[[content.acceptance_criteria]]
+text = "clause canonical edit routing preserves existing behavior while removing the duplicate argument parser"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "cargo clippy --all-targets --all-features -- -D warnings passes"
+status = "done"
+category = "fixed"

--- a/gov/work/2026-04-06-harden-adr-migration-markdown-consequences-parsing.toml
+++ b/gov/work/2026-04-06-harden-adr-migration-markdown-consequences-parsing.toml
@@ -1,0 +1,36 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-04-06-006"
+title = "Harden ADR migration markdown consequences parsing"
+status = "done"
+created = "2026-04-06"
+started = "2026-04-06"
+completed = "2026-04-06"
+refs = [
+    "ADR-0036",
+    "ADR-0032",
+]
+
+[content]
+description = "Scope: make ADR v2->v3 migration parse legacy markdown consequences as semantic blocks instead of line-by-line fragments, and repair already-migrated ADRs that were split incorrectly. Why: migration prose and fenced code blocks currently get expanded into many separate negative consequences, which distorts the ADR model and rendered output."
+
+[[content.journal]]
+date = "2026-04-06"
+scope = "implementation"
+content = "Replaced the line-oriented legacy consequence splitter with pulldown-cmark-based block parsing, added regression coverage for markdown migration blocks and mitigation attachment, normalized ADR-0018 and ADR-0021, and re-rendered the affected ADR docs; cargo test -q and cargo run --quiet -- check pass."
+
+[[content.acceptance_criteria]]
+text = "regression tests cover prose-plus-code-block migration and mitigation attachment semantics"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "currently affected migrated ADRs are normalized and cargo run --quiet -- check passes"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "legacy ADR markdown consequence blocks migrate into single semantic entries instead of per-line fragments"
+status = "done"
+category = "fixed"

--- a/gov/work/2026-04-06-implement-canonical-edit-surface-for-nested-artifact-mutation.toml
+++ b/gov/work/2026-04-06-implement-canonical-edit-surface-for-nested-artifact-mutation.toml
@@ -1,0 +1,51 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-04-06-002"
+title = "Implement canonical edit surface for nested artifact mutation"
+status = "done"
+created = "2026-04-06"
+started = "2026-04-06"
+completed = "2026-04-06"
+refs = [
+    "ADR-0031",
+    "ADR-0037",
+]
+
+[content]
+description = "Implement the canonical path-first edit CLI from ADR-0037 so nested object and array mutation uses one regular single-operation surface, with legacy verbs delegating to the same semantic engine."
+
+[[content.journal]]
+date = "2026-04-06"
+scope = "edit-surface"
+content = "Implemented canonical edit entrypoints for RFC/ADR/work/guard, routed them through shared edit planning, and enabled indexed checklist tick paths plus deep legacy-prefix collapse; cargo test passes."
+
+[[content.journal]]
+date = "2026-04-06"
+scope = "runtime"
+content = "Generalized nested edit rules and runtime from array-root-only handling to recursive object/list traversal, including object-root support for guard.check paths. Added canonical edit regression coverage and reran cargo test plus govctl check successfully."
+
+[[content.acceptance_criteria]]
+text = "Route existing set/add/remove/tick verbs through the same canonical edit planning path"
+status = "done"
+category = "added"
+
+[[content.acceptance_criteria]]
+text = "Generalize nested edit resolution so object and array paths work at arbitrary supported depth"
+status = "done"
+category = "added"
+
+[[content.acceptance_criteria]]
+text = "update CLI help and tests for the canonical edit surface"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "govctl check passes after the edit-surface redesign"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "Introduce canonical <resource> edit <ID> <path> --set/--add/--remove/--tick CLI entrypoints"
+status = "done"
+category = "added"

--- a/gov/work/2026-04-06-increase-coverage-for-canonical-edit-and-adr-migration.toml
+++ b/gov/work/2026-04-06-increase-coverage-for-canonical-edit-and-adr-migration.toml
@@ -1,0 +1,32 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-04-06-005"
+title = "Increase coverage for canonical edit and ADR migration"
+status = "done"
+created = "2026-04-06"
+started = "2026-04-06"
+completed = "2026-04-06"
+
+[content]
+description = "Scope: add regression tests for canonical edit, ADR v3 migration, and structured diagnostics so the adr-refactor patch coverage clears Codecov. Why: the branch landed large changes in edit/runtime/migrate/diagnostic paths and currently leaves significant new logic uncovered."
+
+[[content.journal]]
+date = "2026-04-06"
+scope = "coverage"
+content = "Added regression tests for ADR v3 migration branches, canonical edit/runtime/router paths, guard diagnostics, render missing-item behavior, lock failures before init, and TUI project-load diagnostic selection; cargo test -q, cargo run --quiet -- check, and cargo llvm-cov --summary-only all pass."
+
+[[content.acceptance_criteria]]
+text = "add regression coverage for canonical edit/runtime/router branches introduced by ADR-0037"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "add regression coverage for ADR v3 migration edge cases and structured consequence parsing"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "cargo test -q and cargo run --quiet -- check pass after the coverage-focused regression additions"
+status = "done"
+category = "fixed"

--- a/gov/work/2026-04-06-redesign-adr-model-and-migrate-alternatives-semantics.toml
+++ b/gov/work/2026-04-06-redesign-adr-model-and-migrate-alternatives-semantics.toml
@@ -1,0 +1,47 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-04-06-001"
+title = "Redesign ADR model and migrate alternatives semantics"
+status = "done"
+created = "2026-04-06"
+started = "2026-04-06"
+completed = "2026-04-06"
+refs = [
+    "ADR-0032",
+    "ADR-0027",
+    "ADR-0036",
+]
+
+[content]
+description = "Redesign ADR data model so chosen options live in the decision, alternatives only capture non-selected options, and migration produces renderable artifacts with warnings for unresolved history."
+
+[[content.journal]]
+date = "2026-04-06"
+scope = "governance"
+content = "Paused ADR redesign/migration line to implement ADR-0037 edit-surface work first; split into a dedicated work item to keep CLI-surface changes separately auditable."
+
+[[content.journal]]
+date = "2026-04-06"
+scope = "migration"
+content = "Implemented ADR v3 with selected_option, structured consequences, and migration metadata; updated render/check/edit semantics; added a v2->v3 migrate step; migrated the repository ADRs to schema version 3; cargo test and govctl check both pass, with expected migration-review warnings on historical ADRs that need manual cleanup."
+
+[[content.acceptance_criteria]]
+text = "Define and accept an ADR for the redesigned ADR model and migration behavior"
+status = "done"
+category = "added"
+
+[[content.acceptance_criteria]]
+text = "govctl check passes after the redesign and migration"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "Add a versioned migration step that rewrites legacy ADRs into the new renderable model"
+status = "done"
+category = "added"
+
+[[content.acceptance_criteria]]
+text = "Implement the new ADR schema, render path, and check warnings for migration-review states"
+status = "done"
+category = "added"

--- a/gov/work/2026-04-06-replace-anyhow-temporary-errors-with-coded-diagnostics.toml
+++ b/gov/work/2026-04-06-replace-anyhow-temporary-errors-with-coded-diagnostics.toml
@@ -1,0 +1,32 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-04-06-004"
+title = "Replace anyhow temporary errors with coded diagnostics"
+status = "done"
+created = "2026-04-06"
+started = "2026-04-06"
+completed = "2026-04-06"
+
+[content]
+description = "Scope: replace remaining user-facing anyhow temporary errors with structured diagnostics and stable codes, starting from direct CLI command paths. Why: the project already requires strict machine-parseable diagnostics, but several commands still emit uncoded temporary errors or stringify diagnostics into anyhow wrappers."
+
+[[content.journal]]
+date = "2026-04-06"
+scope = "diagnostics"
+content = "Replaced user-facing temporary anyhow errors in guard, render, lifecycle, edit adapter/runtime, lock, main, and TUI paths with structured diagnostics; normalized not-found context to search scope; cargo test -q, cargo test -q --test test_edit, cargo test -q --test test_changelog, cargo clippy --all-targets --all-features -- -D warnings, and govctl check all pass."
+
+[[content.acceptance_criteria]]
+text = "diagnostics for the converted paths use explicit DiagnosticCode values and preserve stable formatting for automation"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "cargo test -q and cargo run --quiet -- check pass after the diagnostic cleanup"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "direct CLI command paths no longer emit uncoded anyhow temporary errors for expected user-facing failures"
+status = "done"
+category = "fixed"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,41 @@
 //! CLI argument definitions for govctl.
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 use crate::model::{ChangelogCategory, ClauseKind, RfcPhase, WorkItemStatus};
+
+#[derive(Args, Clone, Debug)]
+#[group(id = "edit_action", required = true, multiple = false)]
+pub(crate) struct EditActionArgs {
+    /// Set a scalar value (omit VALUE only when using --stdin)
+    #[arg(long, group = "edit_action", num_args = 0..=1, default_missing_value = "")]
+    pub(crate) set: Option<String>,
+    /// Append a value to a list (omit VALUE only when using --stdin)
+    #[arg(long, group = "edit_action", num_args = 0..=1, default_missing_value = "")]
+    pub(crate) add: Option<String>,
+    /// Remove a matching value, or omit PATTERN when removing an indexed path
+    #[arg(long, group = "edit_action", num_args = 0..=1, default_missing_value = "")]
+    pub(crate) remove: Option<String>,
+    /// Update checklist-style item status
+    #[arg(long, group = "edit_action")]
+    pub(crate) tick: Option<TickStatus>,
+    /// Read set/add value from stdin
+    #[arg(long)]
+    pub(crate) stdin: bool,
+    /// Match by index for remove/tick
+    #[arg(long, allow_hyphen_values = true)]
+    pub(crate) at: Option<i32>,
+    /// Exact match for remove/tick
+    #[arg(long)]
+    pub(crate) exact: bool,
+    /// Regex match for remove/tick
+    #[arg(long)]
+    pub(crate) regex: bool,
+    /// Remove all matches
+    #[arg(long)]
+    pub(crate) all: bool,
+}
 
 #[derive(Parser)]
 #[command(name = "govctl")]
@@ -299,6 +331,21 @@ EXAMPLES:
         id: String,
         /// Field name (omit to show all)
         field: Option<String>,
+    },
+    /// Canonical path-first edit entrypoint
+    #[command(after_help = "\
+EXAMPLES:
+    govctl rfc edit RFC-0001 version --set 1.2.0
+    govctl rfc edit RFC-0001 refs --add RFC-0002
+    govctl rfc edit RFC-0001 refs[0] --remove
+")]
+    Edit {
+        /// RFC ID
+        id: String,
+        /// Canonical field path
+        path: String,
+        #[command(flatten)]
+        action: EditActionArgs,
     },
     /// Set RFC field value
     #[command(after_help = "\
@@ -636,17 +683,23 @@ VALID FIELDS:
   String fields:
     - context: Background and problem description
     - decision: The decision made and rationale
-    - consequences: Impact of this decision
+    - selected_option: The chosen option once decided
     - status: ADR status (proposed|accepted|rejected|superseded)
+
+  Structured fields:
+    - consequences.positive: Positive outcomes
+    - consequences.negative: Negative outcomes with mitigations
+    - consequences.neutral: Neutral side effects
 
   Array fields (returns JSON array):
     - refs: Cross-references to RFCs/ADRs
-    - alternatives: Options that were considered
+    - alternatives: Non-selected options that were considered
 
 EXAMPLES:
     govctl adr get ADR-0001                    # Show all fields
     govctl adr get ADR-0001 context            # Get specific field
     govctl adr get ADR-0001 alternatives       # Get array field
+    govctl adr get ADR-0001 consequences.negative
 ")]
     Get {
         /// ADR ID
@@ -654,21 +707,50 @@ EXAMPLES:
         /// Field name (omit to show all)
         field: Option<String>,
     },
+    /// Canonical path-first edit entrypoint
+    #[command(after_help = "\
+EXAMPLES:
+    govctl adr edit ADR-0001 content.decision --set \"We will ...\"
+    govctl adr edit ADR-0001 content.alternatives --add \"Option A\"
+    govctl adr edit ADR-0001 content.alternatives[0].pros --add \"Readable\"
+")]
+    Edit {
+        /// ADR ID
+        id: String,
+        /// Canonical field path
+        path: String,
+        #[command(flatten)]
+        action: EditActionArgs,
+        /// Pro/advantage for alternative creation (compatibility with `adr add`)
+        #[arg(long)]
+        pro: Vec<String>,
+        /// Con/disadvantage for alternative creation (compatibility with `adr add`)
+        #[arg(long)]
+        con: Vec<String>,
+        /// Rejection reason for alternative creation (compatibility with `adr add`)
+        #[arg(long)]
+        reject_reason: Option<String>,
+    },
     /// Set ADR field value
     #[command(after_help = "\
 VALID FIELDS:
   String fields (use 'set'):
     - context: Background and problem description
     - decision: The decision made and rationale
-    - consequences: Impact of this decision
+    - selected_option: The chosen option once decided
     - title: ADR title
     - date: ADR date
+
+  Nested/object fields:
+    - consequences.positive / consequences.negative / consequences.neutral
+    - migration.state / migration.warnings[*]
 
   Array fields (use 'add'/'remove' instead):
     - refs, alternatives
 
 EXAMPLES:
     govctl adr set ADR-0001 context \"New context\"
+    govctl adr set ADR-0001 selected_option \"Option A\"
     govctl adr set ADR-0001 decision --stdin <<'EOF'
     Multi-line decision here
     EOF
@@ -697,7 +779,6 @@ VALID ARRAY FIELDS:
 ALTERNATIVES FORMAT (per ADR-0027):
     Each alternative has:
     - text: Description of the option (required)
-    - status: considered | accepted | rejected
     - pros: Advantages (use --pro to add)
     - cons: Disadvantages (use --con to add)
     - rejection_reason: Why rejected (use --reject-reason)
@@ -793,27 +874,6 @@ EXAMPLES:
         #[arg(short = 'f', long)]
         force: bool,
     },
-    /// Tick checklist item
-    Tick {
-        /// ADR ID
-        id: String,
-        /// Field (decisions or alternatives)
-        field: String,
-        /// Pattern to match
-        pattern: Option<String>,
-        /// New status
-        #[arg(short, long, value_enum, default_value = "done")]
-        status: TickStatus,
-        /// Match by index
-        #[arg(long, allow_hyphen_values = true)]
-        at: Option<i32>,
-        /// Exact match
-        #[arg(long)]
-        exact: bool,
-        /// Regex pattern
-        #[arg(long)]
-        regex: bool,
-    },
     /// Render a single ADR to markdown
     Render {
         /// ADR ID to render
@@ -887,6 +947,27 @@ EXAMPLES:
         id: String,
         /// Field name (omit to show all)
         field: Option<String>,
+    },
+    /// Canonical path-first edit entrypoint
+    #[command(after_help = "\
+EXAMPLES:
+    govctl work edit WI-2026-04-06-001 description --set \"Scope and why\"
+    govctl work edit WI-2026-04-06-001 content.acceptance_criteria --add \"add: Implement feature X\"
+    govctl work edit WI-2026-04-06-001 content.acceptance_criteria[0] --tick done
+")]
+    Edit {
+        /// Work item ID
+        id: String,
+        /// Canonical field path
+        path: String,
+        #[command(flatten)]
+        action: EditActionArgs,
+        /// Changelog category for acceptance-criteria creation
+        #[arg(short = 'c', long, value_enum)]
+        category: Option<ChangelogCategory>,
+        /// Scope/topic for journal creation
+        #[arg(long)]
+        scope: Option<String>,
     },
     /// Set work item field value
     #[command(after_help = "\
@@ -1096,6 +1177,21 @@ pub(crate) enum GuardCommand {
         id: String,
         /// Field name (omit to show all)
         field: Option<String>,
+    },
+    /// Canonical path-first edit entrypoint
+    #[command(after_help = "\
+EXAMPLES:
+    govctl guard edit GUARD-0001 description --set \"What this guard verifies\"
+    govctl guard edit GUARD-0001 refs --add RFC-0001
+    govctl guard edit GUARD-0001 refs[0] --remove
+")]
+    Edit {
+        /// Guard ID
+        id: String,
+        /// Canonical field path
+        path: String,
+        #[command(flatten)]
+        action: EditActionArgs,
     },
     /// Set guard field value
     Set {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -566,36 +566,74 @@ EXAMPLES:
         /// Field name (omit to show all)
         field: Option<String>,
     },
-    /// Edit clause text
+    /// Canonical path-first clause edit entrypoint
+    #[command(after_help = "\
+EXAMPLES:
+    govctl clause edit RFC-0001:C-SUMMARY text --set \"Updated clause text\"
+    govctl clause edit RFC-0001:C-SUMMARY text --stdin
+    govctl clause edit RFC-0001:C-SUMMARY title --set \"New Title\"
+    govctl clause edit RFC-0001:C-SUMMARY kind --set informative
+
+LEGACY SUGAR:
+    govctl clause edit RFC-0001:C-SUMMARY --text \"Updated clause text\"
+    govctl clause edit RFC-0001:C-SUMMARY --stdin
+")]
     Edit {
         /// Clause ID
         id: String,
-        /// Set text directly
+        /// Canonical field path (`text`, `title`, `kind`, or `anchors`)
+        path: Option<String>,
+        /// Set a scalar value (omit VALUE only when using --stdin)
+        #[arg(long, group = "clause_edit_action", num_args = 0..=1, default_missing_value = "")]
+        set: Option<String>,
+        /// Append a value to a list (omit VALUE only when using --stdin)
+        #[arg(long, group = "clause_edit_action", num_args = 0..=1, default_missing_value = "")]
+        add: Option<String>,
+        /// Remove a matching value, or omit PATTERN when removing an indexed path
+        #[arg(long, group = "clause_edit_action", num_args = 0..=1, default_missing_value = "")]
+        remove: Option<String>,
+        /// Update checklist-style item status
+        #[arg(long, group = "clause_edit_action")]
+        tick: Option<TickStatus>,
+        /// Read set/add value from stdin
+        #[arg(long)]
+        stdin: bool,
+        /// Match by index for remove/tick
+        #[arg(long, allow_hyphen_values = true)]
+        at: Option<i32>,
+        /// Exact match for remove/tick
+        #[arg(long)]
+        exact: bool,
+        /// Regex match for remove/tick
+        #[arg(long)]
+        regex: bool,
+        /// Remove all matches
+        #[arg(long)]
+        all: bool,
+        /// Legacy sugar: set text directly
         #[arg(long, group = "text_source")]
         text: Option<String>,
-        /// Read text from file
+        /// Legacy sugar: read text from file
         #[arg(long, group = "text_source")]
         text_file: Option<PathBuf>,
-        /// Read text from stdin (recommended for multi-line)
-        #[arg(long, group = "text_source")]
-        stdin: bool,
     },
     /// Set clause field value
     #[command(after_help = "\
 VALID FIELDS:
-  String fields (use 'set'):
+  String fields (use 'set' or `edit ... --set`):
     - title: Clause title
     - kind: Clause kind (normative|informative)
+    - text: Clause text content
 
-  Array fields (modify via the clause source file directly):
-    - anchors
+  Array fields (use 'add' / 'remove' or `edit ... --add/--remove`):
+    - anchors: Cross-reference anchors
 
 EXAMPLES:
     govctl clause set RFC-0001:C-SUMMARY title \"New Title\"
     govctl clause set RFC-0001:C-SUMMARY kind informative
+    govctl clause set RFC-0001:C-SUMMARY text --stdin
 
 Use dedicated verbs instead of `set` for:
-    - text → `govctl clause edit`
     - status / superseded_by → `govctl clause deprecate` / `govctl clause supersede`
     - since → `govctl rfc bump` / `govctl rfc finalize`
 ")]

--- a/src/cmd/describe.rs
+++ b/src/cmd/describe.rs
@@ -223,9 +223,11 @@ fn command_catalog() -> Vec<CommandInfo> {
         },
         CommandInfo {
             name: "edit".to_string(),
-            purpose: "Edit clause text".to_string(),
-            when_to_use: "To update normative clause content. Use --stdin for multi-line text.".to_string(),
-            example: "govctl clause edit RFC-0001:C-SCOPE --stdin".to_string(),
+            purpose: "Edit clause fields".to_string(),
+            when_to_use:
+                "To update clause text or metadata. Use path-first edit form; --stdin works well for multi-line text."
+                    .to_string(),
+            example: "govctl clause edit RFC-0001:C-SCOPE text --stdin".to_string(),
             prerequisites: vec!["Clause must exist".to_string()],
         },
         CommandInfo {

--- a/src/cmd/edit/adapter.rs
+++ b/src/cmd/edit/adapter.rs
@@ -4,6 +4,7 @@
 //! artifacts while execution is migrated from legacy dispatch to V2 engine.
 
 use crate::config::Config;
+use crate::diagnostic::{Diagnostic, DiagnosticCode};
 use crate::load::{find_clause_json, find_rfc_json};
 use crate::model::{AdrEntry, ClauseSpec, GuardEntry, RfcSpec, WorkItemEntry};
 use crate::parse::{
@@ -44,8 +45,14 @@ impl JsonAdapter for RfcJsonAdapter {
     type Data = RfcSpec;
 
     fn load(config: &Config, id: &str) -> anyhow::Result<JsonDoc<Self::Data>> {
-        let path =
-            find_rfc_json(config, id).ok_or_else(|| anyhow::anyhow!("RFC not found: {id}"))?;
+        let scope = config.display_path(&config.rfc_dir()).display().to_string();
+        let path = find_rfc_json(config, id).ok_or_else(|| {
+            Diagnostic::new(
+                DiagnosticCode::E0102RfcNotFound,
+                format!("RFC not found: {id}"),
+                &scope,
+            )
+        })?;
         let data = read_rfc(config, &path)?;
         Ok(JsonDoc { path, data })
     }
@@ -67,8 +74,19 @@ impl JsonAdapter for ClauseJsonAdapter {
     type Data = ClauseSpec;
 
     fn load(config: &Config, id: &str) -> anyhow::Result<JsonDoc<Self::Data>> {
-        let path = find_clause_json(config, id)
-            .ok_or_else(|| anyhow::anyhow!("Clause not found: {id}"))?;
+        let scope_path = id
+            .split(':')
+            .next()
+            .map(|rfc_id| config.rfc_dir().join(rfc_id).join("clauses"))
+            .unwrap_or_else(|| config.rfc_dir());
+        let scope = config.display_path(&scope_path).display().to_string();
+        let path = find_clause_json(config, id).ok_or_else(|| {
+            Diagnostic::new(
+                DiagnosticCode::E0202ClauseNotFound,
+                format!("Clause not found: {id}"),
+                &scope,
+            )
+        })?;
         let data = read_clause(config, &path)?;
         Ok(JsonDoc { path, data })
     }
@@ -90,10 +108,17 @@ impl TomlAdapter for AdrTomlAdapter {
     type Entry = AdrEntry;
 
     fn load(config: &Config, id: &str) -> anyhow::Result<Self::Entry> {
-        load_adrs(config)?
+        let scope = config.display_path(&config.adr_dir()).display().to_string();
+        Ok(load_adrs(config)?
             .into_iter()
             .find(|a| a.spec.govctl.id == id)
-            .ok_or_else(|| anyhow::anyhow!("ADR not found: {id}"))
+            .ok_or_else(|| {
+                Diagnostic::new(
+                    DiagnosticCode::E0302AdrNotFound,
+                    format!("ADR not found: {id}"),
+                    &scope,
+                )
+            })?)
     }
 
     fn write(config: &Config, entry: &Self::Entry, op: WriteOp) -> anyhow::Result<()> {
@@ -114,10 +139,20 @@ impl TomlAdapter for WorkTomlAdapter {
     type Entry = WorkItemEntry;
 
     fn load(config: &Config, id: &str) -> anyhow::Result<Self::Entry> {
-        load_work_items(config)?
+        let scope = config
+            .display_path(&config.work_dir())
+            .display()
+            .to_string();
+        Ok(load_work_items(config)?
             .into_iter()
             .find(|w| w.spec.govctl.id == id || w.path.to_string_lossy().contains(id))
-            .ok_or_else(|| anyhow::anyhow!("Work item not found: {id}"))
+            .ok_or_else(|| {
+                Diagnostic::new(
+                    DiagnosticCode::E0402WorkNotFound,
+                    format!("Work item not found: {id}"),
+                    &scope,
+                )
+            })?)
     }
 
     fn write(config: &Config, entry: &Self::Entry, op: WriteOp) -> anyhow::Result<()> {
@@ -138,11 +173,21 @@ impl TomlAdapter for GuardTomlAdapter {
     type Entry = GuardEntry;
 
     fn load(config: &Config, id: &str) -> anyhow::Result<Self::Entry> {
-        load_guards(config)
-            .map_err(|d| anyhow::anyhow!("{}", d.message))?
+        let scope = config
+            .display_path(&config.guard_dir())
+            .display()
+            .to_string();
+        Ok(load_guards(config)
+            .map_err(anyhow::Error::from)?
             .into_iter()
             .find(|g| g.spec.govctl.id == id)
-            .ok_or_else(|| anyhow::anyhow!("Guard not found: {id}"))
+            .ok_or_else(|| {
+                Diagnostic::new(
+                    DiagnosticCode::E1002GuardNotFound,
+                    format!("Guard not found: {id}"),
+                    &scope,
+                )
+            })?)
     }
 
     fn write(config: &Config, entry: &Self::Entry, op: WriteOp) -> anyhow::Result<()> {

--- a/src/cmd/edit/engine.rs
+++ b/src/cmd/edit/engine.rs
@@ -6,12 +6,13 @@
 
 use super::ArtifactType;
 use super::path::{self, FieldPath};
-use super::rules as edit_rules;
+use super::rules::{self as edit_rules, Verb};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EditPlan {
     pub artifact: ArtifactType,
     pub field_path: Option<FieldPath>,
+    pub verb: Option<Verb>,
 }
 
 /// Parse and canonicalize a user field expression using current path rules.
@@ -27,6 +28,18 @@ pub fn parse_and_canonicalize_field(
 /// During migration this function intentionally does not enforce verb/field
 /// capability checks; those remain in the existing execution path.
 pub fn plan_request(id: &str, field: Option<&str>) -> anyhow::Result<EditPlan> {
+    plan_request_with_verb(id, field, None)
+}
+
+pub fn plan_mutation_request(id: &str, field: &str, verb: Verb) -> anyhow::Result<EditPlan> {
+    plan_request_with_verb(id, Some(field), Some(verb))
+}
+
+fn plan_request_with_verb(
+    id: &str,
+    field: Option<&str>,
+    verb: Option<Verb>,
+) -> anyhow::Result<EditPlan> {
     let artifact = resolve_artifact(id)?;
     let field_path = field
         .map(|path| parse_and_canonicalize_field(artifact, path))
@@ -34,6 +47,7 @@ pub fn plan_request(id: &str, field: Option<&str>) -> anyhow::Result<EditPlan> {
     Ok(EditPlan {
         artifact,
         field_path,
+        verb,
     })
 }
 
@@ -98,6 +112,7 @@ mod tests {
             plan.field_path.as_ref().and_then(FieldPath::as_simple),
             Some("title")
         );
+        assert_eq!(plan.verb, None);
     }
 
     #[test]
@@ -106,6 +121,7 @@ mod tests {
         let fp = plan.field_path.as_ref().expect("nested field should exist");
         assert_eq!(fp.segments[0].name, "alternatives");
         assert_eq!(fp.segments[1].name, "pros");
+        assert_eq!(plan.verb, None);
     }
 
     #[test]
@@ -113,6 +129,7 @@ mod tests {
         let plan = plan_request("ADR-0001", None).unwrap();
         assert_eq!(plan.artifact, ArtifactType::Adr);
         assert!(plan.field_path.is_none());
+        assert_eq!(plan.verb, None);
     }
 
     #[test]
@@ -148,5 +165,16 @@ mod tests {
         let fp = plan.field_path.expect("field path should exist");
         assert_eq!(fp.segments[0].name, "alt");
         assert_eq!(fp.segments[1].name, "pro");
+    }
+
+    #[test]
+    fn test_plan_mutation_request_records_verb() {
+        let plan = plan_mutation_request("ADR-0001", "content.decision", Verb::Set).unwrap();
+        assert_eq!(plan.verb, Some(Verb::Set));
+        assert_eq!(
+            plan.field_path
+                .and_then(|fp| fp.as_simple().map(str::to_owned)),
+            Some("decision".to_string())
+        );
     }
 }

--- a/src/cmd/edit/mod.rs
+++ b/src/cmd/edit/mod.rs
@@ -51,7 +51,12 @@ impl ArtifactType {
     }
 
     pub fn unknown_error(id: &str) -> anyhow::Error {
-        anyhow::anyhow!("Unknown artifact type: {id}")
+        Diagnostic::new(
+            DiagnosticCode::E0819UnknownArtifactType,
+            format!("Unknown artifact type: {id}"),
+            id,
+        )
+        .into()
     }
 
     pub fn rule_key(self) -> &'static str {
@@ -169,7 +174,13 @@ fn resolve_match_indices(
     } else {
         let pattern = opts.pattern.unwrap_or("<index>");
         let matches = if opts.regex {
-            let re = Regex::new(pattern).map_err(|e| anyhow::anyhow!("Invalid regex: {}", e))?;
+            let re = Regex::new(pattern).map_err(|e| {
+                Diagnostic::new(
+                    DiagnosticCode::E0806InvalidPattern,
+                    format!("Invalid regex: {}", e),
+                    id,
+                )
+            })?;
             items
                 .iter()
                 .enumerate()
@@ -289,9 +300,13 @@ fn plan_edit_with_field_for_verb(
         Some(verb) => edit_engine::plan_mutation_request(id, field, verb)?,
         None => edit_engine::plan_request(id, Some(field))?,
     };
-    let fp = plan
-        .field_path
-        .ok_or_else(|| anyhow::anyhow!("Field path required"))?;
+    let fp = plan.field_path.ok_or_else(|| {
+        Diagnostic::new(
+            DiagnosticCode::E0801MissingRequiredArg,
+            "Field path required",
+            id,
+        )
+    })?;
     Ok((plan.artifact, fp))
 }
 
@@ -1365,7 +1380,13 @@ pub fn delete_clause(
     let clause_file_name = clause_path
         .file_name()
         .and_then(|name| name.to_str())
-        .ok_or_else(|| anyhow::anyhow!("Invalid clause file path: {}", clause_path.display()))?;
+        .ok_or_else(|| {
+            Diagnostic::new(
+                DiagnosticCode::E0204ClausePathInvalid,
+                format!("Invalid clause file path: {}", clause_path.display()),
+                clause_id,
+            )
+        })?;
 
     if !confirm_delete_prompt(
         force,

--- a/src/cmd/edit/mod.rs
+++ b/src/cmd/edit/mod.rs
@@ -1051,9 +1051,11 @@ pub fn remove_from_field(
 ) -> anyhow::Result<Vec<Diagnostic>> {
     let (artifact, fp) = plan_edit_with_field_for_verb(id, field, Some(edit_rules::Verb::Remove))?;
 
+    let pattern_provided = opts.pattern.is_some_and(|pattern| !pattern.is_empty());
+
     if !fp.is_simple() && fp.has_terminal_index() {
         let has_match_opts =
-            opts.pattern.is_some() || opts.at.is_some() || opts.exact || opts.regex || opts.all;
+            pattern_provided || opts.at.is_some() || opts.exact || opts.regex || opts.all;
         if has_match_opts {
             return Err(Diagnostic::new(
                 DiagnosticCode::E0818PathIndexConflict,

--- a/src/cmd/edit/mod.rs
+++ b/src/cmd/edit/mod.rs
@@ -76,6 +76,46 @@ pub struct MatchOptions<'a> {
     pub all: bool,
 }
 
+#[derive(Debug, Clone)]
+pub enum OwnedEditAction {
+    Set {
+        value: Option<String>,
+        stdin: bool,
+    },
+    Add {
+        value: Option<String>,
+        stdin: bool,
+    },
+    Remove {
+        match_opts: MatchOptionsOwned,
+    },
+    Tick {
+        match_opts: MatchOptionsOwned,
+        status: crate::TickStatus,
+    },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MatchOptionsOwned {
+    pub pattern: Option<String>,
+    pub at: Option<i32>,
+    pub exact: bool,
+    pub regex: bool,
+    pub all: bool,
+}
+
+impl MatchOptionsOwned {
+    pub fn as_match_options(&self) -> MatchOptions<'_> {
+        MatchOptions {
+            pattern: self.pattern.as_deref(),
+            at: self.at,
+            exact: self.exact,
+            regex: self.regex,
+            all: self.all,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MatchUse {
     Remove,
@@ -240,8 +280,15 @@ fn require_simple_field<'a>(fp: &'a FieldPath, id: &str, message: &str) -> anyho
         .ok_or_else(|| Diagnostic::new(DiagnosticCode::E0817PathTypeMismatch, message, id).into())
 }
 
-fn plan_edit_with_field(id: &str, field: &str) -> anyhow::Result<(ArtifactType, FieldPath)> {
-    let plan = edit_engine::plan_request(id, Some(field))?;
+fn plan_edit_with_field_for_verb(
+    id: &str,
+    field: &str,
+    verb: Option<edit_rules::Verb>,
+) -> anyhow::Result<(ArtifactType, FieldPath)> {
+    let plan = match verb {
+        Some(verb) => edit_engine::plan_mutation_request(id, field, verb)?,
+        None => edit_engine::plan_request(id, Some(field))?,
+    };
     let fp = plan
         .field_path
         .ok_or_else(|| anyhow::anyhow!("Field path required"))?;
@@ -292,7 +339,8 @@ impl TomlEditableEntry for GuardEntry {
     }
 }
 
-const TICK_NESTED_PATH_ERROR: &str = "tick does not support nested paths";
+const TICK_NESTED_PATH_ERROR: &str =
+    "tick only supports checklist root paths or indexed checklist items";
 const TICK_UNSUPPORTED_ARTIFACT_ERROR: &str = "Tick only works for work items and ADRs: {id}";
 
 pub fn edit_clause(
@@ -338,7 +386,7 @@ pub fn set_field(
     stdin: bool,
     op: WriteOp,
 ) -> anyhow::Result<Vec<Diagnostic>> {
-    let (artifact, fp) = plan_edit_with_field(id, field)?;
+    let (artifact, fp) = plan_edit_with_field_for_verb(id, field, Some(edit_rules::Verb::Set))?;
     let value = resolve_value(value, stdin)?;
     apply_set_field(config, id, &fp, artifact, value.as_str(), op, true)?;
 
@@ -357,7 +405,7 @@ pub(crate) fn set_field_direct(
     value: &str,
     op: WriteOp,
 ) -> anyhow::Result<()> {
-    let (artifact, fp) = plan_edit_with_field(id, field)?;
+    let (artifact, fp) = plan_edit_with_field_for_verb(id, field, Some(edit_rules::Verb::Set))?;
     apply_set_field(config, id, &fp, artifact, value, op, false)
 }
 
@@ -448,13 +496,6 @@ fn reject_verb_owned_set(artifact: ArtifactType, fp: &FieldPath, id: &str) -> an
                 Some(
                     "ADR lifecycle fields are verb-owned. Use `govctl adr accept`, `govctl adr reject`, or `govctl adr supersede`.",
                 )
-            } else if fp.segments.len() == 2
-                && fp.segments[0].name == "alternatives"
-                && fp.segments[1].name == "status"
-            {
-                Some(
-                    "ADR alternative status is tick-owned. Use `govctl adr tick ... alternatives ...`.",
-                )
             } else {
                 None
             }
@@ -528,6 +569,50 @@ pub fn get_field(
     }
 
     Ok(vec![])
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn edit_field(
+    config: &Config,
+    id: &str,
+    path: &str,
+    action: &OwnedEditAction,
+    category_override: Option<crate::model::ChangelogCategory>,
+    scope_override: Option<&str>,
+    pros: Option<Vec<String>>,
+    cons: Option<Vec<String>>,
+    reject_reason: Option<String>,
+    op: WriteOp,
+) -> anyhow::Result<Vec<Diagnostic>> {
+    match action {
+        OwnedEditAction::Set { value, stdin } => {
+            set_field(config, id, path, value.as_deref(), *stdin, op)
+        }
+        OwnedEditAction::Add { value, stdin } => add_to_field(
+            config,
+            id,
+            path,
+            value.as_deref(),
+            *stdin,
+            category_override,
+            scope_override,
+            pros,
+            cons,
+            reject_reason,
+            op,
+        ),
+        OwnedEditAction::Remove { match_opts } => {
+            remove_from_field(config, id, path, &match_opts.as_match_options(), op)
+        }
+        OwnedEditAction::Tick { match_opts, status } => tick_item(
+            config,
+            id,
+            path,
+            &match_opts.as_match_options(),
+            *status,
+            op,
+        ),
+    }
 }
 
 fn get_toml_field<A>(
@@ -696,7 +781,7 @@ fn adr_add_alternatives(
     value: &str,
     ctx: &AdrAddContext,
 ) -> anyhow::Result<()> {
-    use crate::model::{Alternative, AlternativeStatus};
+    use crate::model::Alternative;
     if entry
         .spec
         .content
@@ -707,15 +792,8 @@ fn adr_add_alternatives(
         return Ok(());
     }
 
-    let status = if ctx.reject_reason.is_some() {
-        AlternativeStatus::Rejected
-    } else {
-        AlternativeStatus::Considered
-    };
-
     entry.spec.content.alternatives.push(Alternative {
         text: value.to_string(),
-        status,
         pros: ctx.pros.clone().unwrap_or_default(),
         cons: ctx.cons.clone().unwrap_or_default(),
         rejection_reason: ctx.reject_reason.clone(),
@@ -796,7 +874,7 @@ pub fn add_to_field(
     reject_reason: Option<String>,
     op: WriteOp,
 ) -> anyhow::Result<Vec<Diagnostic>> {
-    let (artifact, fp) = plan_edit_with_field(id, field)?;
+    let (artifact, fp) = plan_edit_with_field_for_verb(id, field, Some(edit_rules::Verb::Add))?;
     let value = resolve_value(value, stdin)?;
     let value = value.as_str();
     match artifact {
@@ -957,7 +1035,7 @@ pub fn remove_from_field(
     opts: &MatchOptions,
     op: WriteOp,
 ) -> anyhow::Result<Vec<Diagnostic>> {
-    let (artifact, fp) = plan_edit_with_field(id, field)?;
+    let (artifact, fp) = plan_edit_with_field_for_verb(id, field, Some(edit_rules::Verb::Remove))?;
 
     if !fp.is_simple() && fp.has_terminal_index() {
         let has_match_opts =
@@ -1031,16 +1109,29 @@ pub fn tick_item(
     status: crate::TickStatus,
     op: WriteOp,
 ) -> anyhow::Result<Vec<Diagnostic>> {
-    let (artifact, fp) = plan_edit_with_field(id, field)?;
-    if !fp.is_simple() {
+    let (artifact, fp) = plan_edit_with_field_for_verb(id, field, Some(edit_rules::Verb::Tick))?;
+    let mut indexed_match = MatchOptions::default();
+    let (field, effective_opts) = if fp.is_simple() {
+        (fp.as_simple().unwrap(), opts.clone())
+    } else if fp.segments.len() == 1 && fp.segments[0].index.is_some() {
+        if opts.pattern.is_some() || opts.at.is_some() || opts.exact || opts.regex || opts.all {
+            return Err(Diagnostic::new(
+                DiagnosticCode::E0818PathIndexConflict,
+                "Cannot combine an indexed tick path with match flags",
+                id,
+            )
+            .into());
+        }
+        indexed_match.at = fp.segments[0].index;
+        (fp.segments[0].name.as_str(), indexed_match)
+    } else {
         return Err(Diagnostic::new(
             DiagnosticCode::E0817PathTypeMismatch,
             TICK_NESTED_PATH_ERROR,
             id,
         )
         .into());
-    }
-    let field = fp.as_simple().unwrap();
+    };
 
     let status_str = match (artifact, status) {
         (ArtifactType::Adr, crate::TickStatus::Done) => "accepted",
@@ -1063,7 +1154,7 @@ pub fn tick_item(
             config,
             id,
             field,
-            opts,
+            &effective_opts,
             op,
             ArtifactType::Adr,
             status_str,
@@ -1072,7 +1163,7 @@ pub fn tick_item(
             config,
             id,
             field,
-            opts,
+            &effective_opts,
             op,
             ArtifactType::WorkItem,
             status_str,
@@ -1131,11 +1222,21 @@ where
     } else if fp.segments.len() >= 2 {
         // Nested subfield remove: e.g., alt[0].pros or alt[0].cons[1]
         let removed = if fp.has_terminal_index() {
-            let sub_idx = fp.segments[1].index.unwrap();
-            edit_runtime::remove_nested_list_values(artifact, &mut doc, fp, id, |items| {
-                let resolved = self::path::resolve_index(sub_idx, items.len())?;
-                Ok(vec![resolved])
-            })?
+            let sub_idx = fp.segments.last().and_then(|seg| seg.index).unwrap();
+            let mut container_fp = fp.clone();
+            if let Some(last) = container_fp.segments.last_mut() {
+                last.index = None;
+            }
+            edit_runtime::remove_nested_list_values(
+                artifact,
+                &mut doc,
+                &container_fp,
+                id,
+                |items| {
+                    let resolved = self::path::resolve_index(sub_idx, items.len())?;
+                    Ok(vec![resolved])
+                },
+            )?
         } else {
             edit_runtime::remove_nested_list_values(artifact, &mut doc, fp, id, |items| {
                 resolve_match_indices(id, field, items, opts, MatchUse::Remove)

--- a/src/cmd/edit/mod.rs
+++ b/src/cmd/edit/mod.rs
@@ -341,7 +341,7 @@ impl TomlEditableEntry for GuardEntry {
 
 const TICK_NESTED_PATH_ERROR: &str =
     "tick only supports checklist root paths or indexed checklist items";
-const TICK_UNSUPPORTED_ARTIFACT_ERROR: &str = "Tick only works for work items and ADRs: {id}";
+const TICK_UNSUPPORTED_ARTIFACT_ERROR: &str = "Tick only works for work items: {id}";
 
 pub fn edit_clause(
     config: &Config,
@@ -1133,13 +1133,10 @@ pub fn tick_item(
     };
 
     let status_str = match (artifact, status) {
-        (ArtifactType::Adr, crate::TickStatus::Done) => "accepted",
-        (ArtifactType::Adr, crate::TickStatus::Pending) => "considered",
-        (ArtifactType::Adr, crate::TickStatus::Cancelled) => "rejected",
         (ArtifactType::WorkItem, crate::TickStatus::Done) => "done",
         (ArtifactType::WorkItem, crate::TickStatus::Pending) => "pending",
         (ArtifactType::WorkItem, crate::TickStatus::Cancelled) => "cancelled",
-        (ArtifactType::Rfc | ArtifactType::Clause | ArtifactType::Guard, _) => {
+        (ArtifactType::Rfc | ArtifactType::Clause | ArtifactType::Adr | ArtifactType::Guard, _) => {
             return Err(Diagnostic::new(
                 DiagnosticCode::E0813SupersedeNotSupported,
                 TICK_UNSUPPORTED_ARTIFACT_ERROR.replace("{id}", id),
@@ -1149,15 +1146,6 @@ pub fn tick_item(
         }
     };
     let ticked_text = match artifact {
-        ArtifactType::Adr => tick_toml_field::<AdrTomlAdapter>(
-            config,
-            id,
-            field,
-            &effective_opts,
-            op,
-            ArtifactType::Adr,
-            status_str,
-        )?,
         ArtifactType::WorkItem => tick_toml_field::<WorkTomlAdapter>(
             config,
             id,
@@ -1167,7 +1155,7 @@ pub fn tick_item(
             ArtifactType::WorkItem,
             status_str,
         )?,
-        ArtifactType::Rfc | ArtifactType::Clause | ArtifactType::Guard => {
+        ArtifactType::Rfc | ArtifactType::Clause | ArtifactType::Adr | ArtifactType::Guard => {
             unreachable!("handled above")
         }
     };

--- a/src/cmd/edit/mod.rs
+++ b/src/cmd/edit/mod.rs
@@ -479,7 +479,6 @@ fn reject_verb_owned_set(artifact: ArtifactType, fp: &FieldPath, id: &str) -> an
             _ => None,
         },
         ArtifactType::Clause => match fp.as_simple() {
-            Some("text") => Some("Clause text is edit-owned. Use `govctl clause edit`."),
             Some("status") => Some(
                 "Clause status is lifecycle-owned. Use `govctl clause deprecate` or `govctl clause supersede`.",
             ),

--- a/src/cmd/edit/path.rs
+++ b/src/cmd/edit/path.rs
@@ -60,11 +60,11 @@ impl FieldPath {
         self
     }
 
-    /// Collapse legacy two-segment prefixes into their canonical single-segment form.
+    /// Collapse legacy prefixes into their canonical field-path form.
     ///
     /// `content.decision` → `decision`, `govctl.status` → `status`, etc.
     pub fn collapse_legacy_prefixes(mut self) -> Self {
-        if self.segments.len() == 2 && self.segments[0].index.is_none() {
+        if self.segments.len() >= 2 && self.segments[0].index.is_none() {
             let prefix = self.segments[0].name.as_str();
             let field = self.segments[1].name.as_str();
             if edit_rules::can_collapse_legacy_prefix(prefix, field) {
@@ -357,6 +357,17 @@ mod tests {
             .collapse_legacy_prefixes();
         assert_eq!(p.segments.len(), 2);
         assert_eq!(p.segments[0].name, "content");
+    }
+
+    #[test]
+    fn test_collapse_legacy_prefix_for_deeper_path() {
+        let p = parse_field_path("content.alternatives[0].pros")
+            .unwrap()
+            .collapse_legacy_prefixes();
+        assert_eq!(p.segments.len(), 2);
+        assert_eq!(p.segments[0].name, "alternatives");
+        assert_eq!(p.segments[0].index, Some(0));
+        assert_eq!(p.segments[1].name, "pros");
     }
 
     // =========================================================================

--- a/src/cmd/edit/rules.rs
+++ b/src/cmd/edit/rules.rs
@@ -1,5 +1,7 @@
 //! Edit path rules generated from JSON SSOT (ADR-0030).
 
+use crate::diagnostic::DiagnosticCode;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FieldKind {
     Scalar,
@@ -7,10 +9,41 @@ pub enum FieldKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct NestedFieldRule {
+pub enum NestedNodeKind {
+    Scalar,
+    Object,
+    List,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum NestedScalarMode {
+    String,
+    OptionalString {
+        empty_as_null: bool,
+    },
+    Integer,
+    Enum {
+        allowed: &'static [&'static str],
+        invalid_msg: &'static str,
+        code: Option<DiagnosticCode>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NestedChildRule {
     pub name: &'static str,
-    pub kind: FieldKind,
+    pub node: &'static NestedNodeRule,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NestedNodeRule {
+    pub kind: NestedNodeKind,
     pub verbs: &'static [&'static str],
+    pub text_key: Option<&'static str>,
+    pub set_mode: Option<NestedScalarMode>,
+    pub item: Option<&'static NestedNodeRule>,
+    pub fields: &'static [NestedChildRule],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18,10 +51,7 @@ pub struct NestedRootRule {
     pub artifact: &'static str,
     pub root: &'static str,
     pub content_path: &'static [&'static str],
-    pub text_key: Option<&'static str>,
-    pub requires_index: bool,
-    pub max_depth: usize,
-    pub fields: &'static [NestedFieldRule],
+    pub node: &'static NestedNodeRule,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -112,13 +142,25 @@ pub fn nested_field_rule(
     artifact: &str,
     root: &str,
     field: &str,
-) -> Option<&'static NestedFieldRule> {
-    nested_root_rule(artifact, root).and_then(|rule| rule.fields.iter().find(|f| f.name == field))
+) -> Option<&'static NestedChildRule> {
+    let rule = nested_root_rule(artifact, root)?;
+    match rule.node.kind {
+        NestedNodeKind::Object => rule.node.fields.iter().find(|f| f.name == field),
+        NestedNodeKind::List => {
+            let item = rule.node.item?;
+            if item.kind != NestedNodeKind::Object {
+                return None;
+            }
+            item.fields.iter().find(|f| f.name == field)
+        }
+        NestedNodeKind::Scalar => None,
+    }
 }
 
 #[cfg(test)]
 pub fn nested_field_supports_verb(artifact: &str, root: &str, field: &str, verb: Verb) -> bool {
-    nested_field_rule(artifact, root, field).is_some_and(|rule| rule.verbs.contains(&verb.as_str()))
+    nested_field_rule(artifact, root, field)
+        .is_some_and(|rule| rule.node.verbs.contains(&verb.as_str()))
 }
 
 pub fn field_validation_rule(artifact: &str, field: &str) -> Option<&'static FieldValidationRule> {
@@ -152,9 +194,8 @@ mod tests {
     #[test]
     fn test_nested_rule_lookup() {
         let rule = nested_root_rule("adr", "alternatives").expect("rule should exist");
-        assert_eq!(rule.max_depth, 2);
-        assert!(rule.requires_index);
-        assert_eq!(EDIT_RULES_VERSION, 1);
+        assert_eq!(rule.node.kind, NestedNodeKind::List);
+        assert_eq!(EDIT_RULES_VERSION, 2);
     }
 
     #[test]
@@ -174,12 +215,16 @@ mod tests {
     }
 
     #[test]
+    fn test_nested_object_root_lookup() {
+        let rule = nested_root_rule("guard", "check").expect("rule should exist");
+        assert_eq!(rule.node.kind, NestedNodeKind::Object);
+        let child = nested_field_rule("guard", "check", "timeout_secs").expect("child exists");
+        assert_eq!(child.node.kind, NestedNodeKind::Scalar);
+    }
+
+    #[test]
     fn test_simple_field_supports_verb() {
-        assert!(simple_field_supports_verb(
-            "adr",
-            "alternatives",
-            Verb::Tick
-        ));
+        assert!(simple_field_supports_verb("adr", "alternatives", Verb::Add));
         assert!(!simple_field_supports_verb(
             "adr",
             "superseded_by",

--- a/src/cmd/edit/runtime.rs
+++ b/src/cmd/edit/runtime.rs
@@ -1,6 +1,8 @@
 use super::ArtifactType;
 use super::path::{self, FieldPath};
-use super::rules::{self as edit_rules, FieldKind, NestedRootRule, Verb};
+use super::rules::{
+    self as edit_rules, NestedNodeKind, NestedNodeRule, NestedRootRule, NestedScalarMode, Verb,
+};
 use crate::diagnostic::{Diagnostic, DiagnosticCode};
 use serde_json::Value;
 
@@ -9,6 +11,9 @@ enum RenderMode {
     Scalar,
     CsvStrings,
     LineStrings,
+    TextLines {
+        text_key: &'static str,
+    },
     StatusLines {
         status_key: &'static str,
         text_key: &'static str,
@@ -337,6 +342,7 @@ fn render_field(doc: &Value, spec: SimpleFieldSpec, id: &str) -> anyhow::Result<
         RenderMode::Scalar => Ok(render_scalar(v)),
         RenderMode::CsvStrings => render_string_array(v, ", ", id),
         RenderMode::LineStrings => render_string_array(v, "\n", id),
+        RenderMode::TextLines { text_key } => render_text_lines(v, text_key, id),
         RenderMode::StatusLines {
             status_key,
             text_key,
@@ -426,6 +432,38 @@ fn render_status_lines(
             .and_then(Value::as_str)
             .unwrap_or_default();
         out.push(format!("[{status}] {text}"));
+    }
+    Ok(out.join("\n"))
+}
+
+fn render_text_lines(v: Option<&Value>, text_key: &str, id: &str) -> anyhow::Result<String> {
+    let Some(v) = v else {
+        return Ok(String::new());
+    };
+    let Some(items) = v.as_array() else {
+        return Err(Diagnostic::new(
+            DiagnosticCode::E0817PathTypeMismatch,
+            "Expected an array value",
+            id,
+        )
+        .into());
+    };
+
+    let mut out = Vec::with_capacity(items.len());
+    for item in items {
+        let Some(text) = item
+            .as_object()
+            .and_then(|obj| obj.get(text_key))
+            .and_then(Value::as_str)
+        else {
+            return Err(Diagnostic::new(
+                DiagnosticCode::E0817PathTypeMismatch,
+                format!("Expected object array items with '{text_key}' field"),
+                id,
+            )
+            .into());
+        };
+        out.push(text.to_string());
     }
     Ok(out.join("\n"))
 }
@@ -528,7 +566,6 @@ fn ensure_array_path_mut<'a>(
 // Generic nested field operations (ADR-0031 V2)
 // ===========================================================================
 
-/// Resolve a nested root rule from the SSOT, returning an error if not found.
 fn resolve_nested_root(
     artifact: ArtifactType,
     root: &str,
@@ -544,114 +581,6 @@ fn resolve_nested_root(
     })
 }
 
-/// Validate a nested field path against SSOT rules for a given verb.
-///
-/// Validates depth, index requirements, and subfield verb support.
-/// Returns the resolved root index.
-fn validate_nested_path(
-    artifact: ArtifactType,
-    rule: &NestedRootRule,
-    fp: &FieldPath,
-    verb: Verb,
-    root_array_len: usize,
-    id: &str,
-) -> anyhow::Result<usize> {
-    let root_name = &fp.segments[0].name;
-
-    // Validate depth
-    if fp.segments.len() > rule.max_depth {
-        return Err(Diagnostic::new(
-            DiagnosticCode::E0814InvalidPath,
-            format!(
-                "Path '{}' exceeds max depth {} for {}.{}",
-                fp,
-                rule.max_depth,
-                artifact.rule_key(),
-                root_name
-            ),
-            id,
-        )
-        .into());
-    }
-
-    // Resolve root index
-    let root_idx = path::require_index(&fp.segments[0], root_array_len)?;
-
-    // Validate subfield if present
-    if fp.segments.len() >= 2 {
-        let subfield = &fp.segments[1].name;
-        let field_rule = edit_rules::nested_field_rule(artifact.rule_key(), root_name, subfield)
-            .ok_or_else(|| {
-                Diagnostic::new(
-                    DiagnosticCode::E0815PathFieldNotFound,
-                    format!(
-                        "Unknown field '{}' under {}.{}",
-                        subfield,
-                        artifact.rule_key(),
-                        root_name
-                    ),
-                    id,
-                )
-            })?;
-        if !field_rule.verbs.contains(&verb.as_str()) {
-            return Err(Diagnostic::new(
-                DiagnosticCode::E0817PathTypeMismatch,
-                format!(
-                    "Field '{}.{}' does not support verb '{}'",
-                    root_name,
-                    subfield,
-                    verb.as_str()
-                ),
-                id,
-            )
-            .into());
-        }
-    }
-
-    Ok(root_idx)
-}
-
-/// Navigate to the root array in a JSON document using the SSOT content_path.
-fn root_array<'a>(
-    doc: &'a Value,
-    rule: &NestedRootRule,
-    id: &str,
-) -> anyhow::Result<&'a Vec<Value>> {
-    value_at_path(doc, rule.content_path)
-        .and_then(Value::as_array)
-        .ok_or_else(|| {
-            Diagnostic::new(
-                DiagnosticCode::E0817PathTypeMismatch,
-                format!("Expected array at path '{}'", rule.content_path.join(".")),
-                id,
-            )
-            .into()
-        })
-}
-
-/// Navigate to the root array (mutable) in a JSON document.
-fn root_array_mut<'a>(
-    doc: &'a mut Value,
-    rule: &NestedRootRule,
-    id: &str,
-) -> anyhow::Result<&'a mut Vec<Value>> {
-    ensure_array_path_mut(doc, rule.content_path, id)?
-        .as_array_mut()
-        .ok_or_else(|| {
-            Diagnostic::new(
-                DiagnosticCode::E0817PathTypeMismatch,
-                format!("Expected array at path '{}'", rule.content_path.join(".")),
-                id,
-            )
-            .into()
-        })
-}
-
-/// GET a nested field value. Handles:
-/// - `root[i]` → render all fields of the item
-/// - `root[i].scalar` → render scalar value
-/// - `root[i].list` → render all list items
-/// - `root[i].list[j]` → render one list item
 pub fn get_nested_field(
     artifact: ArtifactType,
     doc: &Value,
@@ -660,51 +589,18 @@ pub fn get_nested_field(
 ) -> anyhow::Result<String> {
     let root_name = &fp.segments[0].name;
     let rule = resolve_nested_root(artifact, root_name, id)?;
-    let arr = root_array(doc, rule, id)?;
-    let root_idx = validate_nested_path(artifact, rule, fp, Verb::Get, arr.len(), id)?;
-    let item = &arr[root_idx];
-
-    if fp.segments.len() == 1 {
-        // Render whole item
-        return render_nested_item(item, rule, id);
-    }
-
-    let subfield = &fp.segments[1].name;
-    let field_rule =
-        edit_rules::nested_field_rule(artifact.rule_key(), root_name, subfield).unwrap();
-
-    match field_rule.kind {
-        FieldKind::Scalar => {
-            if fp.segments[1].index.is_some() {
-                return Err(Diagnostic::new(
-                    DiagnosticCode::E0817PathTypeMismatch,
-                    format!("Cannot index into scalar field '{subfield}'"),
-                    id,
-                )
-                .into());
-            }
-            Ok(render_scalar(item.get(subfield)))
-        }
-        FieldKind::List => {
-            let list = item
-                .get(subfield)
-                .and_then(Value::as_array)
-                .cloned()
-                .unwrap_or_default();
-            if let Some(sub_idx) = fp.segments[1].index {
-                let resolved = path::resolve_index(sub_idx, list.len())?;
-                Ok(render_scalar(list.get(resolved)))
-            } else {
-                let strs: Vec<String> = list.iter().map(|v| render_scalar(Some(v))).collect();
-                Ok(strs.join("\n"))
-            }
-        }
-    }
+    let root_value = value_at_path(doc, rule.content_path);
+    let (node, value) = descend_get(
+        rule.node,
+        root_value,
+        &fp.segments[0],
+        &fp.segments[1..],
+        Verb::Get,
+        id,
+    )?;
+    render_nested_node(node, value, id)
 }
 
-/// SET a nested field value. Handles:
-/// - `root[i].scalar "value"` → set scalar field
-/// - `root[i].list[j] "value"` → replace list item at index
 pub fn set_nested_field(
     artifact: ArtifactType,
     doc: &mut Value,
@@ -714,59 +610,36 @@ pub fn set_nested_field(
 ) -> anyhow::Result<()> {
     let root_name = &fp.segments[0].name;
     let rule = resolve_nested_root(artifact, root_name, id)?;
-    let arr = root_array_mut(doc, rule, id)?;
-    let root_idx = validate_nested_path(artifact, rule, fp, Verb::Set, arr.len(), id)?;
-
-    if fp.segments.len() < 2 {
-        return Err(Diagnostic::new(
+    let root_value = ensure_node_path_mut(doc, rule.content_path, rule.node, id)?;
+    let (node, slot) = descend_mut(
+        rule.node,
+        root_value,
+        &fp.segments[0],
+        &fp.segments[1..],
+        Verb::Set,
+        id,
+    )?;
+    match node.kind {
+        NestedNodeKind::Scalar => apply_nested_scalar_set(slot, node.set_mode, value, id),
+        NestedNodeKind::List => Err(Diagnostic::new(
             DiagnosticCode::E0817PathTypeMismatch,
             format!(
-                "Cannot set entire '{}' item directly; specify a subfield",
-                root_name
+                "Field '{}' is a list; use an index to set a specific item, or use 'add'/'remove'",
+                fp
             ),
             id,
         )
-        .into());
-    }
-
-    let subfield = &fp.segments[1].name;
-    let field_rule =
-        edit_rules::nested_field_rule(artifact.rule_key(), root_name, subfield).unwrap();
-    let item = arr[root_idx]
-        .as_object_mut()
-        .ok_or_else(|| type_mismatch("Expected object item in array", id))?;
-
-    match field_rule.kind {
-        FieldKind::Scalar => {
-            // For optional fields (current value is null), empty → null
-            let json_value = if value.is_empty() && item.get(subfield).is_none_or(|v| v.is_null()) {
-                Value::Null
-            } else {
-                Value::String(value.to_string())
-            };
-            item.insert(subfield.to_string(), json_value);
-        }
-        FieldKind::List => {
-            let sub_idx = fp.segments[1].index.ok_or_else(|| {
-                Diagnostic::new(
-                    DiagnosticCode::E0817PathTypeMismatch,
-                    format!("Field '{subfield}' is a list; use an index to set a specific item, or use 'add'/'remove'"),
-                    id,
-                )
-            })?;
-            let list = item
-                .entry(subfield)
-                .or_insert_with(|| Value::Array(Vec::new()))
-                .as_array_mut()
-                .ok_or_else(|| type_mismatch("Expected array for list field", id))?;
-            let resolved = path::resolve_index(sub_idx, list.len())?;
-            list[resolved] = Value::String(value.to_string());
-        }
-    }
+        .into()),
+        NestedNodeKind::Object => Err(Diagnostic::new(
+            DiagnosticCode::E0817PathTypeMismatch,
+            format!("Cannot set object path '{}' directly", fp),
+            id,
+        )
+        .into()),
+    }?;
     Ok(())
 }
 
-/// ADD a value to a nested list field: `root[i].list "value"`.
 pub fn add_nested_list_value(
     artifact: ArtifactType,
     doc: &mut Value,
@@ -776,23 +649,7 @@ pub fn add_nested_list_value(
 ) -> anyhow::Result<()> {
     let root_name = &fp.segments[0].name;
     let rule = resolve_nested_root(artifact, root_name, id)?;
-    let arr = root_array_mut(doc, rule, id)?;
-    let root_idx = validate_nested_path(artifact, rule, fp, Verb::Add, arr.len(), id)?;
-
-    if fp.segments.len() < 2 {
-        return Err(Diagnostic::new(
-            DiagnosticCode::E0817PathTypeMismatch,
-            format!(
-                "Cannot add to '{}' without specifying a list subfield",
-                root_name
-            ),
-            id,
-        )
-        .into());
-    }
-
-    // Reject indexed terminal paths: e.g., alt[0].pros[999]
-    if fp.segments[1].index.is_some() {
+    if fp.has_terminal_index() {
         return Err(Diagnostic::new(
             DiagnosticCode::E0817PathTypeMismatch,
             format!(
@@ -803,37 +660,78 @@ pub fn add_nested_list_value(
         )
         .into());
     }
-
-    let subfield = &fp.segments[1].name;
-    let field_rule =
-        edit_rules::nested_field_rule(artifact.rule_key(), root_name, subfield).unwrap();
-    if field_rule.kind != FieldKind::List {
+    let root_value = ensure_node_path_mut(doc, rule.content_path, rule.node, id)?;
+    let (node, slot) = descend_mut(
+        rule.node,
+        root_value,
+        &fp.segments[0],
+        &fp.segments[1..],
+        Verb::Add,
+        id,
+    )?;
+    if node.kind != NestedNodeKind::List {
         return Err(Diagnostic::new(
             DiagnosticCode::E0817PathTypeMismatch,
-            format!("Field '{subfield}' is not a list; cannot add to it"),
+            format!("Field '{}' is not a list; cannot add to it", fp),
             id,
         )
         .into());
     }
-
-    let item = arr[root_idx]
-        .as_object_mut()
-        .ok_or_else(|| type_mismatch("Expected object item in array", id))?;
-    let list = item
-        .entry(subfield)
-        .or_insert_with(|| Value::Array(Vec::new()))
+    let item_rule = node
+        .item
+        .ok_or_else(|| type_mismatch("List node missing item rule", id))?;
+    let list = slot
         .as_array_mut()
         .ok_or_else(|| type_mismatch("Expected array for list field", id))?;
 
-    // Duplicate check
-    if !list.iter().any(|v| v.as_str() == Some(value)) {
-        list.push(Value::String(value.to_string()));
+    match item_rule.kind {
+        NestedNodeKind::Scalar => {
+            if !list.iter().any(|v| v.as_str() == Some(value)) {
+                list.push(Value::String(value.to_string()));
+            }
+        }
+        NestedNodeKind::Object => {
+            let Some(text_key) = node.text_key else {
+                return Err(Diagnostic::new(
+                    DiagnosticCode::E0817PathTypeMismatch,
+                    format!(
+                        "Field '{}' requires structured list items and cannot be appended with a plain string",
+                        fp
+                    ),
+                    id,
+                )
+                .into());
+            };
+            let duplicate = list.iter().any(|item| {
+                item.as_object()
+                    .and_then(|obj| obj.get(text_key))
+                    .and_then(Value::as_str)
+                    == Some(value)
+            });
+            if !duplicate {
+                let mut item = default_value_for_node(item_rule);
+                let obj = item
+                    .as_object_mut()
+                    .ok_or_else(|| type_mismatch("Expected object list item", id))?;
+                obj.insert(text_key.to_string(), Value::String(value.to_string()));
+                list.push(item);
+            }
+        }
+        NestedNodeKind::List => {
+            return Err(Diagnostic::new(
+                DiagnosticCode::E0817PathTypeMismatch,
+                format!(
+                    "Field '{}' requires structured list items and cannot be appended with a plain string",
+                    fp
+                ),
+                id,
+            )
+            .into());
+        }
     }
     Ok(())
 }
 
-/// REMOVE values from a nested list field: `root[i].list` with matcher.
-/// Returns the removed values.
 pub fn remove_nested_list_values<F>(
     artifact: ArtifactType,
     doc: &mut Value,
@@ -846,42 +744,50 @@ where
 {
     let root_name = &fp.segments[0].name;
     let rule = resolve_nested_root(artifact, root_name, id)?;
-    let arr = root_array_mut(doc, rule, id)?;
-    let root_idx = validate_nested_path(artifact, rule, fp, Verb::Remove, arr.len(), id)?;
-
-    if fp.segments.len() < 2 {
-        return Err(Diagnostic::new(
-            DiagnosticCode::E0817PathTypeMismatch,
-            format!(
-                "Cannot remove from '{}' without specifying a list subfield",
-                root_name
-            ),
-            id,
-        )
-        .into());
+    let root_value = ensure_node_path_mut(doc, rule.content_path, rule.node, id)?;
+    let (node, slot) = descend_mut(
+        rule.node,
+        root_value,
+        &fp.segments[0],
+        &fp.segments[1..],
+        Verb::Remove,
+        id,
+    )?;
+    if node.kind != NestedNodeKind::List {
+        return Err(type_mismatch("Expected array for list field", id).into());
     }
-
-    let subfield = &fp.segments[1].name;
-    let item = arr[root_idx]
-        .as_object_mut()
-        .ok_or_else(|| type_mismatch("Expected object item in array", id))?;
-    let list = item
-        .get_mut(subfield)
-        .and_then(Value::as_array_mut)
+    let item_rule = node
+        .item
+        .ok_or_else(|| type_mismatch("List node missing item rule", id))?;
+    let list = slot
+        .as_array_mut()
         .ok_or_else(|| type_mismatch("Expected array for list field", id))?;
 
-    let texts: Vec<&str> = list
-        .iter()
-        .map(|v| {
-            v.as_str().ok_or_else(|| {
-                Diagnostic::new(
-                    DiagnosticCode::E0817PathTypeMismatch,
-                    "Expected string items in list",
-                    id,
-                )
+    let texts: Vec<&str> = match item_rule.kind {
+        NestedNodeKind::Scalar => list
+            .iter()
+            .map(|v| {
+                v.as_str().ok_or_else(|| {
+                    Diagnostic::new(
+                        DiagnosticCode::E0817PathTypeMismatch,
+                        "Expected string items in list",
+                        id,
+                    )
+                })
             })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()?,
+        NestedNodeKind::Object => {
+            let text_key = node
+                .text_key
+                .ok_or_else(|| type_mismatch("Expected text_key for object list", id))?;
+            list.iter()
+                .map(|v| status_list_text(v, text_key, id))
+                .collect::<Result<Vec<_>, _>>()?
+        }
+        NestedNodeKind::List => {
+            return Err(type_mismatch("Expected scalar or object items in list", id).into());
+        }
+    };
 
     let indices = resolve(&texts)?;
     let mut sorted = indices;
@@ -890,14 +796,22 @@ where
     let mut removed = Vec::with_capacity(sorted.len());
     for idx in sorted {
         let val = list.remove(idx);
-        removed.push(val.as_str().unwrap_or_default().to_string());
+        let text = match item_rule.kind {
+            NestedNodeKind::Scalar => val.as_str().unwrap_or_default().to_string(),
+            NestedNodeKind::Object => {
+                let text_key = node
+                    .text_key
+                    .ok_or_else(|| type_mismatch("Expected text_key for object list", id))?;
+                status_list_text(&val, text_key, id)?.to_string()
+            }
+            NestedNodeKind::List => unreachable!("guarded above"),
+        };
+        removed.push(text);
     }
     removed.reverse();
     Ok(removed)
 }
 
-/// REMOVE an entire item from the root array by index: `root[i]`.
-/// Returns a display text for the removed item.
 pub fn remove_nested_root_item(
     artifact: ArtifactType,
     doc: &mut Value,
@@ -906,12 +820,18 @@ pub fn remove_nested_root_item(
 ) -> anyhow::Result<String> {
     let root_name = &fp.segments[0].name;
     let rule = resolve_nested_root(artifact, root_name, id)?;
-    let arr = root_array_mut(doc, rule, id)?;
+    if rule.node.kind != NestedNodeKind::List {
+        return Err(type_mismatch("Expected list root", id).into());
+    }
+    let root_value = ensure_node_path_mut(doc, rule.content_path, rule.node, id)?;
+    let arr = root_value
+        .as_array_mut()
+        .ok_or_else(|| type_mismatch("Expected array at root path", id))?;
     let root_idx = path::require_index(&fp.segments[0], arr.len())?;
     let removed = arr.remove(root_idx);
 
-    // Extract display text using SSOT text_key, falling back to bare string items
     let text = rule
+        .node
         .text_key
         .and_then(|key| removed.get(key).and_then(Value::as_str))
         .or_else(|| removed.as_str())
@@ -920,32 +840,377 @@ pub fn remove_nested_root_item(
     Ok(text)
 }
 
-/// Render all fields of a nested object item for display.
-fn render_nested_item(item: &Value, rule: &NestedRootRule, _id: &str) -> anyhow::Result<String> {
-    let mut lines = Vec::new();
-    if let Some(obj) = item.as_object() {
-        for field in rule.fields {
-            if let Some(val) = obj.get(field.name) {
-                match field.kind {
-                    FieldKind::Scalar => {
-                        lines.push(format!("{}: {}", field.name, render_scalar(Some(val))));
-                    }
-                    FieldKind::List => {
-                        if let Some(arr) = val.as_array() {
-                            let items: Vec<&str> = arr.iter().filter_map(Value::as_str).collect();
-                            lines.push(format!("{}: {}", field.name, items.join(", ")));
-                        }
-                    }
-                }
-            }
+fn descend_get<'a>(
+    node: &'static NestedNodeRule,
+    value: Option<&'a Value>,
+    root_segment: &super::path::PathSegment,
+    rest: &[super::path::PathSegment],
+    verb: Verb,
+    id: &str,
+) -> anyhow::Result<(&'static NestedNodeRule, Option<&'a Value>)> {
+    let root_path = format_segment(root_segment);
+    let (node, value) = apply_optional_index(
+        node,
+        value,
+        root_segment.index,
+        id,
+        &root_path,
+        &root_segment.name,
+    )?;
+    descend_get_rest(node, value, rest, verb, id, &root_path)
+}
+
+fn descend_get_rest<'a>(
+    node: &'static NestedNodeRule,
+    value: Option<&'a Value>,
+    rest: &[super::path::PathSegment],
+    verb: Verb,
+    id: &str,
+    current_path: &str,
+) -> anyhow::Result<(&'static NestedNodeRule, Option<&'a Value>)> {
+    if rest.is_empty() {
+        if !node.verbs.contains(&verb.as_str()) {
+            return Err(Diagnostic::new(
+                DiagnosticCode::E0817PathTypeMismatch,
+                format!("Path does not support verb '{}'", verb.as_str()),
+                id,
+            )
+            .into());
         }
-    } else if let Some(s) = item.as_str() {
-        // Simple string items (e.g., notes)
-        lines.push(s.to_string());
+        return Ok((node, value));
+    }
+    let seg = &rest[0];
+    if node.kind != NestedNodeKind::Object {
+        return Err(type_mismatch(
+            &format!(
+                "Cannot descend into non-object path '{}'",
+                append_segment(current_path, seg)
+            ),
+            id,
+        )
+        .into());
+    }
+    let child = node
+        .fields
+        .iter()
+        .find(|field| field.name == seg.name)
+        .ok_or_else(|| {
+            Diagnostic::new(
+                DiagnosticCode::E0815PathFieldNotFound,
+                format!("Unknown nested field '{}'", seg.name),
+                id,
+            )
+        })?;
+    let child_value = value.and_then(|value| value.get(seg.name.as_str()));
+    let next_path = append_segment(current_path, seg);
+    let (child_node, child_value) = apply_optional_index(
+        child.node,
+        child_value,
+        seg.index,
+        id,
+        &next_path,
+        &seg.name,
+    )?;
+    descend_get_rest(child_node, child_value, &rest[1..], verb, id, &next_path)
+}
+
+fn apply_optional_index<'a>(
+    node: &'static NestedNodeRule,
+    value: Option<&'a Value>,
+    index: Option<i32>,
+    id: &str,
+    path: &str,
+    field_name: &str,
+) -> anyhow::Result<(&'static NestedNodeRule, Option<&'a Value>)> {
+    let Some(index) = index else {
+        return Ok((node, value));
+    };
+    if node.kind != NestedNodeKind::List {
+        return Err(type_mismatch(
+            &format!("Cannot index into non-list field '{field_name}' at '{path}'"),
+            id,
+        )
+        .into());
+    }
+    let item = node
+        .item
+        .ok_or_else(|| type_mismatch("List node missing item rule", id))?;
+    let selected = match value.and_then(Value::as_array) {
+        Some(items) => Some(&items[path::resolve_index(index, items.len())?]),
+        None => None,
+    };
+    Ok((item, selected))
+}
+
+fn descend_mut<'a>(
+    node: &'static NestedNodeRule,
+    value: &'a mut Value,
+    root_segment: &super::path::PathSegment,
+    rest: &[super::path::PathSegment],
+    verb: Verb,
+    id: &str,
+) -> anyhow::Result<(&'static NestedNodeRule, &'a mut Value)> {
+    let root_path = format_segment(root_segment);
+    let (node, value) = apply_optional_index_mut(
+        node,
+        value,
+        root_segment.index,
+        id,
+        &root_path,
+        &root_segment.name,
+    )?;
+    descend_mut_rest(node, value, rest, verb, id, &root_path)
+}
+
+fn descend_mut_rest<'a>(
+    node: &'static NestedNodeRule,
+    value: &'a mut Value,
+    rest: &[super::path::PathSegment],
+    verb: Verb,
+    id: &str,
+    current_path: &str,
+) -> anyhow::Result<(&'static NestedNodeRule, &'a mut Value)> {
+    if rest.is_empty() {
+        if !node.verbs.contains(&verb.as_str()) {
+            return Err(Diagnostic::new(
+                DiagnosticCode::E0817PathTypeMismatch,
+                format!("Path does not support verb '{}'", verb.as_str()),
+                id,
+            )
+            .into());
+        }
+        return Ok((node, value));
+    }
+    let seg = &rest[0];
+    if node.kind != NestedNodeKind::Object {
+        return Err(type_mismatch(
+            &format!(
+                "Cannot descend into non-object path '{}'",
+                append_segment(current_path, seg)
+            ),
+            id,
+        )
+        .into());
+    }
+    let child = node
+        .fields
+        .iter()
+        .find(|field| field.name == seg.name)
+        .ok_or_else(|| {
+            Diagnostic::new(
+                DiagnosticCode::E0815PathFieldNotFound,
+                format!("Unknown nested field '{}'", seg.name),
+                id,
+            )
+        })?;
+    let obj = value
+        .as_object_mut()
+        .ok_or_else(|| type_mismatch("Expected object value", id))?;
+    let child_value = obj
+        .entry(seg.name.clone())
+        .or_insert_with(|| default_value_for_node(child.node));
+    let next_path = append_segment(current_path, seg);
+    let (child_node, child_value) = apply_optional_index_mut(
+        child.node,
+        child_value,
+        seg.index,
+        id,
+        &next_path,
+        &seg.name,
+    )?;
+    descend_mut_rest(child_node, child_value, &rest[1..], verb, id, &next_path)
+}
+
+fn apply_optional_index_mut<'a>(
+    node: &'static NestedNodeRule,
+    value: &'a mut Value,
+    index: Option<i32>,
+    id: &str,
+    path: &str,
+    field_name: &str,
+) -> anyhow::Result<(&'static NestedNodeRule, &'a mut Value)> {
+    let Some(index) = index else {
+        return Ok((node, value));
+    };
+    if node.kind != NestedNodeKind::List {
+        return Err(type_mismatch(
+            &format!("Cannot index into non-list field '{field_name}' at '{path}'"),
+            id,
+        )
+        .into());
+    }
+    let arr = value
+        .as_array_mut()
+        .ok_or_else(|| type_mismatch("Expected array value", id))?;
+    let resolved = path::resolve_index(index, arr.len())?;
+    let item = node
+        .item
+        .ok_or_else(|| type_mismatch("List node missing item rule", id))?;
+    Ok((item, &mut arr[resolved]))
+}
+
+fn ensure_node_path_mut<'a>(
+    doc: &'a mut Value,
+    path: &[&str],
+    node: &'static NestedNodeRule,
+    id: &str,
+) -> anyhow::Result<&'a mut Value> {
+    let mut cur = doc;
+    for (idx, key) in path.iter().enumerate() {
+        let is_leaf = idx + 1 == path.len();
+        let obj = cur.as_object_mut().ok_or_else(|| {
+            Diagnostic::new(
+                DiagnosticCode::E0817PathTypeMismatch,
+                format!("Cannot resolve field path '{}'", path.join(".")),
+                id,
+            )
+        })?;
+        if !obj.contains_key(*key) {
+            obj.insert(
+                (*key).to_string(),
+                if is_leaf {
+                    default_value_for_node(node)
+                } else {
+                    Value::Object(serde_json::Map::new())
+                },
+            );
+        }
+        cur = obj.get_mut(*key).expect("inserted above");
+    }
+    Ok(cur)
+}
+
+fn default_value_for_node(node: &NestedNodeRule) -> Value {
+    match node.kind {
+        NestedNodeKind::Scalar => Value::Null,
+        NestedNodeKind::Object => Value::Object(serde_json::Map::new()),
+        NestedNodeKind::List => Value::Array(Vec::new()),
+    }
+}
+
+fn render_nested_node(
+    node: &'static NestedNodeRule,
+    value: Option<&Value>,
+    id: &str,
+) -> anyhow::Result<String> {
+    match node.kind {
+        NestedNodeKind::Scalar => Ok(render_scalar(value)),
+        NestedNodeKind::List => render_nested_list(node, value, id),
+        NestedNodeKind::Object => render_nested_object(node, value, id),
+    }
+}
+
+fn render_nested_list(
+    node: &'static NestedNodeRule,
+    value: Option<&Value>,
+    id: &str,
+) -> anyhow::Result<String> {
+    let Some(value) = value else {
+        return Ok(String::new());
+    };
+    let arr = value
+        .as_array()
+        .ok_or_else(|| type_mismatch("Expected array value", id))?;
+    let item = node
+        .item
+        .ok_or_else(|| type_mismatch("List node missing item rule", id))?;
+    if item.kind == NestedNodeKind::Scalar {
+        let rendered: Vec<String> = arr.iter().map(|item| render_scalar(Some(item))).collect();
+        return Ok(rendered.join("\n"));
+    }
+    let mut rendered = Vec::new();
+    for item_value in arr {
+        rendered.push(render_nested_node(item, Some(item_value), id)?);
+    }
+    Ok(rendered.join("\n\n"))
+}
+
+fn render_nested_object(
+    node: &'static NestedNodeRule,
+    value: Option<&Value>,
+    id: &str,
+) -> anyhow::Result<String> {
+    let Some(value) = value else {
+        return Ok(String::new());
+    };
+    let obj = value
+        .as_object()
+        .ok_or_else(|| type_mismatch("Expected object value", id))?;
+    let mut lines = Vec::new();
+    for field in node.fields {
+        if let Some(field_value) = obj.get(field.name) {
+            let rendered = if field.node.kind == NestedNodeKind::List
+                && field
+                    .node
+                    .item
+                    .is_some_and(|item| item.kind == NestedNodeKind::Scalar)
+            {
+                let items = field_value
+                    .as_array()
+                    .ok_or_else(|| type_mismatch("Expected array value", id))?;
+                items
+                    .iter()
+                    .map(|item| render_scalar(Some(item)))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            } else {
+                render_nested_node(field.node, Some(field_value), id)?
+            };
+            lines.push(format!("{}: {}", field.name, rendered));
+        }
     }
     Ok(lines.join("\n"))
 }
 
+fn apply_nested_scalar_set(
+    slot: &mut Value,
+    mode: Option<NestedScalarMode>,
+    value: &str,
+    id: &str,
+) -> anyhow::Result<()> {
+    match mode.unwrap_or(NestedScalarMode::String) {
+        NestedScalarMode::String => *slot = Value::String(value.to_string()),
+        NestedScalarMode::OptionalString { empty_as_null } => {
+            if empty_as_null && value.is_empty() {
+                *slot = Value::Null;
+            } else {
+                *slot = Value::String(value.to_string());
+            }
+        }
+        NestedScalarMode::Integer => {
+            let n: i64 = value
+                .parse()
+                .map_err(|_| anyhow::anyhow!("Invalid integer value for {}: {value}", id))?;
+            *slot = Value::Number(serde_json::Number::from(n));
+        }
+        NestedScalarMode::Enum {
+            allowed,
+            invalid_msg,
+            code,
+        } => {
+            if !allowed.contains(&value) {
+                if let Some(code) = code {
+                    return Err(Diagnostic::new(code, format!("{invalid_msg}: {value}"), id).into());
+                }
+                return Err(anyhow::anyhow!("{invalid_msg}: {value}"));
+            }
+            *slot = Value::String(value.to_string());
+        }
+    }
+    Ok(())
+}
+
 fn type_mismatch(msg: &str, id: &str) -> Diagnostic {
     Diagnostic::new(DiagnosticCode::E0817PathTypeMismatch, msg, id)
+}
+
+fn format_segment(seg: &super::path::PathSegment) -> String {
+    match seg.index {
+        Some(idx) => format!("{}[{idx}]", seg.name),
+        None => seg.name.clone(),
+    }
+}
+
+fn append_segment(prefix: &str, seg: &super::path::PathSegment) -> String {
+    format!("{prefix}.{}", format_segment(seg))
 }

--- a/src/cmd/edit/runtime.rs
+++ b/src/cmd/edit/runtime.rs
@@ -474,9 +474,13 @@ fn apply_set(doc: &mut Value, spec: SimpleSetSpec, value: &str, id: &str) -> any
     match spec.mode {
         SetMode::String => *slot = Value::String(value.to_string()),
         SetMode::Integer => {
-            let n: i64 = value
-                .parse()
-                .map_err(|_| anyhow::anyhow!("Invalid integer value for {}: {value}", id))?;
+            let n: i64 = value.parse().map_err(|_| {
+                Diagnostic::new(
+                    DiagnosticCode::E0820InvalidFieldValue,
+                    format!("Invalid integer value for {}: {value}", id),
+                    id,
+                )
+            })?;
             *slot = Value::Number(serde_json::Number::from(n));
         }
         SetMode::OptionalString { empty_as_null } => {
@@ -495,7 +499,12 @@ fn apply_set(doc: &mut Value, spec: SimpleSetSpec, value: &str, id: &str) -> any
                 if let Some(code) = code {
                     return Err(Diagnostic::new(code, format!("{invalid_msg}: {value}"), id).into());
                 }
-                return Err(anyhow::anyhow!("{invalid_msg}: {value}"));
+                return Err(Diagnostic::new(
+                    DiagnosticCode::E0820InvalidFieldValue,
+                    format!("{invalid_msg}: {value}"),
+                    id,
+                )
+                .into());
             }
             *slot = Value::String(value.to_string());
         }
@@ -1178,9 +1187,13 @@ fn apply_nested_scalar_set(
             }
         }
         NestedScalarMode::Integer => {
-            let n: i64 = value
-                .parse()
-                .map_err(|_| anyhow::anyhow!("Invalid integer value for {}: {value}", id))?;
+            let n: i64 = value.parse().map_err(|_| {
+                Diagnostic::new(
+                    DiagnosticCode::E0820InvalidFieldValue,
+                    format!("Invalid integer value for {}: {value}", id),
+                    id,
+                )
+            })?;
             *slot = Value::Number(serde_json::Number::from(n));
         }
         NestedScalarMode::Enum {
@@ -1192,7 +1205,12 @@ fn apply_nested_scalar_set(
                 if let Some(code) = code {
                     return Err(Diagnostic::new(code, format!("{invalid_msg}: {value}"), id).into());
                 }
-                return Err(anyhow::anyhow!("{invalid_msg}: {value}"));
+                return Err(Diagnostic::new(
+                    DiagnosticCode::E0820InvalidFieldValue,
+                    format!("{invalid_msg}: {value}"),
+                    id,
+                )
+                .into());
             }
             *slot = Value::String(value.to_string());
         }

--- a/src/cmd/edit/runtime.rs
+++ b/src/cmd/edit/runtime.rs
@@ -1232,3 +1232,126 @@ fn format_segment(seg: &super::path::PathSegment) -> String {
 fn append_segment(prefix: &str, seg: &super::path::PathSegment) -> String {
     format!("{prefix}.{}", format_segment(seg))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn path(input: &str) -> FieldPath {
+        path::parse_field_path(input)
+            .expect("valid path")
+            .collapse_legacy_prefixes()
+    }
+
+    #[test]
+    fn test_add_nested_object_list_value_deduplicates_by_text() {
+        let mut doc = json!({
+            "content": {
+                "consequences": {
+                    "negative": [
+                        { "text": "Higher memory use", "mitigations": [] }
+                    ]
+                }
+            }
+        });
+
+        add_nested_list_value(
+            ArtifactType::Adr,
+            &mut doc,
+            &path("consequences.negative"),
+            "Higher memory use",
+            "ADR-0001",
+        )
+        .unwrap();
+        add_nested_list_value(
+            ArtifactType::Adr,
+            &mut doc,
+            &path("consequences.negative"),
+            "Slower warmup",
+            "ADR-0001",
+        )
+        .unwrap();
+
+        let negatives = doc["content"]["consequences"]["negative"]
+            .as_array()
+            .unwrap();
+        assert_eq!(negatives.len(), 2);
+        assert_eq!(negatives[1]["text"], "Slower warmup");
+    }
+
+    #[test]
+    fn test_set_nested_field_rejects_list_path_without_index() {
+        let mut doc = json!({
+            "content": {
+                "consequences": {
+                    "negative": []
+                }
+            }
+        });
+
+        let err = set_nested_field(
+            ArtifactType::Adr,
+            &mut doc,
+            &path("consequences.negative"),
+            "oops",
+            "ADR-0001",
+        )
+        .expect_err("list path should reject set");
+
+        let diag = err.downcast_ref::<Diagnostic>().expect("diagnostic");
+        assert_eq!(diag.code, DiagnosticCode::E0817PathTypeMismatch);
+    }
+
+    #[test]
+    fn test_remove_nested_root_item_returns_removed_text() {
+        let mut doc = json!({
+            "content": {
+                "alternatives": [
+                    { "text": "Option A", "pros": [], "cons": [] },
+                    { "text": "Option B", "pros": [], "cons": [] }
+                ]
+            }
+        });
+
+        let removed = remove_nested_root_item(
+            ArtifactType::Adr,
+            &mut doc,
+            &path("alternatives[0]"),
+            "ADR-0001",
+        )
+        .unwrap();
+
+        assert_eq!(removed, "Option A");
+        let alternatives = doc["content"]["alternatives"].as_array().unwrap();
+        assert_eq!(alternatives.len(), 1);
+        assert_eq!(alternatives[0]["text"], "Option B");
+    }
+
+    #[test]
+    fn test_get_nested_field_renders_object_item_with_scalar_lists() {
+        let doc = json!({
+            "content": {
+                "consequences": {
+                    "negative": [
+                        {
+                            "text": "Higher memory use",
+                            "mitigations": ["Cap cache size", "Reduce retention"]
+                        }
+                    ]
+                }
+            }
+        });
+
+        let rendered = get_nested_field(
+            ArtifactType::Adr,
+            &doc,
+            &path("consequences.negative[0]"),
+            "ADR-0001",
+        )
+        .unwrap();
+
+        assert!(rendered.contains("text: Higher memory use"));
+        assert!(rendered.contains("mitigations: Cap cache size, Reduce retention"));
+    }
+}

--- a/src/cmd/guard.rs
+++ b/src/cmd/guard.rs
@@ -2,7 +2,7 @@
 
 use crate::OutputFormat;
 use crate::config::Config;
-use crate::diagnostic::Diagnostic;
+use crate::diagnostic::{Diagnostic, DiagnosticCode};
 use crate::model::{GuardCheck, GuardMeta, GuardSpec};
 use crate::parse::{load_guards, write_guard};
 use crate::ui;
@@ -19,17 +19,27 @@ pub fn new_guard(config: &Config, title: &str, op: WriteOp) -> anyhow::Result<Ve
     // Generate ID from title: slugify, uppercase, prefix with GUARD-
     let slug = slugify(title).to_uppercase().replace('_', "-");
     if slug.is_empty() || !slug.starts_with(|c: char| c.is_ascii_uppercase()) {
-        return Err(anyhow::anyhow!(
-            "Invalid guard title: must produce a slug starting with a letter (got \"{title}\")"
-        ));
+        return Err(Diagnostic::new(
+            DiagnosticCode::E1006GuardInvalidTitle,
+            format!(
+                "Invalid guard title: must produce a slug starting with a letter (got \"{title}\")"
+            ),
+            title,
+        )
+        .into());
     }
     let id = format!("GUARD-{slug}");
 
     // Check for duplicate
     if !op.is_preview() {
-        let existing = load_guards(config).map_err(|d| anyhow::anyhow!("{}", d.message))?;
+        let existing = load_guards(config).map_err(anyhow::Error::from)?;
         if existing.iter().any(|g| g.spec.govctl.id == id) {
-            return Err(anyhow::anyhow!("Guard already exists: {id}"));
+            return Err(Diagnostic::new(
+                DiagnosticCode::E1003GuardDuplicate,
+                format!("Guard already exists: {id}"),
+                &id,
+            )
+            .into());
         }
     }
 
@@ -72,11 +82,17 @@ pub fn delete_guard(
     _force: bool,
     op: WriteOp,
 ) -> anyhow::Result<Vec<Diagnostic>> {
-    let guards = load_guards(config).map_err(|d| anyhow::anyhow!("{}", d.message))?;
+    let guards = load_guards(config).map_err(anyhow::Error::from)?;
     let guard = guards
         .iter()
         .find(|g| g.spec.govctl.id == id)
-        .ok_or_else(|| anyhow::anyhow!("Guard not found: {id}"))?;
+        .ok_or_else(|| {
+            Diagnostic::new(
+                DiagnosticCode::E1002GuardNotFound,
+                format!("Guard not found: {id}"),
+                id,
+            )
+        })?;
 
     // Safety checks always run — --force only skips confirmation, not reference checks
     let mut blockers = Vec::new();
@@ -103,15 +119,20 @@ pub fn delete_guard(
     }
 
     if !blockers.is_empty() {
-        return Err(anyhow::anyhow!(
-            "Cannot delete guard '{}': still referenced:\n{}",
+        return Err(Diagnostic::new(
+            DiagnosticCode::E1007GuardStillReferenced,
+            format!(
+                "Cannot delete guard '{}': still referenced:\n{}",
+                id,
+                blockers
+                    .iter()
+                    .map(|b| format!("  - {b}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ),
             id,
-            blockers
-                .iter()
-                .map(|b| format!("  - {b}"))
-                .collect::<Vec<_>>()
-                .join("\n")
-        ));
+        )
+        .into());
     }
 
     let path = guard.path.clone();
@@ -130,11 +151,17 @@ pub fn show_guard(
     id: &str,
     output: OutputFormat,
 ) -> anyhow::Result<Vec<Diagnostic>> {
-    let guards = load_guards(config).map_err(|d| anyhow::anyhow!("{}", d.message))?;
+    let guards = load_guards(config).map_err(anyhow::Error::from)?;
     let guard = guards
         .iter()
         .find(|g| g.spec.govctl.id == id)
-        .ok_or_else(|| anyhow::anyhow!("Guard not found: {id}"))?;
+        .ok_or_else(|| {
+            Diagnostic::new(
+                DiagnosticCode::E1002GuardNotFound,
+                format!("Guard not found: {id}"),
+                id,
+            )
+        })?;
 
     match output {
         OutputFormat::Json => {

--- a/src/cmd/lifecycle.rs
+++ b/src/cmd/lifecycle.rs
@@ -554,11 +554,11 @@ pub fn cut_release(
             format!("Invalid semver version: {version}"),
             &releases_path_str,
         );
-        anyhow::anyhow!("{}", diag)
+        anyhow::Error::from(diag)
     })?;
 
     // Load existing releases
-    let mut releases_file = load_releases(config).map_err(|d| anyhow::anyhow!("{}", d))?;
+    let mut releases_file = load_releases(config).map_err(anyhow::Error::from)?;
 
     // Check for duplicate version
     if releases_file.releases.iter().any(|r| r.version == version) {
@@ -567,7 +567,7 @@ pub fn cut_release(
             format!("Release {version} already exists"),
             &releases_path_str,
         );
-        anyhow::bail!("{}", diag);
+        return Err(diag.into());
     }
 
     // Get all work item IDs already in releases
@@ -578,7 +578,7 @@ pub fn cut_release(
         .collect();
 
     // Load all done work items
-    let work_items = load_work_items(config).map_err(|d| anyhow::anyhow!("{}", d))?;
+    let work_items = load_work_items(config).map_err(anyhow::Error::from)?;
     let unreleased: Vec<_> = work_items
         .iter()
         .filter(|w| w.spec.govctl.status == WorkItemStatus::Done)
@@ -591,7 +591,7 @@ pub fn cut_release(
             "No unreleased work items to include in release",
             &releases_path_str,
         );
-        anyhow::bail!("{}", diag);
+        return Err(diag.into());
     }
 
     // Create new release
@@ -612,7 +612,7 @@ pub fn cut_release(
     releases_file.releases.insert(0, release);
 
     // Write releases file
-    write_releases(config, &releases_file, op).map_err(|d| anyhow::anyhow!("{}", d))?;
+    write_releases(config, &releases_file, op).map_err(anyhow::Error::from)?;
 
     if !op.is_preview() {
         ui::release_created(version, &release_date, refs.len());

--- a/src/cmd/lifecycle.rs
+++ b/src/cmd/lifecycle.rs
@@ -269,6 +269,18 @@ pub fn accept_adr(config: &Config, adr_id: &str, op: WriteOp) -> anyhow::Result<
         .into());
     }
 
+    if entry.spec.content.selected_option.is_none() {
+        return Err(Diagnostic::new(
+            DiagnosticCode::E0301AdrSchemaInvalid,
+            format!(
+                "Accepted ADRs require content.selected_option before acceptance (hint: `govctl adr set {} selected_option \"...\"`)",
+                adr_id
+            ),
+            adr_id,
+        )
+        .into());
+    }
+
     edit::set_field_direct(config, adr_id, "status", "accepted", op)?;
 
     if !op.is_preview() {

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -65,8 +65,7 @@ pub fn list(
     output: OutputFormat,
 ) -> anyhow::Result<Vec<Diagnostic>> {
     if target == ListTarget::Guard {
-        let result =
-            load_guards_with_warnings(config).map_err(|d| anyhow::anyhow!("{}", d.message))?;
+        let result = load_guards_with_warnings(config).map_err(anyhow::Error::from)?;
         list_guards(&result.items, filter, limit, output);
         return Ok(result.warnings);
     }

--- a/src/cmd/migrate.rs
+++ b/src/cmd/migrate.rs
@@ -5,18 +5,23 @@
 
 use crate::config::Config;
 use crate::diagnostic::{Diagnostic, DiagnosticCode};
-use crate::model::{ClauseSpec, ClauseWire, ReleasesFile, RfcSpec, RfcWire};
+use crate::model::{
+    AdrConsequences, AdrContent, AdrMeta, AdrMigrationMeta, AdrMigrationState, AdrMigrationWarning,
+    AdrNegativeConsequence, AdrSpec, AdrStatus, Alternative, ClauseSpec, ClauseWire, ReleasesFile,
+    RfcSpec, RfcWire,
+};
 use crate::schema::{
     ARTIFACT_SCHEMA_TEMPLATES, ArtifactSchema, validate_toml_value, with_schema_header,
 };
 use crate::ui;
 use crate::write::{WriteOp, read_clause, read_rfc, write_file};
+use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Latest schema version. Bump when adding a new migration step.
-pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+pub const CURRENT_SCHEMA_VERSION: u32 = 3;
 
 // =============================================================================
 // Core types
@@ -38,12 +43,20 @@ struct MigrationStep {
 }
 
 /// All registered migrations, ordered by version.
-const MIGRATIONS: &[MigrationStep] = &[MigrationStep {
-    from: 1,
-    to: 2,
-    name: "structured wire format and schema headers",
-    plan_fn: plan_v1_to_v2,
-}];
+const MIGRATIONS: &[MigrationStep] = &[
+    MigrationStep {
+        from: 1,
+        to: 2,
+        name: "structured wire format and schema headers",
+        plan_fn: plan_v1_to_v2,
+    },
+    MigrationStep {
+        from: 2,
+        to: 3,
+        name: "adr chosen-option and consequences restructuring",
+        plan_fn: plan_v2_to_v3,
+    },
+];
 
 // =============================================================================
 // Public API
@@ -322,6 +335,356 @@ fn plan_v1_to_v2(config: &Config) -> anyhow::Result<Vec<FileOp>> {
     ops.extend(rewrite_ops);
 
     Ok(ops)
+}
+
+// =============================================================================
+// v2 -> v3: ADR chosen-option + structured consequences
+// =============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[derive(Default)]
+enum LegacyAlternativeStatus {
+    #[default]
+    Considered,
+    Rejected,
+    Accepted,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyAlternative {
+    text: String,
+    #[serde(default)]
+    status: LegacyAlternativeStatus,
+    #[serde(default)]
+    pros: Vec<String>,
+    #[serde(default)]
+    cons: Vec<String>,
+    #[serde(default)]
+    rejection_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyAdrContent {
+    context: String,
+    decision: String,
+    consequences: String,
+    #[serde(default)]
+    alternatives: Vec<LegacyAlternative>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyAdrMeta {
+    #[serde(default)]
+    schema: u32,
+    id: String,
+    title: String,
+    status: AdrStatus,
+    date: String,
+    #[serde(default)]
+    superseded_by: Option<String>,
+    #[serde(default)]
+    refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyAdrSpec {
+    govctl: LegacyAdrMeta,
+    content: LegacyAdrContent,
+}
+
+fn plan_v2_to_v3(config: &Config) -> anyhow::Result<Vec<FileOp>> {
+    let adr_dir = config.adr_dir();
+    if !adr_dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let mut ops = Vec::new();
+    let mut entries: Vec<PathBuf> = fs::read_dir(&adr_dir)?
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|ext| ext.to_str()) == Some("toml"))
+        .collect();
+    entries.sort();
+
+    for path in entries {
+        let content = fs::read_to_string(&path)?;
+        let raw: toml::Value = toml::from_str(&content).map_err(|e| {
+            Diagnostic::new(
+                DiagnosticCode::E0301AdrSchemaInvalid,
+                format!("Invalid ADR TOML during migration: {e}"),
+                config.display_path(&path).display().to_string(),
+            )
+        })?;
+
+        // Skip ADRs that already validate as v3.
+        let already_v3 = validate_toml_value(ArtifactSchema::Adr, config, &path, &raw).is_ok()
+            && raw
+                .get("content")
+                .and_then(|v| v.get("consequences"))
+                .and_then(toml::Value::as_table)
+                .is_some();
+        if already_v3 {
+            continue;
+        }
+
+        let legacy: LegacyAdrSpec = raw.clone().try_into().map_err(|e| {
+            Diagnostic::new(
+                DiagnosticCode::E0301AdrSchemaInvalid,
+                format!("Failed to deserialize legacy ADR during migration: {e}"),
+                config.display_path(&path).display().to_string(),
+            )
+        })?;
+
+        let migrated = migrate_legacy_adr(legacy);
+        let body = toml::to_string_pretty(&migrated)?;
+        let migrated_raw: toml::Value = toml::from_str(&body)?;
+        validate_toml_value(ArtifactSchema::Adr, config, &path, &migrated_raw)?;
+
+        ops.push(FileOp::Write {
+            path: path.clone(),
+            content: with_schema_header(ArtifactSchema::Adr, &body),
+        });
+    }
+
+    Ok(ops)
+}
+
+fn migrate_legacy_adr(legacy: LegacyAdrSpec) -> AdrSpec {
+    let mut decision = legacy.content.decision;
+    let mut consequences = parse_legacy_consequences(&legacy.content.consequences);
+    let mut alternatives = Vec::new();
+    let mut migration_warnings = Vec::new();
+    let mut selected_option = None;
+
+    let accepted: Vec<_> = legacy
+        .content
+        .alternatives
+        .iter()
+        .filter(|alt| matches!(alt.status, LegacyAlternativeStatus::Accepted))
+        .cloned()
+        .collect();
+
+    if accepted.len() == 1 {
+        let chosen = &accepted[0];
+        selected_option = Some(chosen.text.clone());
+        if !chosen.pros.is_empty() {
+            append_recovered_selected_pros(&mut decision, &chosen.pros);
+        }
+        for con in &chosen.cons {
+            consequences.negative.push(AdrNegativeConsequence {
+                text: con.clone(),
+                mitigations: vec![],
+            });
+        }
+    } else if accepted.len() > 1 {
+        migration_warnings.push(AdrMigrationWarning {
+            code: "ADR_MULTIPLE_ACCEPTED_OPTIONS".to_string(),
+            message: "Multiple accepted alternatives were found; the chosen option could not be resolved automatically.".to_string(),
+            path: Some("content.alternatives".to_string()),
+        });
+    } else if matches!(
+        legacy.govctl.status,
+        AdrStatus::Accepted | AdrStatus::Superseded
+    ) {
+        migration_warnings.push(AdrMigrationWarning {
+            code: "ADR_SELECTED_OPTION_UNRESOLVED".to_string(),
+            message: "Accepted or superseded ADR had no accepted alternative to migrate into selected_option.".to_string(),
+            path: Some("content.selected_option".to_string()),
+        });
+    }
+
+    for alt in legacy.content.alternatives {
+        match alt.status {
+            LegacyAlternativeStatus::Accepted => {
+                if accepted.len() > 1 {
+                    alternatives.push(Alternative {
+                        text: alt.text,
+                        pros: alt.pros,
+                        cons: alt.cons,
+                        rejection_reason: alt.rejection_reason,
+                    });
+                }
+            }
+            LegacyAlternativeStatus::Rejected => {
+                let rejection_reason = if alt.rejection_reason.is_some() {
+                    alt.rejection_reason
+                } else {
+                    migration_warnings.push(AdrMigrationWarning {
+                        code: "ADR_REJECTION_REASON_SYNTHETIC".to_string(),
+                        message: format!(
+                            "Alternative '{}' had no rejection_reason; a synthetic note was added during migration.",
+                            alt.text
+                        ),
+                        path: Some("content.alternatives".to_string()),
+                    });
+                    Some(
+                        "Not selected; exact rejection rationale was not recoverable during migration."
+                            .to_string(),
+                    )
+                };
+                alternatives.push(Alternative {
+                    text: alt.text,
+                    pros: alt.pros,
+                    cons: alt.cons,
+                    rejection_reason,
+                });
+            }
+            LegacyAlternativeStatus::Considered => {
+                let rejection_reason = if matches!(
+                    legacy.govctl.status,
+                    AdrStatus::Accepted | AdrStatus::Superseded
+                ) {
+                    migration_warnings.push(AdrMigrationWarning {
+                            code: "ADR_CONSIDERED_OPTION_SYNTHETIC_REJECTION".to_string(),
+                            message: format!(
+                                "Considered alternative '{}' was converted into a non-selected option with a synthetic rejection reason.",
+                                alt.text
+                            ),
+                            path: Some("content.alternatives".to_string()),
+                        });
+                    Some(
+                            "Not selected; exact rejection rationale was not recoverable during migration."
+                                .to_string(),
+                        )
+                } else {
+                    alt.rejection_reason
+                };
+                alternatives.push(Alternative {
+                    text: alt.text,
+                    pros: alt.pros,
+                    cons: alt.cons,
+                    rejection_reason,
+                });
+            }
+        }
+    }
+
+    let migration = if migration_warnings.is_empty() {
+        None
+    } else {
+        Some(AdrMigrationMeta {
+            state: AdrMigrationState::NeedsReview,
+            warnings: migration_warnings,
+        })
+    };
+
+    AdrSpec {
+        govctl: AdrMeta {
+            schema: legacy.govctl.schema,
+            id: legacy.govctl.id,
+            title: legacy.govctl.title,
+            status: legacy.govctl.status,
+            date: legacy.govctl.date,
+            superseded_by: legacy.govctl.superseded_by,
+            refs: legacy.govctl.refs,
+            migration,
+        },
+        content: AdrContent {
+            context: legacy.content.context,
+            decision,
+            selected_option,
+            consequences,
+            alternatives,
+        },
+    }
+}
+
+fn append_recovered_selected_pros(decision: &mut String, pros: &[String]) {
+    if pros.is_empty() {
+        return;
+    }
+
+    if !decision.ends_with('\n') {
+        decision.push('\n');
+    }
+    decision.push_str("\n### Recovered Selected-Option Advantages\n\n");
+    for pro in pros {
+        decision.push_str("- ");
+        decision.push_str(pro);
+        decision.push('\n');
+    }
+}
+
+fn parse_legacy_consequences(raw: &str) -> AdrConsequences {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Section {
+        Positive,
+        Negative,
+        Neutral,
+    }
+
+    let mut parsed = AdrConsequences::default();
+    let mut current = None;
+    let mut saw_heading = false;
+
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        match trimmed {
+            "### Positive" => {
+                current = Some(Section::Positive);
+                saw_heading = true;
+                continue;
+            }
+            "### Negative" => {
+                current = Some(Section::Negative);
+                saw_heading = true;
+                continue;
+            }
+            "### Neutral" => {
+                current = Some(Section::Neutral);
+                saw_heading = true;
+                continue;
+            }
+            _ => {}
+        }
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix("- ") {
+            match current {
+                Some(Section::Positive) => parsed.positive.push(rest.to_string()),
+                Some(Section::Neutral) => parsed.neutral.push(rest.to_string()),
+                Some(Section::Negative) => parsed.negative.push(AdrNegativeConsequence {
+                    text: rest.to_string(),
+                    mitigations: vec![],
+                }),
+                None => {}
+            }
+            continue;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix("Mitigation: ")
+            && let Some(last) = parsed.negative.last_mut()
+        {
+            last.mitigations.push(rest.to_string());
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("- Mitigation: ")
+            && let Some(last) = parsed.negative.last_mut()
+        {
+            last.mitigations.push(rest.to_string());
+            continue;
+        }
+
+        match current {
+            Some(Section::Positive) => parsed.positive.push(trimmed.to_string()),
+            Some(Section::Neutral) => parsed.neutral.push(trimmed.to_string()),
+            Some(Section::Negative) => parsed.negative.push(AdrNegativeConsequence {
+                text: trimmed.to_string(),
+                mitigations: vec![],
+            }),
+            None => {}
+        }
+    }
+
+    if !saw_heading && !raw.trim().is_empty() {
+        parsed.neutral.push(raw.trim().to_string());
+    }
+
+    parsed
 }
 
 fn plan_rfc_json_to_toml(

--- a/src/cmd/migrate.rs
+++ b/src/cmd/migrate.rs
@@ -541,18 +541,23 @@ fn migrate_legacy_adr(legacy: LegacyAdrSpec) -> AdrSpec {
                     legacy.govctl.status,
                     AdrStatus::Accepted | AdrStatus::Superseded
                 ) {
-                    migration_warnings.push(AdrMigrationWarning {
-                            code: "ADR_CONSIDERED_OPTION_SYNTHETIC_REJECTION".to_string(),
-                            message: format!(
-                                "Considered alternative '{}' was converted into a non-selected option with a synthetic rejection reason.",
-                                alt.text
-                            ),
-                            path: Some("content.alternatives".to_string()),
-                        });
-                    Some(
-                            "Not selected; exact rejection rationale was not recoverable during migration."
-                                .to_string(),
-                        )
+                    match alt.rejection_reason {
+                        Some(reason) if !reason.trim().is_empty() => Some(reason),
+                        _ => {
+                            migration_warnings.push(AdrMigrationWarning {
+                                code: "ADR_CONSIDERED_OPTION_SYNTHETIC_REJECTION".to_string(),
+                                message: format!(
+                                    "Considered alternative '{}' was converted into a non-selected option with a synthetic rejection reason.",
+                                    alt.text
+                                ),
+                                path: Some("content.alternatives".to_string()),
+                            });
+                            Some(
+                                "Not selected; exact rejection rationale was not recoverable during migration."
+                                    .to_string(),
+                            )
+                        }
+                    }
                 } else {
                     alt.rejection_reason
                 };
@@ -1244,6 +1249,34 @@ mod tests {
                 .warnings
                 .iter()
                 .any(|w| w.code == "ADR_REJECTION_REASON_SYNTHETIC")
+        );
+    }
+
+    #[test]
+    fn test_migrate_considered_option_preserves_existing_rejection_reason() {
+        let migrated = migrate_legacy_adr(legacy_spec(
+            AdrStatus::Accepted,
+            "",
+            vec![legacy_alternative(
+                "Option A",
+                LegacyAlternativeStatus::Considered,
+                &[],
+                &[],
+                Some("Recovered from release notes"),
+            )],
+        ));
+
+        assert_eq!(migrated.content.alternatives.len(), 1);
+        assert_eq!(
+            migrated.content.alternatives[0].rejection_reason.as_deref(),
+            Some("Recovered from release notes")
+        );
+        let migration = migrated.govctl.migration.expect("migration metadata");
+        assert!(
+            !migration
+                .warnings
+                .iter()
+                .any(|w| w.code == "ADR_CONSIDERED_OPTION_SYNTHETIC_REJECTION")
         );
     }
 }

--- a/src/cmd/migrate.rs
+++ b/src/cmd/migrate.rs
@@ -181,10 +181,15 @@ fn execute_ops(config: &Config, ops: &[FileOp]) -> anyhow::Result<()> {
     let backup_root = gov_root.join(".migrate-backup");
 
     if stage_root.exists() || backup_root.exists() {
-        return Err(anyhow::anyhow!(
-            "Migration staging directories already exist under {}",
-            config.display_path(gov_root).display()
-        ));
+        return Err(Diagnostic::new(
+            DiagnosticCode::E0504PathConflict,
+            format!(
+                "Migration staging directories already exist under {}",
+                config.display_path(gov_root).display()
+            ),
+            config.display_path(gov_root).display().to_string(),
+        )
+        .into());
     }
 
     fs::create_dir_all(&stage_root)?;
@@ -786,7 +791,13 @@ fn plan_rfc_json_to_toml(
             let file_name = Path::new(clause_path)
                 .file_name()
                 .and_then(|n| n.to_str())
-                .ok_or_else(|| anyhow::anyhow!("Invalid clause path: {clause_path}"))?;
+                .ok_or_else(|| {
+                    Diagnostic::new(
+                        DiagnosticCode::E0204ClausePathInvalid,
+                        format!("Invalid clause path: {clause_path}"),
+                        config.display_path(&rfc_json).display().to_string(),
+                    )
+                })?;
             if !clause_map.contains_key(file_name) {
                 return Err(Diagnostic::new(
                     DiagnosticCode::E0202ClauseNotFound,

--- a/src/cmd/migrate.rs
+++ b/src/cmd/migrate.rs
@@ -15,6 +15,7 @@ use crate::schema::{
 };
 use crate::ui;
 use crate::write::{WriteOp, read_clause, read_rfc, write_file};
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::fs;
@@ -619,74 +620,279 @@ fn parse_legacy_consequences(raw: &str) -> AdrConsequences {
         Neutral,
     }
 
-    let mut parsed = AdrConsequences::default();
-    let mut current = None;
-    let mut saw_heading = false;
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum EntryKind {
+        ListItem,
+        BlockGroup,
+    }
 
-    for line in raw.lines() {
-        let trimmed = line.trim();
-        match trimmed {
-            "### Positive" => {
-                current = Some(Section::Positive);
-                saw_heading = true;
-                continue;
-            }
-            "### Negative" => {
-                current = Some(Section::Negative);
-                saw_heading = true;
-                continue;
-            }
-            "### Neutral" => {
-                current = Some(Section::Neutral);
-                saw_heading = true;
-                continue;
-            }
-            _ => {}
-        }
+    #[derive(Clone, Copy)]
+    struct EntryRange {
+        start: usize,
+        end: usize,
+        kind: EntryKind,
+    }
 
-        if trimmed.is_empty() {
-            continue;
-        }
+    fn markdown_options() -> Options {
+        let mut options = Options::empty();
+        options.insert(Options::ENABLE_TABLES);
+        options.insert(Options::ENABLE_STRIKETHROUGH);
+        options.insert(Options::ENABLE_TASKLISTS);
+        options
+    }
 
-        if let Some(rest) = trimmed.strip_prefix("Mitigation: ")
-            && let Some(last) = parsed.negative.last_mut()
-        {
-            last.mitigations.push(rest.to_string());
-            continue;
-        }
-        if let Some(rest) = trimmed.strip_prefix("- Mitigation: ")
-            && let Some(last) = parsed.negative.last_mut()
-        {
-            last.mitigations.push(rest.to_string());
-            continue;
-        }
-
-        if let Some(rest) = trimmed.strip_prefix("- ") {
-            match current {
-                Some(Section::Positive) => parsed.positive.push(rest.to_string()),
-                Some(Section::Neutral) => parsed.neutral.push(rest.to_string()),
-                Some(Section::Negative) => parsed.negative.push(AdrNegativeConsequence {
-                    text: rest.to_string(),
-                    mitigations: vec![],
-                }),
-                None => {}
-            }
-            continue;
-        }
-
-        match current {
-            Some(Section::Positive) => parsed.positive.push(trimmed.to_string()),
-            Some(Section::Neutral) => parsed.neutral.push(trimmed.to_string()),
-            Some(Section::Negative) => parsed.negative.push(AdrNegativeConsequence {
-                text: trimmed.to_string(),
-                mitigations: vec![],
-            }),
-            None => {}
+    fn section_from_heading(text: &str) -> Option<Section> {
+        match text.trim() {
+            "Positive" => Some(Section::Positive),
+            "Negative" => Some(Section::Negative),
+            "Neutral" => Some(Section::Neutral),
+            _ => None,
         }
     }
 
-    if !saw_heading && !raw.trim().is_empty() {
-        parsed.neutral.push(raw.trim().to_string());
+    fn legacy_sections(raw: &str) -> Vec<(Section, &str)> {
+        let mut sections = Vec::new();
+        let mut current: Option<(Section, usize)> = None;
+        let mut heading_level: Option<HeadingLevel> = None;
+        let mut heading_start = 0usize;
+        let mut heading_text = String::new();
+
+        for (event, range) in Parser::new_ext(raw, markdown_options()).into_offset_iter() {
+            match event {
+                Event::Start(Tag::Heading { level, .. }) => {
+                    heading_level = Some(level);
+                    heading_start = range.start;
+                    heading_text.clear();
+                }
+                Event::Text(text) | Event::Code(text)
+                    if heading_level == Some(HeadingLevel::H3) =>
+                {
+                    heading_text.push_str(&text);
+                }
+                Event::End(TagEnd::Heading(level)) if Some(level) == heading_level => {
+                    if level == HeadingLevel::H3
+                        && let Some(section) = section_from_heading(&heading_text)
+                    {
+                        if let Some((previous, start)) = current.take() {
+                            let body = raw[start..heading_start].trim();
+                            if !body.is_empty() {
+                                sections.push((previous, body));
+                            }
+                        }
+                        current = Some((section, range.end));
+                    }
+                    heading_level = None;
+                    heading_text.clear();
+                }
+                _ => {}
+            }
+        }
+
+        if let Some((section, start)) = current {
+            let body = raw[start..].trim();
+            if !body.is_empty() {
+                sections.push((section, body));
+            }
+        }
+
+        sections
+    }
+
+    fn strip_list_marker(item: &str) -> String {
+        let trimmed = item.trim();
+        for prefix in ["- ", "* ", "+ "] {
+            if let Some(rest) = trimmed.strip_prefix(prefix) {
+                return rest.trim().to_string();
+            }
+        }
+        if let Some((number, rest)) = trimmed.split_once(". ")
+            && number.chars().all(|c| c.is_ascii_digit())
+        {
+            return rest.trim().to_string();
+        }
+        trimmed.to_string()
+    }
+
+    fn collect_markdown_entries(section_markdown: &str) -> Vec<(EntryKind, String)> {
+        fn is_root_block_start(tag: &Tag<'_>) -> bool {
+            matches!(
+                tag,
+                Tag::Paragraph
+                    | Tag::Heading { .. }
+                    | Tag::CodeBlock(_)
+                    | Tag::BlockQuote(_)
+                    | Tag::HtmlBlock
+                    | Tag::Table(_)
+                    | Tag::FootnoteDefinition(_)
+            )
+        }
+
+        let mut entries = Vec::new();
+        let mut current_group: Option<EntryRange> = None;
+        let mut root_list_depth = 0usize;
+        let mut top_level_item_start: Option<usize> = None;
+        let mut block_stack: Vec<(Tag<'_>, bool, bool)> = Vec::new();
+
+        for (event, range) in
+            Parser::new_ext(section_markdown, markdown_options()).into_offset_iter()
+        {
+            match event {
+                Event::Start(tag) => {
+                    let stack_depth = block_stack.len();
+                    let is_top_level_list = matches!(&tag, Tag::List(_)) && stack_depth == 0;
+                    if is_top_level_list {
+                        if let Some(group) = current_group.take() {
+                            entries.push(group);
+                        }
+                        root_list_depth += 1;
+                    }
+
+                    let is_top_level_item =
+                        matches!(&tag, Tag::Item) && root_list_depth == 1 && stack_depth == 1;
+                    if is_top_level_item {
+                        if let Some(group) = current_group.take() {
+                            entries.push(group);
+                        }
+                        top_level_item_start = Some(range.start);
+                    }
+
+                    let is_root_block =
+                        root_list_depth == 0 && stack_depth == 0 && is_root_block_start(&tag);
+                    if is_root_block {
+                        match current_group.as_mut() {
+                            Some(group) => group.end = range.end,
+                            None => {
+                                current_group = Some(EntryRange {
+                                    start: range.start,
+                                    end: range.end,
+                                    kind: EntryKind::BlockGroup,
+                                });
+                            }
+                        }
+                    }
+
+                    block_stack.push((tag, is_root_block, is_top_level_item));
+                }
+                Event::End(end_tag) => {
+                    let Some((start_tag, was_root_block, was_top_level_item)) = block_stack.pop()
+                    else {
+                        continue;
+                    };
+
+                    if was_root_block && let Some(group) = current_group.as_mut() {
+                        group.end = range.end;
+                    }
+
+                    if was_top_level_item
+                        && matches!(end_tag, TagEnd::Item)
+                        && let Some(start) = top_level_item_start.take()
+                    {
+                        entries.push(EntryRange {
+                            start,
+                            end: range.end,
+                            kind: EntryKind::ListItem,
+                        });
+                    }
+
+                    if matches!(start_tag, Tag::List(_)) && root_list_depth > 0 {
+                        root_list_depth -= 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(group) = current_group.take() {
+            entries.push(group);
+        }
+
+        entries
+            .into_iter()
+            .filter_map(|entry| {
+                let raw = section_markdown[entry.start..entry.end].trim();
+                if raw.is_empty() {
+                    None
+                } else {
+                    let text = match entry.kind {
+                        EntryKind::ListItem => strip_list_marker(raw),
+                        EntryKind::BlockGroup => raw.to_string(),
+                    };
+                    Some((entry.kind, text))
+                }
+            })
+            .collect()
+    }
+
+    fn parse_negative_entry(text: String) -> AdrNegativeConsequence {
+        let mut lines = Vec::new();
+        let mut mitigations = Vec::new();
+
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("Mitigation: ") {
+                mitigations.push(rest.to_string());
+            } else if let Some(rest) = trimmed.strip_prefix("- Mitigation: ") {
+                mitigations.push(rest.to_string());
+            } else {
+                lines.push(line);
+            }
+        }
+
+        AdrNegativeConsequence {
+            text: lines.join("\n").trim().to_string(),
+            mitigations,
+        }
+    }
+
+    if raw.trim().is_empty() {
+        return AdrConsequences::default();
+    }
+
+    let sections = legacy_sections(raw);
+    if sections.is_empty() {
+        return AdrConsequences {
+            positive: vec![],
+            negative: vec![],
+            neutral: vec![raw.trim().to_string()],
+        };
+    }
+
+    let mut parsed = AdrConsequences::default();
+    for (section, body) in sections {
+        let entries = collect_markdown_entries(body);
+        match section {
+            Section::Positive => {
+                parsed
+                    .positive
+                    .extend(entries.into_iter().map(|(_, text)| text));
+            }
+            Section::Neutral => {
+                parsed
+                    .neutral
+                    .extend(entries.into_iter().map(|(_, text)| text));
+            }
+            Section::Negative => {
+                for (_, text) in entries {
+                    let trimmed = text.trim();
+                    if let Some(rest) = trimmed.strip_prefix("Mitigation: ")
+                        && let Some(last) = parsed.negative.last_mut()
+                    {
+                        last.mitigations.push(rest.to_string());
+                        continue;
+                    }
+                    if let Some(rest) = trimmed.strip_prefix("- Mitigation: ")
+                        && let Some(last) = parsed.negative.last_mut()
+                    {
+                        last.mitigations.push(rest.to_string());
+                        continue;
+                    }
+                    let consequence = parse_negative_entry(text);
+                    if !consequence.text.is_empty() || !consequence.mitigations.is_empty() {
+                        parsed.negative.push(consequence);
+                    }
+                }
+            }
+        }
     }
 
     parsed
@@ -920,6 +1126,21 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_legacy_consequences_keeps_markdown_block_as_one_negative_item() {
+        let parsed = parse_legacy_consequences(
+            "### Negative\n\n- Breaking change\nMitigation: Document the change\n\n### Migration\nUsers need to update:\n\n```bash\nold command\nnew command\n```\n",
+        );
+
+        assert_eq!(parsed.negative.len(), 2);
+        assert_eq!(parsed.negative[0].text, "Breaking change");
+        assert_eq!(parsed.negative[0].mitigations, vec!["Document the change"]);
+        assert_eq!(
+            parsed.negative[1].text,
+            "### Migration\nUsers need to update:\n\n```bash\nold command\nnew command\n```"
+        );
+    }
+
+    #[test]
     fn test_migrate_legacy_adr_promotes_single_accepted_option() {
         let migrated = migrate_legacy_adr(legacy_spec(
             AdrStatus::Accepted,
@@ -942,7 +1163,10 @@ mod tests {
             ],
         ));
 
-        assert_eq!(migrated.content.selected_option.as_deref(), Some("Option A"));
+        assert_eq!(
+            migrated.content.selected_option.as_deref(),
+            Some("Option A")
+        );
         assert!(
             migrated
                 .content
@@ -965,8 +1189,20 @@ mod tests {
             AdrStatus::Accepted,
             "",
             vec![
-                legacy_alternative("Option A", LegacyAlternativeStatus::Accepted, &[], &[], None),
-                legacy_alternative("Option B", LegacyAlternativeStatus::Accepted, &[], &[], None),
+                legacy_alternative(
+                    "Option A",
+                    LegacyAlternativeStatus::Accepted,
+                    &[],
+                    &[],
+                    None,
+                ),
+                legacy_alternative(
+                    "Option B",
+                    LegacyAlternativeStatus::Accepted,
+                    &[],
+                    &[],
+                    None,
+                ),
             ],
         ));
 

--- a/src/cmd/migrate.rs
+++ b/src/cmd/migrate.rs
@@ -648,19 +648,6 @@ fn parse_legacy_consequences(raw: &str) -> AdrConsequences {
             continue;
         }
 
-        if let Some(rest) = trimmed.strip_prefix("- ") {
-            match current {
-                Some(Section::Positive) => parsed.positive.push(rest.to_string()),
-                Some(Section::Neutral) => parsed.neutral.push(rest.to_string()),
-                Some(Section::Negative) => parsed.negative.push(AdrNegativeConsequence {
-                    text: rest.to_string(),
-                    mitigations: vec![],
-                }),
-                None => {}
-            }
-            continue;
-        }
-
         if let Some(rest) = trimmed.strip_prefix("Mitigation: ")
             && let Some(last) = parsed.negative.last_mut()
         {
@@ -671,6 +658,19 @@ fn parse_legacy_consequences(raw: &str) -> AdrConsequences {
             && let Some(last) = parsed.negative.last_mut()
         {
             last.mitigations.push(rest.to_string());
+            continue;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix("- ") {
+            match current {
+                Some(Section::Positive) => parsed.positive.push(rest.to_string()),
+                Some(Section::Neutral) => parsed.neutral.push(rest.to_string()),
+                Some(Section::Negative) => parsed.negative.push(AdrNegativeConsequence {
+                    text: rest.to_string(),
+                    mitigations: vec![],
+                }),
+                None => {}
+            }
             continue;
         }
 
@@ -849,6 +849,167 @@ fn plan_rfc_json_to_toml(
     }
 
     Ok(Some((ops, rfc_id)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn legacy_alternative(
+        text: &str,
+        status: LegacyAlternativeStatus,
+        pros: &[&str],
+        cons: &[&str],
+        rejection_reason: Option<&str>,
+    ) -> LegacyAlternative {
+        LegacyAlternative {
+            text: text.to_string(),
+            status,
+            pros: pros.iter().map(|s| s.to_string()).collect(),
+            cons: cons.iter().map(|s| s.to_string()).collect(),
+            rejection_reason: rejection_reason.map(str::to_string),
+        }
+    }
+
+    fn legacy_spec(
+        status: AdrStatus,
+        consequences: &str,
+        alternatives: Vec<LegacyAlternative>,
+    ) -> LegacyAdrSpec {
+        LegacyAdrSpec {
+            govctl: LegacyAdrMeta {
+                schema: 2,
+                id: "ADR-9999".to_string(),
+                title: "Legacy ADR".to_string(),
+                status,
+                date: "2026-04-06".to_string(),
+                superseded_by: None,
+                refs: vec!["RFC-0001".to_string()],
+            },
+            content: LegacyAdrContent {
+                context: "Legacy context".to_string(),
+                decision: "Legacy decision".to_string(),
+                consequences: consequences.to_string(),
+                alternatives,
+            },
+        }
+    }
+
+    #[test]
+    fn test_parse_legacy_consequences_extracts_sections_and_mitigations() {
+        let parsed = parse_legacy_consequences(
+            "### Positive\n\n- Fast rollout\n\n### Negative\n\n- Higher memory use\nMitigation: Add cache cap\n- Slower warmup\n- Mitigation: Precompute metadata\n\n### Neutral\n\n- Operator training needed\n",
+        );
+
+        assert_eq!(parsed.positive, vec!["Fast rollout"]);
+        assert_eq!(parsed.neutral, vec!["Operator training needed"]);
+        assert_eq!(parsed.negative.len(), 2);
+        assert_eq!(parsed.negative[0].text, "Higher memory use");
+        assert_eq!(parsed.negative[0].mitigations, vec!["Add cache cap"]);
+        assert_eq!(parsed.negative[1].text, "Slower warmup");
+        assert_eq!(parsed.negative[1].mitigations, vec!["Precompute metadata"]);
+    }
+
+    #[test]
+    fn test_parse_legacy_consequences_without_headings_falls_back_to_neutral() {
+        let parsed = parse_legacy_consequences("Single paragraph consequence.");
+
+        assert!(parsed.positive.is_empty());
+        assert!(parsed.negative.is_empty());
+        assert_eq!(parsed.neutral, vec!["Single paragraph consequence."]);
+    }
+
+    #[test]
+    fn test_migrate_legacy_adr_promotes_single_accepted_option() {
+        let migrated = migrate_legacy_adr(legacy_spec(
+            AdrStatus::Accepted,
+            "### Positive\n\n- Easier rollout\n",
+            vec![
+                legacy_alternative(
+                    "Option A",
+                    LegacyAlternativeStatus::Accepted,
+                    &["Matches current rollout plan"],
+                    &["Higher memory use"],
+                    None,
+                ),
+                legacy_alternative(
+                    "Option B",
+                    LegacyAlternativeStatus::Rejected,
+                    &["Cheaper"],
+                    &[],
+                    Some("Does not match rollout constraints"),
+                ),
+            ],
+        ));
+
+        assert_eq!(migrated.content.selected_option.as_deref(), Some("Option A"));
+        assert!(
+            migrated
+                .content
+                .decision
+                .contains("Recovered Selected-Option Advantages")
+        );
+        assert_eq!(migrated.content.consequences.negative.len(), 1);
+        assert_eq!(
+            migrated.content.consequences.negative[0].text,
+            "Higher memory use"
+        );
+        assert_eq!(migrated.content.alternatives.len(), 1);
+        assert_eq!(migrated.content.alternatives[0].text, "Option B");
+        assert!(migrated.govctl.migration.is_none());
+    }
+
+    #[test]
+    fn test_migrate_legacy_adr_marks_multiple_accepted_options_for_review() {
+        let migrated = migrate_legacy_adr(legacy_spec(
+            AdrStatus::Accepted,
+            "",
+            vec![
+                legacy_alternative("Option A", LegacyAlternativeStatus::Accepted, &[], &[], None),
+                legacy_alternative("Option B", LegacyAlternativeStatus::Accepted, &[], &[], None),
+            ],
+        ));
+
+        assert!(migrated.content.selected_option.is_none());
+        assert_eq!(migrated.content.alternatives.len(), 2);
+        let migration = migrated.govctl.migration.expect("migration metadata");
+        assert_eq!(migration.state, AdrMigrationState::NeedsReview);
+        assert!(
+            migration
+                .warnings
+                .iter()
+                .any(|w| w.code == "ADR_MULTIPLE_ACCEPTED_OPTIONS")
+        );
+    }
+
+    #[test]
+    fn test_migrate_legacy_adr_warns_when_accepted_status_has_no_chosen_option() {
+        let migrated = migrate_legacy_adr(legacy_spec(
+            AdrStatus::Accepted,
+            "",
+            vec![legacy_alternative(
+                "Option B",
+                LegacyAlternativeStatus::Rejected,
+                &[],
+                &[],
+                None,
+            )],
+        ));
+
+        let migration = migrated.govctl.migration.expect("migration metadata");
+        assert!(
+            migration
+                .warnings
+                .iter()
+                .any(|w| w.code == "ADR_SELECTED_OPTION_UNRESOLVED")
+        );
+        assert!(
+            migration
+                .warnings
+                .iter()
+                .any(|w| w.code == "ADR_REJECTION_REASON_SYNTHETIC")
+        );
+    }
 }
 
 fn plan_release_upgrade(config: &Config) -> anyhow::Result<Option<Vec<FileOp>>> {

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -4,9 +4,9 @@ use crate::NewTarget;
 use crate::config::{Config, IdStrategy};
 use crate::diagnostic::{Diagnostic, DiagnosticCode};
 use crate::model::{
-    AdrContent, AdrMeta, AdrSpec, AdrStatus, ChangelogEntry, ClauseKind, ClauseSpec, ClauseStatus,
-    ClauseWire, RfcPhase, RfcSpec, RfcStatus, RfcWire, SectionSpec, WorkItemContent, WorkItemMeta,
-    WorkItemSpec, WorkItemStatus, WorkItemVerification,
+    AdrConsequences, AdrContent, AdrMeta, AdrSpec, AdrStatus, ChangelogEntry, ClauseKind,
+    ClauseSpec, ClauseStatus, ClauseWire, RfcPhase, RfcSpec, RfcStatus, RfcWire, SectionSpec,
+    WorkItemContent, WorkItemMeta, WorkItemSpec, WorkItemStatus, WorkItemVerification,
 };
 use crate::schema::ARTIFACT_SCHEMA_TEMPLATES;
 use crate::schema::{ArtifactSchema, with_schema_header};
@@ -506,11 +506,13 @@ fn create_adr(config: &Config, title: &str, op: WriteOp) -> anyhow::Result<Vec<D
             date: today(),
             superseded_by: None,
             refs: vec![],
+            migration: None,
         },
         content: AdrContent {
             context: "Describe the context and problem statement.\nWhat is the issue that we're seeing that is motivating this decision?".to_string(),
             decision: "Describe the decision that was made.\nWhat is the change that we're proposing and/or doing?".to_string(),
-            consequences: "Describe the resulting context after applying the decision.\nWhat becomes easier or more difficult to do because of this change?".to_string(),
+            selected_option: None,
+            consequences: AdrConsequences::default(),
             alternatives: vec![],
         },
     };

--- a/src/cmd/render.rs
+++ b/src/cmd/render.rs
@@ -15,10 +15,9 @@ pub fn render(
     rfc_id: Option<&str>,
     dry_run: bool,
 ) -> anyhow::Result<Vec<Diagnostic>> {
-    let rfcs = load_rfcs(config).map_err(|e| {
-        let diag: Diagnostic = e.into();
-        anyhow::anyhow!("{}", diag)
-    })?;
+    let rfcs = load_rfcs(config)
+        .map_err(Diagnostic::from)
+        .map_err(anyhow::Error::from)?;
 
     if rfcs.is_empty() {
         ui::not_found("RFC", &config.rfc_dir());
@@ -35,10 +34,11 @@ pub fn render(
     if rfcs_to_render.is_empty()
         && let Some(id) = rfc_id
     {
+        let scope = config.display_path(&config.rfc_dir()).display().to_string();
         return Err(Diagnostic::new(
             DiagnosticCode::E0102RfcNotFound,
             format!("RFC not found: {id}"),
-            id,
+            scope,
         )
         .into());
     }
@@ -81,10 +81,11 @@ pub fn render_adrs(
     if adrs_to_render.is_empty()
         && let Some(id) = adr_id
     {
+        let scope = config.display_path(&config.adr_dir()).display().to_string();
         return Err(Diagnostic::new(
             DiagnosticCode::E0302AdrNotFound,
             format!("ADR not found: {id}"),
-            id,
+            scope,
         )
         .into());
     }
@@ -128,10 +129,14 @@ pub fn render_work_items(
     if items_to_render.is_empty()
         && let Some(id) = work_id
     {
+        let scope = config
+            .display_path(&config.work_dir())
+            .display()
+            .to_string();
         return Err(Diagnostic::new(
             DiagnosticCode::E0402WorkNotFound,
             format!("Work item not found: {id}"),
-            id,
+            scope,
         )
         .into());
     }
@@ -157,8 +162,8 @@ pub fn render_changelog(
     dry_run: bool,
     force: bool,
 ) -> anyhow::Result<Vec<Diagnostic>> {
-    let releases_file = load_releases(config).map_err(|d| anyhow::anyhow!("{}", d.message))?;
-    let work_items = load_work_items(config).map_err(|d| anyhow::anyhow!("{}", d.message))?;
+    let releases_file = load_releases(config).map_err(anyhow::Error::from)?;
+    let work_items = load_work_items(config).map_err(anyhow::Error::from)?;
 
     // Get all released work item IDs
     let released_ids: HashSet<_> = releases_file
@@ -496,19 +501,19 @@ pub fn show_rfc(
     id: &str,
     output: OutputFormat,
 ) -> anyhow::Result<Vec<Diagnostic>> {
-    let rfcs = load_rfcs(config).map_err(|e| {
-        let diag: Diagnostic = e.into();
-        anyhow::anyhow!("{}", diag)
-    })?;
+    let rfcs = load_rfcs(config)
+        .map_err(Diagnostic::from)
+        .map_err(anyhow::Error::from)?;
 
     let rfc = rfcs
         .into_iter()
         .find(|r| r.rfc.rfc_id == id)
         .ok_or_else(|| {
+            let scope = config.display_path(&config.rfc_dir()).display().to_string();
             Diagnostic::new(
                 DiagnosticCode::E0102RfcNotFound,
                 format!("RFC not found: {id}"),
-                id,
+                scope,
             )
         })?;
 
@@ -542,10 +547,11 @@ pub fn show_adr(
         .into_iter()
         .find(|a| a.spec.govctl.id == id)
         .ok_or_else(|| {
+            let scope = config.display_path(&config.adr_dir()).display().to_string();
             Diagnostic::new(
                 DiagnosticCode::E0302AdrNotFound,
                 format!("ADR not found: {id}"),
-                id,
+                scope,
             )
         })?;
 
@@ -578,10 +584,14 @@ pub fn show_work(
         .into_iter()
         .find(|w| w.spec.govctl.id == id)
         .ok_or_else(|| {
+            let scope = config
+                .display_path(&config.work_dir())
+                .display()
+                .to_string();
             Diagnostic::new(
                 DiagnosticCode::E0402WorkNotFound,
                 format!("Work item not found: {id}"),
-                id,
+                scope,
             )
         })?;
 
@@ -621,19 +631,19 @@ pub fn show_clause(
     let rfc_id = parts[0];
     let clause_name = parts[1];
 
-    let rfcs = load_rfcs(config).map_err(|e| {
-        let diag: Diagnostic = e.into();
-        anyhow::anyhow!("{}", diag)
-    })?;
+    let rfcs = load_rfcs(config)
+        .map_err(Diagnostic::from)
+        .map_err(anyhow::Error::from)?;
 
     let rfc = rfcs
         .into_iter()
         .find(|r| r.rfc.rfc_id == rfc_id)
         .ok_or_else(|| {
+            let scope = config.display_path(&config.rfc_dir()).display().to_string();
             Diagnostic::new(
                 DiagnosticCode::E0102RfcNotFound,
                 format!("RFC not found: {rfc_id}"),
-                rfc_id,
+                scope,
             )
         })?;
 
@@ -642,10 +652,14 @@ pub fn show_clause(
         .into_iter()
         .find(|c| c.spec.clause_id == clause_name)
         .ok_or_else(|| {
+            let scope = config
+                .display_path(&config.rfc_dir().join(rfc_id).join("clauses"))
+                .display()
+                .to_string();
             Diagnostic::new(
                 DiagnosticCode::E0202ClauseNotFound,
                 format!("Clause not found: {id}"),
-                id,
+                scope,
             )
         })?;
 

--- a/src/command_router.rs
+++ b/src/command_router.rs
@@ -11,7 +11,7 @@
 
 use crate::cmd;
 use crate::config::Config;
-use crate::diagnostic::Diagnostic;
+use crate::diagnostic::{Diagnostic, DiagnosticCode};
 use crate::model::{ChangelogCategory, ClauseKind, RfcPhase, WorkItemStatus};
 use crate::write::{BumpLevel, WriteOp};
 use crate::{
@@ -78,7 +78,12 @@ fn owned_edit_action(args: &EditActionArgs) -> anyhow::Result<OwnedEditAction> {
         });
     }
 
-    Err(anyhow::anyhow!("exactly one edit action is required"))
+    Err(Diagnostic::new(
+        DiagnosticCode::E0801MissingRequiredArg,
+        "exactly one edit action is required",
+        "edit action",
+    )
+    .into())
 }
 
 /// Canonical internal representation of all commands.
@@ -1110,8 +1115,11 @@ impl CanonicalCommand {
                     || tick.is_some();
                 if uses_canonical {
                     let path = path.clone().ok_or_else(|| {
-                        anyhow::anyhow!(
+                        Diagnostic::new(
+                            DiagnosticCode::E0801MissingRequiredArg,
                             "canonical clause edit requires a field path before --set/--add/--remove/--tick"
+                            ,
+                            id,
                         )
                     })?;
                     let action = owned_edit_action(&EditActionArgs {

--- a/src/command_router.rs
+++ b/src/command_router.rs
@@ -1482,3 +1482,146 @@ impl CanonicalCommand {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ClauseCommand, TickStatus};
+
+    #[test]
+    fn test_owned_edit_action_requires_exactly_one_action() {
+        let err = owned_edit_action(&EditActionArgs {
+            set: None,
+            add: None,
+            remove: None,
+            tick: None,
+            stdin: false,
+            at: None,
+            exact: false,
+            regex: false,
+            all: false,
+        })
+        .expect_err("missing action should fail");
+
+        let diag = err.downcast_ref::<Diagnostic>().expect("diagnostic");
+        assert_eq!(diag.code, DiagnosticCode::E0801MissingRequiredArg);
+    }
+
+    #[test]
+    fn test_from_clause_command_uses_canonical_edit_when_path_is_present() {
+        let cmd = ClauseCommand::Edit {
+            id: "RFC-0001:C-TEST".to_string(),
+            path: Some("text".to_string()),
+            set: Some("Updated".to_string()),
+            add: None,
+            remove: None,
+            tick: None,
+            stdin: false,
+            at: None,
+            exact: false,
+            regex: false,
+            all: false,
+            text: None,
+            text_file: None,
+        };
+
+        let canonical = CanonicalCommand::from_clause_command(&cmd).expect("canonical edit");
+        match canonical {
+            CanonicalCommand::ClauseEdit { id, path, action } => {
+                assert_eq!(id, "RFC-0001:C-TEST");
+                assert_eq!(path, "text");
+                match action {
+                    OwnedEditAction::Set { value, stdin } => {
+                        assert_eq!(value.as_deref(), Some("Updated"));
+                        assert!(!stdin);
+                    }
+                    other => panic!("expected set action, got {other:?}"),
+                }
+            }
+            other => panic!("expected ClauseEdit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_from_clause_command_requires_path_for_canonical_flags() {
+        let cmd = ClauseCommand::Edit {
+            id: "RFC-0001:C-TEST".to_string(),
+            path: None,
+            set: Some("Updated".to_string()),
+            add: None,
+            remove: None,
+            tick: None,
+            stdin: false,
+            at: None,
+            exact: false,
+            regex: false,
+            all: false,
+            text: None,
+            text_file: None,
+        };
+
+        let err = CanonicalCommand::from_clause_command(&cmd).expect_err("missing path");
+        let diag = err.downcast_ref::<Diagnostic>().expect("diagnostic");
+        assert_eq!(diag.code, DiagnosticCode::E0801MissingRequiredArg);
+    }
+
+    #[test]
+    fn test_from_clause_command_uses_legacy_edit_without_canonical_flags() {
+        let cmd = ClauseCommand::Edit {
+            id: "RFC-0001:C-TEST".to_string(),
+            path: None,
+            set: None,
+            add: None,
+            remove: None,
+            tick: None,
+            stdin: true,
+            at: None,
+            exact: false,
+            regex: false,
+            all: false,
+            text: None,
+            text_file: None,
+        };
+
+        let canonical = CanonicalCommand::from_clause_command(&cmd).expect("legacy edit");
+        match canonical {
+            CanonicalCommand::ClauseLegacyEdit {
+                id,
+                text,
+                text_file,
+                stdin,
+            } => {
+                assert_eq!(id, "RFC-0001:C-TEST");
+                assert!(text.is_none());
+                assert!(text_file.is_none());
+                assert!(stdin);
+            }
+            other => panic!("expected ClauseLegacyEdit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_owned_edit_action_builds_tick_match_options() {
+        let action = owned_edit_action(&EditActionArgs {
+            set: None,
+            add: None,
+            remove: None,
+            tick: Some(TickStatus::Done),
+            stdin: false,
+            at: Some(2),
+            exact: true,
+            regex: false,
+            all: false,
+        })
+        .expect("tick action");
+
+        match action {
+            OwnedEditAction::Tick { match_opts, status } => {
+                assert!(matches!(status, TickStatus::Done));
+                assert_eq!(match_opts.at, Some(2));
+                assert!(match_opts.exact);
+            }
+            other => panic!("expected tick action, got {other:?}"),
+        }
+    }
+}

--- a/src/command_router.rs
+++ b/src/command_router.rs
@@ -81,6 +81,74 @@ fn owned_edit_action(args: &EditActionArgs) -> anyhow::Result<OwnedEditAction> {
     Err(anyhow::anyhow!("exactly one edit action is required"))
 }
 
+fn owned_clause_edit_action(
+    set: &Option<String>,
+    add: &Option<String>,
+    remove: &Option<String>,
+    tick: Option<TickStatus>,
+    stdin: bool,
+    at: Option<i32>,
+    exact: bool,
+    regex: bool,
+    all: bool,
+) -> anyhow::Result<OwnedEditAction> {
+    let empty_to_none = |value: Option<&String>| {
+        value.and_then(|value| {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value.clone())
+            }
+        })
+    };
+
+    if let Some(value) = set {
+        return Ok(OwnedEditAction::Set {
+            value: if value.is_empty() {
+                None
+            } else {
+                Some(value.clone())
+            },
+            stdin,
+        });
+    }
+    if let Some(value) = add {
+        return Ok(OwnedEditAction::Add {
+            value: if value.is_empty() {
+                None
+            } else {
+                Some(value.clone())
+            },
+            stdin,
+        });
+    }
+    if let Some(status) = tick {
+        return Ok(OwnedEditAction::Tick {
+            match_opts: OwnedMatchOptions {
+                pattern: None,
+                at,
+                exact,
+                regex,
+                all: false,
+            },
+            status,
+        });
+    }
+    if remove.is_some() {
+        return Ok(OwnedEditAction::Remove {
+            match_opts: OwnedMatchOptions {
+                pattern: empty_to_none(remove.as_ref()),
+                at,
+                exact,
+                regex,
+                all,
+            },
+        });
+    }
+
+    Err(anyhow::anyhow!("exactly one edit action is required"))
+}
+
 /// Canonical internal representation of all commands.
 /// This is the single source of truth for command execution.
 #[derive(Debug, Clone)]
@@ -210,6 +278,11 @@ pub enum CanonicalCommand {
         field: Option<String>,
     },
     ClauseEdit {
+        id: String,
+        path: String,
+        action: OwnedEditAction,
+    },
+    ClauseLegacyEdit {
         id: String,
         text: Option<String>,
         text_file: Option<PathBuf>,
@@ -685,7 +758,10 @@ impl CanonicalCommand {
                 *output,
             ),
             Self::ClauseGet { id, field } => cmd::edit::get_field(config, id, field.as_deref()),
-            Self::ClauseEdit {
+            Self::ClauseEdit { id, path, action } => cmd::edit::edit_field(
+                config, id, path, action, None, None, None, None, None, op,
+            ),
+            Self::ClauseLegacyEdit {
                 id,
                 text,
                 text_file,
@@ -1082,15 +1158,46 @@ impl CanonicalCommand {
             },
             ClauseCommand::Edit {
                 id,
+                path,
+                set,
+                add,
+                remove,
+                tick,
+                stdin,
+                at,
+                exact,
+                regex,
+                all,
                 text,
                 text_file,
-                stdin,
-            } => Self::ClauseEdit {
-                id: id.clone(),
-                text: text.clone(),
-                text_file: text_file.clone(),
-                stdin: *stdin,
-            },
+            } => {
+                let uses_canonical = path.is_some()
+                    || set.is_some()
+                    || add.is_some()
+                    || remove.is_some()
+                    || tick.is_some();
+                if uses_canonical {
+                    let path = path.clone().ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "canonical clause edit requires a field path before --set/--add/--remove/--tick"
+                        )
+                    })?;
+                    let action =
+                        owned_clause_edit_action(set, add, remove, *tick, *stdin, *at, *exact, *regex, *all)?;
+                    Self::ClauseEdit {
+                        id: id.clone(),
+                        path,
+                        action,
+                    }
+                } else {
+                    Self::ClauseLegacyEdit {
+                        id: id.clone(),
+                        text: text.clone(),
+                        text_file: text_file.clone(),
+                        stdin: *stdin,
+                    }
+                }
+            }
             ClauseCommand::Set {
                 id,
                 field,

--- a/src/command_router.rs
+++ b/src/command_router.rs
@@ -81,74 +81,6 @@ fn owned_edit_action(args: &EditActionArgs) -> anyhow::Result<OwnedEditAction> {
     Err(anyhow::anyhow!("exactly one edit action is required"))
 }
 
-fn owned_clause_edit_action(
-    set: &Option<String>,
-    add: &Option<String>,
-    remove: &Option<String>,
-    tick: Option<TickStatus>,
-    stdin: bool,
-    at: Option<i32>,
-    exact: bool,
-    regex: bool,
-    all: bool,
-) -> anyhow::Result<OwnedEditAction> {
-    let empty_to_none = |value: Option<&String>| {
-        value.and_then(|value| {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value.clone())
-            }
-        })
-    };
-
-    if let Some(value) = set {
-        return Ok(OwnedEditAction::Set {
-            value: if value.is_empty() {
-                None
-            } else {
-                Some(value.clone())
-            },
-            stdin,
-        });
-    }
-    if let Some(value) = add {
-        return Ok(OwnedEditAction::Add {
-            value: if value.is_empty() {
-                None
-            } else {
-                Some(value.clone())
-            },
-            stdin,
-        });
-    }
-    if let Some(status) = tick {
-        return Ok(OwnedEditAction::Tick {
-            match_opts: OwnedMatchOptions {
-                pattern: None,
-                at,
-                exact,
-                regex,
-                all: false,
-            },
-            status,
-        });
-    }
-    if remove.is_some() {
-        return Ok(OwnedEditAction::Remove {
-            match_opts: OwnedMatchOptions {
-                pattern: empty_to_none(remove.as_ref()),
-                at,
-                exact,
-                regex,
-                all,
-            },
-        });
-    }
-
-    Err(anyhow::anyhow!("exactly one edit action is required"))
-}
-
 /// Canonical internal representation of all commands.
 /// This is the single source of truth for command execution.
 #[derive(Debug, Clone)]
@@ -758,9 +690,9 @@ impl CanonicalCommand {
                 *output,
             ),
             Self::ClauseGet { id, field } => cmd::edit::get_field(config, id, field.as_deref()),
-            Self::ClauseEdit { id, path, action } => cmd::edit::edit_field(
-                config, id, path, action, None, None, None, None, None, op,
-            ),
+            Self::ClauseEdit { id, path, action } => {
+                cmd::edit::edit_field(config, id, path, action, None, None, None, None, None, op)
+            }
             Self::ClauseLegacyEdit {
                 id,
                 text,
@@ -1182,8 +1114,17 @@ impl CanonicalCommand {
                             "canonical clause edit requires a field path before --set/--add/--remove/--tick"
                         )
                     })?;
-                    let action =
-                        owned_clause_edit_action(set, add, remove, *tick, *stdin, *at, *exact, *regex, *all)?;
+                    let action = owned_edit_action(&EditActionArgs {
+                        set: set.clone(),
+                        add: add.clone(),
+                        remove: remove.clone(),
+                        tick: *tick,
+                        stdin: *stdin,
+                        at: *at,
+                        exact: *exact,
+                        regex: *regex,
+                        all: *all,
+                    })?;
                     Self::ClauseEdit {
                         id: id.clone(),
                         path,

--- a/src/command_router.rs
+++ b/src/command_router.rs
@@ -447,6 +447,7 @@ impl CanonicalCommand {
                 | Render { .. }
                 | Migrate
                 | RfcNew { .. }
+                | RfcEdit { .. }
                 | RfcSet { .. }
                 | RfcAdd { .. }
                 | RfcRemove { .. }
@@ -458,11 +459,13 @@ impl CanonicalCommand {
                 | RfcRender { .. }
                 | ClauseNew { .. }
                 | ClauseEdit { .. }
+                | ClauseLegacyEdit { .. }
                 | ClauseSet { .. }
                 | ClauseDelete { .. }
                 | ClauseDeprecate { .. }
                 | ClauseSupersede { .. }
                 | AdrNew { .. }
+                | AdrEdit { .. }
                 | AdrSet { .. }
                 | AdrAdd { .. }
                 | AdrRemove { .. }
@@ -472,6 +475,7 @@ impl CanonicalCommand {
                 | AdrSupersede { .. }
                 | AdrRender { .. }
                 | WorkNew { .. }
+                | WorkEdit { .. }
                 | WorkSet { .. }
                 | WorkAdd { .. }
                 | WorkRemove { .. }
@@ -480,6 +484,7 @@ impl CanonicalCommand {
                 | WorkDelete { .. }
                 | WorkRender { .. }
                 | GuardNew { .. }
+                | GuardEdit { .. }
                 | GuardSet { .. }
                 | GuardAdd { .. }
                 | GuardRemove { .. }
@@ -1623,5 +1628,71 @@ mod tests {
             }
             other => panic!("expected tick action, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_is_write_command_includes_canonical_edit_variants() {
+        assert!(
+            CanonicalCommand::RfcEdit {
+                id: "RFC-0001".to_string(),
+                path: "title".to_string(),
+                action: OwnedEditAction::Set {
+                    value: Some("X".to_string()),
+                    stdin: false,
+                },
+            }
+            .is_write_command()
+        );
+
+        assert!(
+            CanonicalCommand::AdrEdit {
+                id: "ADR-0001".to_string(),
+                path: "decision".to_string(),
+                action: OwnedEditAction::Set {
+                    value: Some("X".to_string()),
+                    stdin: false,
+                },
+                pro: vec![],
+                con: vec![],
+                reject_reason: None,
+            }
+            .is_write_command()
+        );
+
+        assert!(
+            CanonicalCommand::WorkEdit {
+                id: "WI-2026-04-06-001".to_string(),
+                path: "acceptance_criteria[0]".to_string(),
+                action: OwnedEditAction::Tick {
+                    match_opts: OwnedMatchOptions::default(),
+                    status: TickStatus::Done,
+                },
+                category: None,
+                scope: None,
+            }
+            .is_write_command()
+        );
+
+        assert!(
+            CanonicalCommand::GuardEdit {
+                id: "GUARD-0001".to_string(),
+                path: "title".to_string(),
+                action: OwnedEditAction::Set {
+                    value: Some("X".to_string()),
+                    stdin: false,
+                },
+            }
+            .is_write_command()
+        );
+
+        assert!(
+            CanonicalCommand::ClauseLegacyEdit {
+                id: "RFC-0001:C-TEST".to_string(),
+                text: Some("Updated text".to_string()),
+                text_file: None,
+                stdin: false,
+            }
+            .is_write_command()
+        );
     }
 }

--- a/src/command_router.rs
+++ b/src/command_router.rs
@@ -24,44 +24,34 @@ type OwnedMatchOptions = cmd::edit::MatchOptionsOwned;
 type OwnedEditAction = cmd::edit::OwnedEditAction;
 
 fn owned_edit_action(args: &EditActionArgs) -> anyhow::Result<OwnedEditAction> {
-    let empty_to_none = |value: Option<&String>| {
-        value.and_then(|value| {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value.clone())
-            }
-        })
-    };
-
     if let Some(value) = &args.set {
         return Ok(OwnedEditAction::Set {
-            value: if value.is_empty() {
-                None
-            } else {
-                Some(value.clone())
-            },
+            value: Some(value.clone()),
             stdin: args.stdin,
         });
     }
     if let Some(value) = &args.add {
         return Ok(OwnedEditAction::Add {
-            value: if value.is_empty() {
-                None
-            } else {
-                Some(value.clone())
-            },
+            value: Some(value.clone()),
             stdin: args.stdin,
         });
     }
     if let Some(status) = args.tick {
+        if args.all {
+            return Err(Diagnostic::new(
+                DiagnosticCode::E0802ConflictingArgs,
+                "Cannot use --all with --tick; tick requires a single target",
+                "edit action",
+            )
+            .into());
+        }
         return Ok(OwnedEditAction::Tick {
             match_opts: OwnedMatchOptions {
                 pattern: None,
                 at: args.at,
                 exact: args.exact,
                 regex: args.regex,
-                all: false,
+                all: args.all,
             },
             status,
         });
@@ -69,7 +59,7 @@ fn owned_edit_action(args: &EditActionArgs) -> anyhow::Result<OwnedEditAction> {
     if args.remove.is_some() {
         return Ok(OwnedEditAction::Remove {
             match_opts: OwnedMatchOptions {
-                pattern: empty_to_none(args.remove.as_ref()),
+                pattern: args.remove.clone(),
                 at: args.at,
                 exact: args.exact,
                 regex: args.regex,
@@ -1627,6 +1617,87 @@ mod tests {
                 assert!(match_opts.exact);
             }
             other => panic!("expected tick action, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_owned_edit_action_rejects_tick_all_combination() {
+        let err = owned_edit_action(&EditActionArgs {
+            set: None,
+            add: None,
+            remove: None,
+            tick: Some(TickStatus::Done),
+            stdin: false,
+            at: None,
+            exact: false,
+            regex: false,
+            all: true,
+        })
+        .expect_err("tick with --all should fail");
+
+        let diag = err.downcast_ref::<Diagnostic>().expect("diagnostic");
+        assert_eq!(diag.code, DiagnosticCode::E0802ConflictingArgs);
+    }
+
+    #[test]
+    fn test_owned_edit_action_preserves_explicit_empty_strings() {
+        let set = owned_edit_action(&EditActionArgs {
+            set: Some(String::new()),
+            add: None,
+            remove: None,
+            tick: None,
+            stdin: false,
+            at: None,
+            exact: false,
+            regex: false,
+            all: false,
+        })
+        .expect("set action");
+        match set {
+            OwnedEditAction::Set { value, stdin } => {
+                assert_eq!(value.as_deref(), Some(""));
+                assert!(!stdin);
+            }
+            other => panic!("expected set action, got {other:?}"),
+        }
+
+        let add = owned_edit_action(&EditActionArgs {
+            set: None,
+            add: Some(String::new()),
+            remove: None,
+            tick: None,
+            stdin: false,
+            at: None,
+            exact: false,
+            regex: false,
+            all: false,
+        })
+        .expect("add action");
+        match add {
+            OwnedEditAction::Add { value, stdin } => {
+                assert_eq!(value.as_deref(), Some(""));
+                assert!(!stdin);
+            }
+            other => panic!("expected add action, got {other:?}"),
+        }
+
+        let remove = owned_edit_action(&EditActionArgs {
+            set: None,
+            add: None,
+            remove: Some(String::new()),
+            tick: None,
+            stdin: false,
+            at: None,
+            exact: false,
+            regex: false,
+            all: false,
+        })
+        .expect("remove action");
+        match remove {
+            OwnedEditAction::Remove { match_opts } => {
+                assert_eq!(match_opts.pattern.as_deref(), Some(""));
+            }
+            other => panic!("expected remove action, got {other:?}"),
         }
     }
 

--- a/src/command_router.rs
+++ b/src/command_router.rs
@@ -15,32 +15,70 @@ use crate::diagnostic::Diagnostic;
 use crate::model::{ChangelogCategory, ClauseKind, RfcPhase, WorkItemStatus};
 use crate::write::{BumpLevel, WriteOp};
 use crate::{
-    Commands, FinalizeStatus, GuardCommand, ListTarget, NewTarget, OutputFormat, RenderTarget,
-    TickStatus,
+    Commands, EditActionArgs, FinalizeStatus, GuardCommand, ListTarget, NewTarget, OutputFormat,
+    RenderTarget, TickStatus,
 };
 use std::path::PathBuf;
 
-/// Owned version of MatchOptions for storage in CanonicalCommand.
-#[derive(Debug, Clone)]
-pub struct OwnedMatchOptions {
-    pub pattern: Option<String>,
-    pub at: Option<i32>,
-    pub exact: bool,
-    pub regex: bool,
-    pub all: bool,
-}
+type OwnedMatchOptions = cmd::edit::MatchOptionsOwned;
+type OwnedEditAction = cmd::edit::OwnedEditAction;
 
-impl OwnedMatchOptions {
-    /// Convert to borrowed MatchOptions with appropriate lifetime.
-    pub fn as_match_options(&self) -> cmd::edit::MatchOptions<'_> {
-        cmd::edit::MatchOptions {
-            pattern: self.pattern.as_deref(),
-            at: self.at,
-            exact: self.exact,
-            regex: self.regex,
-            all: self.all,
-        }
+fn owned_edit_action(args: &EditActionArgs) -> anyhow::Result<OwnedEditAction> {
+    let empty_to_none = |value: Option<&String>| {
+        value.and_then(|value| {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value.clone())
+            }
+        })
+    };
+
+    if let Some(value) = &args.set {
+        return Ok(OwnedEditAction::Set {
+            value: if value.is_empty() {
+                None
+            } else {
+                Some(value.clone())
+            },
+            stdin: args.stdin,
+        });
     }
+    if let Some(value) = &args.add {
+        return Ok(OwnedEditAction::Add {
+            value: if value.is_empty() {
+                None
+            } else {
+                Some(value.clone())
+            },
+            stdin: args.stdin,
+        });
+    }
+    if let Some(status) = args.tick {
+        return Ok(OwnedEditAction::Tick {
+            match_opts: OwnedMatchOptions {
+                pattern: None,
+                at: args.at,
+                exact: args.exact,
+                regex: args.regex,
+                all: false,
+            },
+            status,
+        });
+    }
+    if args.remove.is_some() {
+        return Ok(OwnedEditAction::Remove {
+            match_opts: OwnedMatchOptions {
+                pattern: empty_to_none(args.remove.as_ref()),
+                at: args.at,
+                exact: args.exact,
+                regex: args.regex,
+                all: args.all,
+            },
+        });
+    }
+
+    Err(anyhow::anyhow!("exactly one edit action is required"))
 }
 
 /// Canonical internal representation of all commands.
@@ -98,6 +136,11 @@ pub enum CanonicalCommand {
     RfcGet {
         id: String,
         field: Option<String>,
+    },
+    RfcEdit {
+        id: String,
+        path: String,
+        action: OwnedEditAction,
     },
     RfcSet {
         id: String,
@@ -211,6 +254,14 @@ pub enum CanonicalCommand {
         id: String,
         field: Option<String>,
     },
+    AdrEdit {
+        id: String,
+        path: String,
+        action: OwnedEditAction,
+        pro: Vec<String>,
+        con: Vec<String>,
+        reject_reason: Option<String>,
+    },
     AdrSet {
         id: String,
         field: String,
@@ -246,12 +297,6 @@ pub enum CanonicalCommand {
         by: String,
         force: bool,
     },
-    AdrTick {
-        id: String,
-        field: String,
-        match_opts: OwnedMatchOptions,
-        status: TickStatus,
-    },
     AdrRender {
         id: String,
         dry_run: bool,
@@ -276,6 +321,13 @@ pub enum CanonicalCommand {
     WorkGet {
         id: String,
         field: Option<String>,
+    },
+    WorkEdit {
+        id: String,
+        path: String,
+        action: OwnedEditAction,
+        category: Option<ChangelogCategory>,
+        scope: Option<String>,
     },
     WorkSet {
         id: String,
@@ -333,6 +385,11 @@ pub enum CanonicalCommand {
     GuardGet {
         id: String,
         field: Option<String>,
+    },
+    GuardEdit {
+        id: String,
+        path: String,
+        action: OwnedEditAction,
     },
     GuardSet {
         id: String,
@@ -403,7 +460,6 @@ impl CanonicalCommand {
                 | AdrReject { .. }
                 | AdrDeprecate { .. }
                 | AdrSupersede { .. }
-                | AdrTick { .. }
                 | AdrRender { .. }
                 | WorkNew { .. }
                 | WorkSet { .. }
@@ -553,6 +609,9 @@ impl CanonicalCommand {
                 output,
             } => cmd::list::list(config, ListTarget::Rfc, filter.as_deref(), *limit, *output),
             Self::RfcGet { id, field } => cmd::edit::get_field(config, id, field.as_deref()),
+            Self::RfcEdit { id, path, action } => {
+                cmd::edit::edit_field(config, id, path, action, None, None, None, None, None, op)
+            }
             Self::RfcSet {
                 id,
                 field,
@@ -667,6 +726,25 @@ impl CanonicalCommand {
                 output,
             } => cmd::list::list(config, ListTarget::Adr, status.as_deref(), *limit, *output),
             Self::AdrGet { id, field } => cmd::edit::get_field(config, id, field.as_deref()),
+            Self::AdrEdit {
+                id,
+                path,
+                action,
+                pro,
+                con,
+                reject_reason,
+            } => cmd::edit::edit_field(
+                config,
+                id,
+                path,
+                action,
+                None,
+                None,
+                Some(pro.clone()),
+                Some(con.clone()),
+                reject_reason.clone(),
+                op,
+            ),
             Self::AdrSet {
                 id,
                 field,
@@ -707,19 +785,6 @@ impl CanonicalCommand {
             Self::AdrSupersede { id, by, force } => {
                 cmd::lifecycle::supersede(config, id, by, *force, op)
             }
-            Self::AdrTick {
-                id,
-                field,
-                match_opts,
-                status,
-            } => cmd::edit::tick_item(
-                config,
-                id,
-                field,
-                &match_opts.as_match_options(),
-                *status,
-                op,
-            ),
             Self::AdrRender { id, dry_run } => cmd::render::render_adrs(config, Some(id), *dry_run),
             Self::AdrShow { id, output } => cmd::render::show_adr(config, id, *output),
 
@@ -737,6 +802,24 @@ impl CanonicalCommand {
                 output,
             } => cmd::list::list(config, ListTarget::Work, status.as_deref(), *limit, *output),
             Self::WorkGet { id, field } => cmd::edit::get_field(config, id, field.as_deref()),
+            Self::WorkEdit {
+                id,
+                path,
+                action,
+                category,
+                scope,
+            } => cmd::edit::edit_field(
+                config,
+                id,
+                path,
+                action,
+                *category,
+                scope.as_deref(),
+                None,
+                None,
+                None,
+                op,
+            ),
             Self::WorkSet {
                 id,
                 field,
@@ -806,6 +889,9 @@ impl CanonicalCommand {
                 *output,
             ),
             Self::GuardGet { id, field } => cmd::edit::get_field(config, id, field.as_deref()),
+            Self::GuardEdit { id, path, action } => {
+                cmd::edit::edit_field(config, id, path, action, None, None, None, None, None, op)
+            }
             Self::GuardSet {
                 id,
                 field,
@@ -866,6 +952,11 @@ impl CanonicalCommand {
             RfcCommand::Get { id, field } => Self::RfcGet {
                 id: id.clone(),
                 field: field.clone(),
+            },
+            RfcCommand::Edit { id, path, action } => Self::RfcEdit {
+                id: id.clone(),
+                path: path.clone(),
+                action: owned_edit_action(action)?,
             },
             RfcCommand::Set {
                 id,
@@ -1051,6 +1142,21 @@ impl CanonicalCommand {
                 id: id.clone(),
                 field: field.clone(),
             },
+            AdrCommand::Edit {
+                id,
+                path,
+                action,
+                pro,
+                con,
+                reject_reason,
+            } => Self::AdrEdit {
+                id: id.clone(),
+                path: path.clone(),
+                action: owned_edit_action(action)?,
+                pro: pro.clone(),
+                con: con.clone(),
+                reject_reason: reject_reason.clone(),
+            },
             AdrCommand::Set {
                 id,
                 field,
@@ -1112,29 +1218,6 @@ impl CanonicalCommand {
                 by: by.clone(),
                 force: *force,
             },
-            AdrCommand::Tick {
-                id,
-                field,
-                pattern,
-                status,
-                at,
-                exact,
-                regex,
-            } => {
-                let match_opts = OwnedMatchOptions {
-                    pattern: pattern.clone(),
-                    at: *at,
-                    exact: *exact,
-                    regex: *regex,
-                    all: false,
-                };
-                Self::AdrTick {
-                    id: id.clone(),
-                    field: field.clone(),
-                    match_opts,
-                    status: *status,
-                }
-            }
             AdrCommand::Render { id, dry_run } => Self::AdrRender {
                 id: id.clone(),
                 dry_run: *dry_run,
@@ -1166,6 +1249,19 @@ impl CanonicalCommand {
             WorkCommand::Get { id, field } => Self::WorkGet {
                 id: id.clone(),
                 field: field.clone(),
+            },
+            WorkCommand::Edit {
+                id,
+                path,
+                action,
+                category,
+                scope,
+            } => Self::WorkEdit {
+                id: id.clone(),
+                path: path.clone(),
+                action: owned_edit_action(action)?,
+                category: *category,
+                scope: scope.clone(),
             },
             WorkCommand::Set {
                 id,
@@ -1275,6 +1371,11 @@ impl CanonicalCommand {
             GuardCommand::Get { id, field } => Self::GuardGet {
                 id: id.clone(),
                 field: field.clone(),
+            },
+            GuardCommand::Edit { id, path, action } => Self::GuardEdit {
+                id: id.clone(),
+                path: path.clone(),
+                action: owned_edit_action(action)?,
             },
             GuardCommand::Set {
                 id,

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -117,6 +117,8 @@ pub enum DiagnosticCode {
     W0108WorkPlaceholderDescription,
     W0109WorkNoActive,
     W0110SchemaOutdated,
+    W0111AdrMigrationNeedsReview,
+    W0112AdrMigrationWarning,
 }
 
 impl DiagnosticCode {
@@ -131,7 +133,9 @@ impl DiagnosticCode {
             | Self::W0107SourceRefOutdated
             | Self::W0108WorkPlaceholderDescription
             | Self::W0109WorkNoActive
-            | Self::W0110SchemaOutdated => DiagnosticLevel::Warning,
+            | Self::W0110SchemaOutdated
+            | Self::W0111AdrMigrationNeedsReview
+            | Self::W0112AdrMigrationWarning => DiagnosticLevel::Warning,
             _ => DiagnosticLevel::Error,
         }
     }
@@ -230,6 +234,8 @@ impl DiagnosticCode {
             Self::W0108WorkPlaceholderDescription => "W0108",
             Self::W0109WorkNoActive => "W0109",
             Self::W0110SchemaOutdated => "W0110",
+            Self::W0111AdrMigrationNeedsReview => "W0111",
+            Self::W0112AdrMigrationWarning => "W0112",
         }
     }
 }

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -62,6 +62,8 @@ pub enum DiagnosticCode {
     // Config errors (E05xx)
     E0501ConfigInvalid,
     E0502PathNotFound,
+    E0503LockTimeout,
+    E0504PathConflict,
 
     // Signature errors (E06xx)
     E0601SignatureMismatch,
@@ -80,6 +82,8 @@ pub enum DiagnosticCode {
     E1003GuardDuplicate,
     E1004GuardCheckFailed,
     E1005GuardTimeout,
+    E1006GuardInvalidTitle,
+    E1007GuardStillReferenced,
 
     // CLI/Command errors (E08xx)
     E0801MissingRequiredArg,
@@ -100,6 +104,8 @@ pub enum DiagnosticCode {
     E0816PathIndexOutOfBounds,
     E0817PathTypeMismatch,
     E0818PathIndexConflict,
+    E0819UnknownArtifactType,
+    E0820InvalidFieldValue,
 
     // General errors (E09xx)
     E0901IoError,
@@ -185,6 +191,8 @@ impl DiagnosticCode {
             // E05xx - Config
             Self::E0501ConfigInvalid => "E0501",
             Self::E0502PathNotFound => "E0502",
+            Self::E0503LockTimeout => "E0503",
+            Self::E0504PathConflict => "E0504",
             // E06xx - Signature
             Self::E0601SignatureMismatch => "E0601",
             Self::E0602SignatureMissing => "E0602",
@@ -200,6 +208,8 @@ impl DiagnosticCode {
             Self::E1003GuardDuplicate => "E1003",
             Self::E1004GuardCheckFailed => "E1004",
             Self::E1005GuardTimeout => "E1005",
+            Self::E1006GuardInvalidTitle => "E1006",
+            Self::E1007GuardStillReferenced => "E1007",
             // E08xx - CLI/Command
             Self::E0801MissingRequiredArg => "E0801",
             Self::E0802ConflictingArgs => "E0802",
@@ -219,6 +229,8 @@ impl DiagnosticCode {
             Self::E0816PathIndexOutOfBounds => "E0816",
             Self::E0817PathTypeMismatch => "E0817",
             Self::E0818PathIndexConflict => "E0818",
+            Self::E0819UnknownArtifactType => "E0819",
+            Self::E0820InvalidFieldValue => "E0820",
             // E09xx - General
             Self::E0901IoError => "E0901",
             Self::E0902JsonParseError => "E0902",

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -5,7 +5,8 @@
 //! (e.g. on process exit or when the command finishes).
 
 use crate::config::Config;
-use anyhow::{Context, Result};
+use crate::diagnostic::{Diagnostic, DiagnosticCode};
+use anyhow::Result;
 use fs2::FileExt;
 use std::fs::OpenOptions;
 use std::io;
@@ -34,10 +35,15 @@ pub fn acquire_gov_lock(config: &Config) -> Result<GovLockGuard> {
 
     // Ensure gov root exists so we can create the lock file
     if !gov_root.exists() {
-        anyhow::bail!(
-            "Gov root does not exist: {}. Run 'govctl init' first.",
-            gov_root.display()
-        );
+        return Err(Diagnostic::new(
+            DiagnosticCode::E0502PathNotFound,
+            format!(
+                "Gov root does not exist: {}. Run 'govctl init' first.",
+                gov_root.display()
+            ),
+            gov_root.display().to_string(),
+        )
+        .into());
     }
 
     let file = OpenOptions::new()
@@ -45,7 +51,13 @@ pub fn acquire_gov_lock(config: &Config) -> Result<GovLockGuard> {
         .truncate(true)
         .write(true)
         .open(&lock_path)
-        .with_context(|| format!("Failed to open lock file: {}", lock_path.display()))?;
+        .map_err(|e| {
+            Diagnostic::new(
+                DiagnosticCode::E0901IoError,
+                format!("Failed to open lock file: {}", e),
+                lock_path.display().to_string(),
+            )
+        })?;
 
     let deadline = Instant::now() + Duration::from_secs(timeout_secs);
     let poll = Duration::from_millis(POLL_INTERVAL_MS);
@@ -57,18 +69,25 @@ pub fn acquire_gov_lock(config: &Config) -> Result<GovLockGuard> {
             }
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
                 if Instant::now() >= deadline {
-                    anyhow::bail!(
-                        "Another govctl write command is in progress. \
-                         Wait for it to finish or retry later. \
-                         (Timed out after {} seconds waiting for exclusive access.)",
-                        timeout_secs
-                    );
+                    return Err(Diagnostic::new(
+                        DiagnosticCode::E0503LockTimeout,
+                        format!(
+                            "Another govctl write command is in progress. Wait for it to finish or retry later. (Timed out after {} seconds waiting for exclusive access.)",
+                            timeout_secs
+                        ),
+                        lock_path.display().to_string(),
+                    )
+                    .into());
                 }
                 thread::sleep(poll);
             }
             Err(e) => {
-                return Err(e)
-                    .with_context(|| format!("Failed to acquire lock: {}", lock_path.display()));
+                return Err(Diagnostic::new(
+                    DiagnosticCode::E0901IoError,
+                    format!("Failed to acquire lock: {}", e),
+                    lock_path.display().to_string(),
+                )
+                .into());
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ mod tui;
 pub(crate) use cli::*;
 
 use config::Config;
-use diagnostic::{Diagnostic, DiagnosticLevel};
+use diagnostic::{Diagnostic, DiagnosticCode, DiagnosticLevel};
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
@@ -122,8 +122,13 @@ fn run(cli: &Cli) -> anyhow::Result<Vec<Diagnostic>> {
         if matches!(canonical, command_router::CanonicalCommand::Init { .. }) {
             let gov_root = config.gov_root.as_path();
             if !gov_root.exists() {
-                std::fs::create_dir_all(gov_root)
-                    .map_err(|e| anyhow::anyhow!("Failed to create gov root: {}", e))?;
+                std::fs::create_dir_all(gov_root).map_err(|e| {
+                    Diagnostic::new(
+                        DiagnosticCode::E0901IoError,
+                        format!("Failed to create gov root: {}", e),
+                        gov_root.display().to_string(),
+                    )
+                })?;
             }
         }
         Some(lock::acquire_gov_lock(&config)?)

--- a/src/model.rs
+++ b/src/model.rs
@@ -298,17 +298,8 @@ pub struct AdrMeta {
     pub superseded_by: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub refs: Vec<String>,
-}
-
-/// Status for ADR alternatives
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, AsRefStr)]
-#[serde(rename_all = "lowercase")]
-#[strum(serialize_all = "lowercase")]
-pub enum AlternativeStatus {
-    #[default]
-    Considered,
-    Rejected,
-    Accepted,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub migration: Option<AdrMigrationMeta>,
 }
 
 /// An alternative option considered in an ADR.
@@ -316,8 +307,6 @@ pub enum AlternativeStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Alternative {
     pub text: String,
-    #[serde(default)]
-    pub status: AlternativeStatus,
     /// Advantages of this alternative per [[ADR-0027]]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pros: Vec<String>,
@@ -334,12 +323,58 @@ impl Alternative {
     pub fn new(text: impl Into<String>) -> Self {
         Self {
             text: text.into(),
-            status: AlternativeStatus::Considered,
             pros: vec![],
             cons: vec![],
             rejection_reason: None,
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AdrNegativeConsequence {
+    pub text: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mitigations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AdrConsequences {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub positive: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub negative: Vec<AdrNegativeConsequence>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub neutral: Vec<String>,
+}
+
+impl AdrConsequences {
+    pub fn is_empty(&self) -> bool {
+        self.positive.is_empty() && self.negative.is_empty() && self.neutral.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, AsRefStr)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum AdrMigrationState {
+    Migrated,
+    NeedsReview,
+    Verified,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdrMigrationWarning {
+    pub code: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdrMigrationMeta {
+    pub state: AdrMigrationState,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<AdrMigrationWarning>,
 }
 
 /// ADR content section `[content]`
@@ -349,8 +384,10 @@ pub struct AdrContent {
     pub context: String,
     #[serde(default)]
     pub decision: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_option: Option<String>,
     #[serde(default)]
-    pub consequences: String,
+    pub consequences: AdrConsequences,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub alternatives: Vec<Alternative>,
 }
@@ -757,14 +794,18 @@ mod tests {
     fn test_alternative_new() {
         let alt = Alternative::new("Use Redis for caching");
         assert_eq!(alt.text, "Use Redis for caching");
-        assert_eq!(alt.status, AlternativeStatus::Considered);
+        assert!(alt.pros.is_empty());
+        assert!(alt.cons.is_empty());
+        assert!(alt.rejection_reason.is_none());
     }
 
     #[test]
     fn test_alternative_new_from_string() {
         let alt = Alternative::new(String::from("Use PostgreSQL"));
         assert_eq!(alt.text, "Use PostgreSQL");
-        assert_eq!(alt.status, AlternativeStatus::Considered);
+        assert!(alt.pros.is_empty());
+        assert!(alt.cons.is_empty());
+        assert!(alt.rejection_reason.is_none());
     }
 
     // =========================================================================
@@ -774,11 +815,6 @@ mod tests {
     #[test]
     fn test_checklist_status_default() {
         assert_eq!(ChecklistStatus::default(), ChecklistStatus::Pending);
-    }
-
-    #[test]
-    fn test_alternative_status_default() {
-        assert_eq!(AlternativeStatus::default(), AlternativeStatus::Considered);
     }
 
     #[test]
@@ -827,13 +863,6 @@ mod tests {
         assert_eq!(ChecklistStatus::Cancelled.as_ref(), "cancelled");
     }
 
-    #[test]
-    fn test_alternative_status_as_ref() {
-        assert_eq!(AlternativeStatus::Considered.as_ref(), "considered");
-        assert_eq!(AlternativeStatus::Rejected.as_ref(), "rejected");
-        assert_eq!(AlternativeStatus::Accepted.as_ref(), "accepted");
-    }
-
     // =========================================================================
     // AdrEntry/WorkItemEntry accessor Tests
     // =========================================================================
@@ -850,6 +879,7 @@ mod tests {
                     date: "2026-01-17".to_string(),
                     superseded_by: None,
                     refs: vec![],
+                    migration: None,
                 },
                 content: AdrContent::default(),
             },

--- a/src/render.rs
+++ b/src/render.rs
@@ -360,6 +360,22 @@ pub fn render_adr(adr: &AdrEntry) -> anyhow::Result<String> {
         let _ = writeln!(out);
     }
 
+    if let Some(ref migration) = meta.migration {
+        let _ = writeln!(out, "> **Migration:** {}", migration.state.as_ref());
+        for warning in &migration.warnings {
+            if let Some(ref path) = warning.path {
+                let _ = writeln!(
+                    out,
+                    "> Warning {} ({}): {}",
+                    warning.code, path, warning.message
+                );
+            } else {
+                let _ = writeln!(out, "> Warning {}: {}", warning.code, warning.message);
+            }
+        }
+        let _ = writeln!(out);
+    }
+
     // Context
     let _ = writeln!(out, "## Context");
     let _ = writeln!(out);
@@ -370,27 +386,24 @@ pub fn render_adr(adr: &AdrEntry) -> anyhow::Result<String> {
     let _ = writeln!(out, "## Decision");
     let _ = writeln!(out);
     let _ = writeln!(out, "{}", content.decision);
+    if let Some(ref selected) = content.selected_option {
+        let _ = writeln!(out);
+        let _ = writeln!(out, "**Selected option:** `{selected}`");
+    }
     let _ = writeln!(out);
 
     // Consequences
     let _ = writeln!(out, "## Consequences");
     let _ = writeln!(out);
-    let _ = writeln!(out, "{}", content.consequences);
+    render_adr_consequences(&mut out, &content.consequences);
     let _ = writeln!(out);
 
     // Alternatives Considered (extended per ADR-0027)
     if !content.alternatives.is_empty() {
-        use crate::model::AlternativeStatus;
         let _ = writeln!(out, "## Alternatives Considered");
         let _ = writeln!(out);
         for alt in &content.alternatives {
-            // Render as subheading with status
-            let status_suffix = match alt.status {
-                AlternativeStatus::Considered => "",
-                AlternativeStatus::Accepted => " (accepted)",
-                AlternativeStatus::Rejected => " (rejected)",
-            };
-            let _ = writeln!(out, "### {}{}", alt.text, status_suffix);
+            let _ = writeln!(out, "### {}", alt.text);
             let _ = writeln!(out);
 
             // Pros
@@ -413,6 +426,49 @@ pub fn render_adr(adr: &AdrEntry) -> anyhow::Result<String> {
     }
 
     Ok(out)
+}
+
+fn render_adr_consequences(out: &mut String, consequences: &crate::model::AdrConsequences) {
+    if consequences.is_empty() {
+        let _ = writeln!(out, "_None recorded._");
+        return;
+    }
+
+    if !consequences.positive.is_empty() {
+        let _ = writeln!(out, "### Positive");
+        let _ = writeln!(out);
+        render_consequence_lines(out, &consequences.positive);
+        let _ = writeln!(out);
+    }
+
+    if !consequences.negative.is_empty() {
+        let _ = writeln!(out, "### Negative");
+        let _ = writeln!(out);
+        for item in &consequences.negative {
+            let _ = writeln!(out, "- {}", item.text);
+            for mitigation in &item.mitigations {
+                let _ = writeln!(out, "  - Mitigation: {}", mitigation);
+            }
+        }
+        let _ = writeln!(out);
+    }
+
+    if !consequences.neutral.is_empty() {
+        let _ = writeln!(out, "### Neutral");
+        let _ = writeln!(out);
+        render_consequence_lines(out, &consequences.neutral);
+    }
+}
+
+fn render_consequence_lines(out: &mut String, items: &[String]) {
+    for item in items {
+        if item.contains('\n') {
+            let _ = writeln!(out, "{}", item);
+            let _ = writeln!(out);
+        } else {
+            let _ = writeln!(out, "- {}", item);
+        }
+    }
 }
 
 /// Write rendered ADR to file
@@ -547,8 +603,8 @@ pub fn write_work_item_md(
 mod tests {
     use super::*;
     use crate::model::{
-        AdrContent, AdrMeta, AdrSpec, AdrStatus, Alternative, AlternativeStatus, JournalEntry,
-        WorkItemContent, WorkItemMeta, WorkItemSpec, WorkItemStatus,
+        AdrConsequences, AdrContent, AdrMeta, AdrNegativeConsequence, AdrSpec, AdrStatus,
+        Alternative, JournalEntry, WorkItemContent, WorkItemMeta, WorkItemSpec, WorkItemStatus,
     };
 
     const DEFAULT_PATTERN: &str = r"\[\[(RFC-\d{4}(?::C-[A-Z][A-Z0-9-]*)?|ADR-\d{4}|WI-\d{4}-\d{2}-\d{2}-(?:[a-f0-9]{4}(?:-\d{3})?|\d{3}))\]\]";
@@ -720,14 +776,19 @@ mod tests {
                     date: "2026-02-22".to_string(),
                     superseded_by: None,
                     refs: vec![],
+                    migration: None,
                 },
                 content: AdrContent {
                     context: "Test context".to_string(),
                     decision: "Test decision".to_string(),
-                    consequences: "Test consequences".to_string(),
+                    selected_option: Some("Option Selected".to_string()),
+                    consequences: AdrConsequences {
+                        positive: vec!["Test consequence".to_string()],
+                        negative: vec![],
+                        neutral: vec![],
+                    },
                     alternatives: vec![Alternative {
                         text: "Option A".to_string(),
-                        status: AlternativeStatus::Considered,
                         pros: vec!["Fast".to_string(), "Cheap".to_string()],
                         cons: vec!["Less reliable".to_string()],
                         rejection_reason: None,
@@ -738,6 +799,7 @@ mod tests {
         };
 
         let result = render_adr(&adr).unwrap();
+        assert!(result.contains("**Selected option:** `Option Selected`"));
         assert!(result.contains("### Option A"));
         assert!(result.contains("- **Pros:** Fast, Cheap"));
         assert!(result.contains("- **Cons:** Less reliable"));
@@ -755,14 +817,22 @@ mod tests {
                     date: "2026-02-22".to_string(),
                     superseded_by: None,
                     refs: vec![],
+                    migration: None,
                 },
                 content: AdrContent {
                     context: "Test context".to_string(),
                     decision: "Test decision".to_string(),
-                    consequences: "Test consequences".to_string(),
+                    selected_option: None,
+                    consequences: AdrConsequences {
+                        positive: vec![],
+                        negative: vec![AdrNegativeConsequence {
+                            text: "Operational cost increases".to_string(),
+                            mitigations: vec!["Automate cleanup".to_string()],
+                        }],
+                        neutral: vec![],
+                    },
                     alternatives: vec![Alternative {
                         text: "Option B".to_string(),
-                        status: AlternativeStatus::Rejected,
                         pros: vec![],
                         cons: vec!["Too expensive".to_string()],
                         rejection_reason: Some("Budget constraints".to_string()),
@@ -773,7 +843,9 @@ mod tests {
         };
 
         let result = render_adr(&adr).unwrap();
-        assert!(result.contains("### Option B (rejected)"));
+        assert!(result.contains("### Negative"));
+        assert!(result.contains("Mitigation: Automate cleanup"));
+        assert!(result.contains("### Option B"));
         assert!(result.contains("- **Rejected because:** Budget constraints"));
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -40,7 +40,8 @@ fn project_load_error(diags: Vec<Diagnostic>, gov_root: &std::path::Path) -> any
 /// Run the TUI application
 pub fn run(config: &Config) -> Result<()> {
     // Load project data
-    let index = load_project(config).map_err(|diags| project_load_error(diags, &config.gov_root))?;
+    let index =
+        load_project(config).map_err(|diags| project_load_error(diags, &config.gov_root))?;
 
     // Setup terminal
     enable_raw_mode()?;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -8,6 +8,7 @@ mod event;
 mod ui;
 
 use crate::config::Config;
+use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticLevel};
 use crate::load::load_project;
 use anyhow::Result;
 use crossterm::{
@@ -23,14 +24,19 @@ pub use app::App;
 pub fn run(config: &Config) -> Result<()> {
     // Load project data
     let index = load_project(config).map_err(|diags| {
-        anyhow::anyhow!(
-            "Failed to load project: {}",
-            diags
-                .iter()
-                .map(|d| d.message.clone())
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
+        let mut diags = diags.into_iter();
+        diags
+            .find(|d| d.level == DiagnosticLevel::Error)
+            .or_else(|| diags.next())
+            .map(anyhow::Error::from)
+            .unwrap_or_else(|| {
+                Diagnostic::new(
+                    DiagnosticCode::E0501ConfigInvalid,
+                    "Failed to load project",
+                    config.gov_root.display().to_string(),
+                )
+                .into()
+            })
     })?;
 
     // Setup terminal

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -20,24 +20,27 @@ use ratatui::prelude::*;
 
 pub use app::App;
 
+fn project_load_error(diags: Vec<Diagnostic>, gov_root: &std::path::Path) -> anyhow::Error {
+    let first = diags.first().cloned();
+    diags
+        .into_iter()
+        .find(|d| d.level == DiagnosticLevel::Error)
+        .or(first)
+        .map(anyhow::Error::from)
+        .unwrap_or_else(|| {
+            Diagnostic::new(
+                DiagnosticCode::E0501ConfigInvalid,
+                "Failed to load project",
+                gov_root.display().to_string(),
+            )
+            .into()
+        })
+}
+
 /// Run the TUI application
 pub fn run(config: &Config) -> Result<()> {
     // Load project data
-    let index = load_project(config).map_err(|diags| {
-        let mut diags = diags.into_iter();
-        diags
-            .find(|d| d.level == DiagnosticLevel::Error)
-            .or_else(|| diags.next())
-            .map(anyhow::Error::from)
-            .unwrap_or_else(|| {
-                Diagnostic::new(
-                    DiagnosticCode::E0501ConfigInvalid,
-                    "Failed to load project",
-                    config.gov_root.display().to_string(),
-                )
-                .into()
-            })
-    })?;
+    let index = load_project(config).map_err(|diags| project_load_error(diags, &config.gov_root))?;
 
     // Setup terminal
     enable_raw_mode()?;
@@ -62,4 +65,50 @@ pub fn run(config: &Config) -> Result<()> {
     terminal.show_cursor()?;
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_project_load_error_prefers_error_diagnostic() {
+        let err = project_load_error(
+            vec![
+                Diagnostic::new(DiagnosticCode::W0109WorkNoActive, "warning", "warn"),
+                Diagnostic::new(DiagnosticCode::E0302AdrNotFound, "missing adr", "gov/adr"),
+            ],
+            std::path::Path::new("gov"),
+        );
+
+        let diag = err.downcast_ref::<Diagnostic>().expect("diagnostic");
+        assert_eq!(diag.code, DiagnosticCode::E0302AdrNotFound);
+        assert_eq!(diag.message, "missing adr");
+    }
+
+    #[test]
+    fn test_project_load_error_uses_warning_when_no_errors_exist() {
+        let err = project_load_error(
+            vec![Diagnostic::new(
+                DiagnosticCode::W0109WorkNoActive,
+                "warning only",
+                "gov/work",
+            )],
+            std::path::Path::new("gov"),
+        );
+
+        let diag = err.downcast_ref::<Diagnostic>().expect("diagnostic");
+        assert_eq!(diag.code, DiagnosticCode::W0109WorkNoActive);
+        assert_eq!(diag.message, "warning only");
+    }
+
+    #[test]
+    fn test_project_load_error_falls_back_when_empty() {
+        let err = project_load_error(vec![], std::path::Path::new("gov"));
+
+        let diag = err.downcast_ref::<Diagnostic>().expect("diagnostic");
+        assert_eq!(diag.code, DiagnosticCode::E0501ConfigInvalid);
+        assert_eq!(diag.message, "Failed to load project");
+        assert_eq!(diag.file, "gov");
+    }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -326,6 +326,38 @@ pub fn validate_project(index: &ProjectIndex, config: &Config) -> ValidationResu
                 adr_path_display,
             ));
         }
+
+        if let Some(ref migration) = adr.meta().migration {
+            if matches!(
+                migration.state,
+                crate::model::AdrMigrationState::NeedsReview
+            ) {
+                result.diagnostics.push(Diagnostic::new(
+                    DiagnosticCode::W0111AdrMigrationNeedsReview,
+                    format!(
+                        "ADR {} still needs migration review before it is treated as fully cleaned up",
+                        adr.meta().id
+                    ),
+                    config.display_path(&adr.path).display().to_string(),
+                ));
+            }
+
+            for warning in &migration.warnings {
+                let location = if let Some(ref path) = warning.path {
+                    format!("{} ({path})", adr.meta().id)
+                } else {
+                    adr.meta().id.clone()
+                };
+                result.diagnostics.push(Diagnostic::new(
+                    DiagnosticCode::W0112AdrMigrationWarning,
+                    format!(
+                        "ADR migration warning [{}]: {}",
+                        warning.code, warning.message
+                    ),
+                    location,
+                ));
+            }
+        }
     }
 
     // Validate artifact references (refs fields)
@@ -613,7 +645,21 @@ fn validate_bracket_reference_hierarchy(
         let c = &adr.spec.content;
         scan_adr_bracket_refs(&re, &c.context, aid, &adr_path, result);
         scan_adr_bracket_refs(&re, &c.decision, aid, &adr_path, result);
-        scan_adr_bracket_refs(&re, &c.consequences, aid, &adr_path, result);
+        if let Some(ref selected) = c.selected_option {
+            scan_adr_bracket_refs(&re, selected, aid, &adr_path, result);
+        }
+        for item in &c.consequences.positive {
+            scan_adr_bracket_refs(&re, item, aid, &adr_path, result);
+        }
+        for item in &c.consequences.neutral {
+            scan_adr_bracket_refs(&re, item, aid, &adr_path, result);
+        }
+        for item in &c.consequences.negative {
+            scan_adr_bracket_refs(&re, &item.text, aid, &adr_path, result);
+            for mitigation in &item.mitigations {
+                scan_adr_bracket_refs(&re, mitigation, aid, &adr_path, result);
+            }
+        }
         for alt in &c.alternatives {
             scan_adr_bracket_refs(&re, &alt.text, aid, &adr_path, result);
             for p in &alt.pros {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -91,7 +91,13 @@ impl FieldValidation {
 
 /// Validate a semver string
 fn validate_semver(value: &str) -> anyhow::Result<()> {
-    semver::Version::parse(value).map_err(|_| anyhow::anyhow!("Invalid semver: {value}"))?;
+    semver::Version::parse(value).map_err(|_| {
+        Diagnostic::new(
+            DiagnosticCode::E0820InvalidFieldValue,
+            format!("Invalid semver: {value}"),
+            value,
+        )
+    })?;
     Ok(())
 }
 
@@ -103,11 +109,13 @@ fn validate_clause_superseded_by(ctx: &ValidationContext, target: &str) -> anyho
     }
 
     // Extract RFC ID from source clause (e.g., "RFC-0001:C-NAME" -> "RFC-0001")
-    let source_rfc = ctx
-        .artifact_id
-        .split(':')
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("Invalid clause ID format: {}", ctx.artifact_id))?;
+    let source_rfc = ctx.artifact_id.split(':').next().ok_or_else(|| {
+        Diagnostic::new(
+            DiagnosticCode::E0210ClauseInvalidIdFormat,
+            format!("Invalid clause ID format: {}", ctx.artifact_id),
+            ctx.artifact_id,
+        )
+    })?;
 
     // Build full target reference
     let full_target = if target.contains(':') {
@@ -117,10 +125,13 @@ fn validate_clause_superseded_by(ctx: &ValidationContext, target: &str) -> anyho
     };
 
     // Check target is in same RFC
-    let target_rfc = full_target
-        .split(':')
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("Invalid target clause ID: {target}"))?;
+    let target_rfc = full_target.split(':').next().ok_or_else(|| {
+        Diagnostic::new(
+            DiagnosticCode::E0210ClauseInvalidIdFormat,
+            format!("Invalid target clause ID: {target}"),
+            target,
+        )
+    })?;
 
     if target_rfc != source_rfc {
         return Err(Diagnostic::new(

--- a/tests/snapshots/test_changelog__changelog_errors.snap
+++ b/tests/snapshots/test_changelog__changelog_errors.snap
@@ -1,11 +1,12 @@
 ---
 source: tests/test_changelog.rs
+assertion_line: 264
 expression: "normalize_output(&error_output, dir, &date)"
 ---
 $ govctl release invalid-version
-Error: error[E0701]: Invalid semver version: invalid-version (gov/releases.toml)
+error[E0701]: Invalid semver version: invalid-version (gov/releases.toml)
 exit: 1
 
 $ govctl release 0.1.0
-Error: error[E0702]: Release 0.1.0 already exists (gov/releases.toml)
+error[E0702]: Release 0.1.0 already exists (gov/releases.toml)
 exit: 1

--- a/tests/snapshots/test_describe__describe_basic.snap
+++ b/tests/snapshots/test_describe__describe_basic.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_describe.rs
+assertion_line: 14
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl describe
@@ -202,9 +203,9 @@ $ govctl describe
     },
     {
       "name": "edit",
-      "purpose": "Edit clause text",
-      "when_to_use": "To update normative clause content. Use --stdin for multi-line text.",
-      "example": "govctl clause edit RFC-0001:C-SCOPE --stdin",
+      "purpose": "Edit clause fields",
+      "when_to_use": "To update clause text or metadata. Use path-first edit form; --stdin works well for multi-line text.",
+      "example": "govctl clause edit RFC-0001:C-SCOPE text --stdin",
       "prerequisites": [
         "Clause must exist"
       ]

--- a/tests/snapshots/test_describe__describe_in_initialized_project.snap
+++ b/tests/snapshots/test_describe__describe_in_initialized_project.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_describe.rs
+assertion_line: 24
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl describe
@@ -202,9 +203,9 @@ $ govctl describe
     },
     {
       "name": "edit",
-      "purpose": "Edit clause text",
-      "when_to_use": "To update normative clause content. Use --stdin for multi-line text.",
-      "example": "govctl clause edit RFC-0001:C-SCOPE --stdin",
+      "purpose": "Edit clause fields",
+      "when_to_use": "To update clause text or metadata. Use path-first edit form; --stdin works well for multi-line text.",
+      "example": "govctl clause edit RFC-0001:C-SCOPE text --stdin",
       "prerequisites": [
         "Clause must exist"
       ]

--- a/tests/snapshots/test_describe__describe_with_context_active_work_item.snap
+++ b/tests/snapshots/test_describe__describe_with_context_active_work_item.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_describe.rs
+assertion_line: 130
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl work new Test task --active
@@ -207,9 +208,9 @@ $ govctl describe --context
     },
     {
       "name": "edit",
-      "purpose": "Edit clause text",
-      "when_to_use": "To update normative clause content. Use --stdin for multi-line text.",
-      "example": "govctl clause edit RFC-0001:C-SCOPE --stdin",
+      "purpose": "Edit clause fields",
+      "when_to_use": "To update clause text or metadata. Use path-first edit form; --stdin works well for multi-line text.",
+      "example": "govctl clause edit RFC-0001:C-SCOPE text --stdin",
       "prerequisites": [
         "Clause must exist"
       ]

--- a/tests/snapshots/test_describe__describe_with_context_draft_rfc.snap
+++ b/tests/snapshots/test_describe__describe_with_context_draft_rfc.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_describe.rs
+assertion_line: 47
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl rfc new Test RFC
@@ -207,9 +208,9 @@ $ govctl describe --context
     },
     {
       "name": "edit",
-      "purpose": "Edit clause text",
-      "when_to_use": "To update normative clause content. Use --stdin for multi-line text.",
-      "example": "govctl clause edit RFC-0001:C-SCOPE --stdin",
+      "purpose": "Edit clause fields",
+      "when_to_use": "To update clause text or metadata. Use path-first edit form; --stdin works well for multi-line text.",
+      "example": "govctl clause edit RFC-0001:C-SCOPE text --stdin",
       "prerequisites": [
         "Clause must exist"
       ]

--- a/tests/snapshots/test_describe__describe_with_context_empty_project.snap
+++ b/tests/snapshots/test_describe__describe_with_context_empty_project.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_describe.rs
+assertion_line: 34
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl describe --context
@@ -202,9 +203,9 @@ $ govctl describe --context
     },
     {
       "name": "edit",
-      "purpose": "Edit clause text",
-      "when_to_use": "To update normative clause content. Use --stdin for multi-line text.",
-      "example": "govctl clause edit RFC-0001:C-SCOPE --stdin",
+      "purpose": "Edit clause fields",
+      "when_to_use": "To update clause text or metadata. Use path-first edit form; --stdin works well for multi-line text.",
+      "example": "govctl clause edit RFC-0001:C-SCOPE text --stdin",
       "prerequisites": [
         "Clause must exist"
       ]

--- a/tests/snapshots/test_describe__describe_with_context_normative_impl_phase_rfc.snap
+++ b/tests/snapshots/test_describe__describe_with_context_normative_impl_phase_rfc.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_describe.rs
+assertion_line: 82
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl rfc new Test RFC
@@ -215,9 +216,9 @@ $ govctl describe --context
     },
     {
       "name": "edit",
-      "purpose": "Edit clause text",
-      "when_to_use": "To update normative clause content. Use --stdin for multi-line text.",
-      "example": "govctl clause edit RFC-0001:C-SCOPE --stdin",
+      "purpose": "Edit clause fields",
+      "when_to_use": "To update clause text or metadata. Use path-first edit form; --stdin works well for multi-line text.",
+      "example": "govctl clause edit RFC-0001:C-SCOPE text --stdin",
       "prerequisites": [
         "Clause must exist"
       ]

--- a/tests/snapshots/test_describe__describe_with_context_normative_spec_phase_rfc.snap
+++ b/tests/snapshots/test_describe__describe_with_context_normative_spec_phase_rfc.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_describe.rs
+assertion_line: 64
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl rfc new Test RFC
@@ -211,9 +212,9 @@ $ govctl describe --context
     },
     {
       "name": "edit",
-      "purpose": "Edit clause text",
-      "when_to_use": "To update normative clause content. Use --stdin for multi-line text.",
-      "example": "govctl clause edit RFC-0001:C-SCOPE --stdin",
+      "purpose": "Edit clause fields",
+      "when_to_use": "To update clause text or metadata. Use path-first edit form; --stdin works well for multi-line text.",
+      "example": "govctl clause edit RFC-0001:C-SCOPE text --stdin",
       "prerequisites": [
         "Clause must exist"
       ]

--- a/tests/snapshots/test_describe__describe_with_context_normative_test_phase_rfc.snap
+++ b/tests/snapshots/test_describe__describe_with_context_normative_test_phase_rfc.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_describe.rs
+assertion_line: 101
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl rfc new Test RFC
@@ -219,9 +220,9 @@ $ govctl describe --context
     },
     {
       "name": "edit",
-      "purpose": "Edit clause text",
-      "when_to_use": "To update normative clause content. Use --stdin for multi-line text.",
-      "example": "govctl clause edit RFC-0001:C-SCOPE --stdin",
+      "purpose": "Edit clause fields",
+      "when_to_use": "To update clause text or metadata. Use path-first edit form; --stdin works well for multi-line text.",
+      "example": "govctl clause edit RFC-0001:C-SCOPE text --stdin",
       "prerequisites": [
         "Clause must exist"
       ]

--- a/tests/snapshots/test_describe__describe_with_context_proposed_adr.snap
+++ b/tests/snapshots/test_describe__describe_with_context_proposed_adr.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_describe.rs
+assertion_line: 114
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl adr new Test Decision
@@ -206,9 +207,9 @@ $ govctl describe --context
     },
     {
       "name": "edit",
-      "purpose": "Edit clause text",
-      "when_to_use": "To update normative clause content. Use --stdin for multi-line text.",
-      "example": "govctl clause edit RFC-0001:C-SCOPE --stdin",
+      "purpose": "Edit clause fields",
+      "when_to_use": "To update clause text or metadata. Use path-first edit form; --stdin works well for multi-line text.",
+      "example": "govctl clause edit RFC-0001:C-SCOPE text --stdin",
       "prerequisites": [
         "Clause must exist"
       ]

--- a/tests/snapshots/test_describe__describe_with_context_queued_work_items.snap
+++ b/tests/snapshots/test_describe__describe_with_context_queued_work_items.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_describe.rs
+assertion_line: 147
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl work new Task one
@@ -212,9 +213,9 @@ $ govctl describe --context
     },
     {
       "name": "edit",
-      "purpose": "Edit clause text",
-      "when_to_use": "To update normative clause content. Use --stdin for multi-line text.",
-      "example": "govctl clause edit RFC-0001:C-SCOPE --stdin",
+      "purpose": "Edit clause fields",
+      "when_to_use": "To update clause text or metadata. Use path-first edit form; --stdin works well for multi-line text.",
+      "example": "govctl clause edit RFC-0001:C-SCOPE text --stdin",
       "prerequisites": [
         "Clause must exist"
       ]

--- a/tests/snapshots/test_display_paths__render_adr_missing_returns_scope_context.snap
+++ b/tests/snapshots/test_display_paths__render_adr_missing_returns_scope_context.snap
@@ -1,0 +1,8 @@
+---
+source: tests/test_display_paths.rs
+assertion_line: 159
+expression: "normalize_output(&output, temp_dir.path(), &date)"
+---
+$ govctl adr render ADR-9999
+No ADRs found
+exit: 0

--- a/tests/snapshots/test_display_paths__render_rfc_missing_returns_scope_context.snap
+++ b/tests/snapshots/test_display_paths__render_rfc_missing_returns_scope_context.snap
@@ -1,0 +1,8 @@
+---
+source: tests/test_display_paths.rs
+assertion_line: 150
+expression: "normalize_output(&output, temp_dir.path(), &date)"
+---
+$ govctl rfc render RFC-9999
+No RFCs found in <TEMPDIR>/gov/rfc
+exit: 0

--- a/tests/snapshots/test_display_paths__render_work_missing_returns_scope_context.snap
+++ b/tests/snapshots/test_display_paths__render_work_missing_returns_scope_context.snap
@@ -1,0 +1,8 @@
+---
+source: tests/test_display_paths.rs
+assertion_line: 168
+expression: "normalize_output(&output, temp_dir.path(), &date)"
+---
+$ govctl work render WI-<DATE>-001
+No work items found
+exit: 0

--- a/tests/snapshots/test_edit__adr_get_nested_path.snap
+++ b/tests/snapshots/test_edit__adr_get_nested_path.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_edit.rs
+assertion_line: 1075
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl adr new Path Test
@@ -29,7 +30,6 @@ exit: 0
 
 $ govctl adr get ADR-0001 alternatives[0]
 text: Use traits
-status: considered
 pros: Flexible, Reusable
 cons: Complex
 exit: 0

--- a/tests/snapshots/test_edit__adr_get_nested_scalar_rejects_index.snap
+++ b/tests/snapshots/test_edit__adr_get_nested_scalar_rejects_index.snap
@@ -12,5 +12,5 @@ Added 'Option X' to ADR-0001.alternatives
 exit: 0
 
 $ govctl adr get ADR-0001 alt[0].text[0]
-error[E0817]: Cannot index into scalar field 'text' (ADR-0001)
+error[E0817]: Cannot index into non-list field 'text' at 'alternatives[0].text[0]' (ADR-0001)
 exit: 1

--- a/tests/snapshots/test_edit__adr_get_nonexistent.snap
+++ b/tests/snapshots/test_edit__adr_get_nonexistent.snap
@@ -1,7 +1,8 @@
 ---
 source: tests/test_edit.rs
+assertion_line: 655
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl adr get ADR-9999 title
-Error: ADR not found: ADR-9999
+error[E0302]: ADR not found: ADR-9999 (gov/adr)
 exit: 1

--- a/tests/snapshots/test_edit__adr_nested_path_rejects_extra_segments.snap
+++ b/tests/snapshots/test_edit__adr_nested_path_rejects_extra_segments.snap
@@ -12,5 +12,5 @@ Added 'Option X' to ADR-0001.alternatives
 exit: 0
 
 $ govctl adr get ADR-0001 alt[0].pros[0].oops
-error[E0814]: Path 'alternatives[0].pros[0].oops' exceeds max depth 2 for adr.alternatives (ADR-0001)
+error[E0817]: Cannot descend into non-object path 'alternatives[0].pros[0].oops' (ADR-0001)
 exit: 1

--- a/tests/snapshots/test_edit__adr_set_consequences.snap
+++ b/tests/snapshots/test_edit__adr_set_consequences.snap
@@ -1,13 +1,22 @@
 ---
 source: tests/test_edit.rs
+assertion_line: 579
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl adr new Test Decision
 Created ADR: gov/adr/ADR-XXXX-test-decision.toml
 exit: 0
 
-$ govctl adr set ADR-0001 consequences Good: faster. Bad: more memory.
-Set ADR-0001.consequences = Good: faster. Bad: more memory.
+$ govctl adr edit ADR-0001 content.consequences.positive --add Faster reads
+Added 'Faster reads' to ADR-0001.consequences.positive
+exit: 0
+
+$ govctl adr edit ADR-0001 content.consequences.negative --add More memory use
+Added 'More memory use' to ADR-0001.consequences.negative
+exit: 0
+
+$ govctl adr edit ADR-0001 content.consequences.negative[0].mitigations --add Cache only hot paths
+Added 'Cache only hot paths' to ADR-0001.consequences.negative[0].mitigations
 exit: 0
 
 $ govctl adr show ADR-0001
@@ -27,5 +36,12 @@ What is the change that we're proposing and/or doing?
 
 ## Consequences
 
-Good: faster. Bad: more memory.
+### Positive
+
+- Faster reads
+
+### Negative
+
+- More memory use
+  - Mitigation: Cache only hot paths
 exit: 0

--- a/tests/snapshots/test_edit__adr_set_context.snap
+++ b/tests/snapshots/test_edit__adr_set_context.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_edit.rs
+assertion_line: 524
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl adr new Test Decision
@@ -26,6 +27,5 @@ What is the change that we're proposing and/or doing?
 
 ## Consequences
 
-Describe the resulting context after applying the decision.
-What becomes easier or more difficult to do because of this change?
+_None recorded._
 exit: 0

--- a/tests/snapshots/test_edit__adr_set_decision.snap
+++ b/tests/snapshots/test_edit__adr_set_decision.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_edit.rs
+assertion_line: 540
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl adr new Test Decision
@@ -26,6 +27,5 @@ We decided to do X
 
 ## Consequences
 
-Describe the resulting context after applying the decision.
-What becomes easier or more difficult to do because of this change?
+_None recorded._
 exit: 0

--- a/tests/snapshots/test_edit__clause_edit_nonexistent.snap
+++ b/tests/snapshots/test_edit__clause_edit_nonexistent.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_edit.rs
+assertion_line: 435
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl rfc new Test RFC

--- a/tests/snapshots/test_edit__clause_edit_nonexistent.snap
+++ b/tests/snapshots/test_edit__clause_edit_nonexistent.snap
@@ -9,5 +9,5 @@ Created RFC: gov/rfc/RFC-0001/rfc.toml
 exit: 0
 
 $ govctl clause edit RFC-0001:C-NONEXISTENT --text Text
-Error: Clause not found: RFC-0001:C-NONEXISTENT
+error[E0202]: Clause not found: RFC-0001:C-NONEXISTENT (gov/rfc/RFC-0001/clauses)
 exit: 1

--- a/tests/snapshots/test_edit__clause_edit_text_canonical.snap
+++ b/tests/snapshots/test_edit__clause_edit_text_canonical.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/test_edit.rs
-assertion_line: 217
+assertion_line: 250
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl rfc new Test RFC
@@ -13,8 +13,8 @@ Created clause: gov/rfc/RFC-0001/clauses/C-TEST.toml
   Added to section 'Specification', path: clauses/C-TEST.toml
 exit: 0
 
-$ govctl clause edit RFC-0001:C-TEST --text Updated clause text
-Updated clause: RFC-0001:C-TEST
+$ govctl clause edit RFC-0001:C-TEST text --set Updated clause text
+Set RFC-0001:C-TEST.text = Updated clause text
 exit: 0
 
 $ govctl clause show RFC-0001:C-TEST

--- a/tests/snapshots/test_edit__clause_edit_title_canonical.snap
+++ b/tests/snapshots/test_edit__clause_edit_title_canonical.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/test_edit.rs
-assertion_line: 217
+assertion_line: 309
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl rfc new Test RFC
@@ -8,17 +8,17 @@ Created RFC: gov/rfc/RFC-0001/rfc.toml
   Clauses dir: gov/rfc/RFC-0001/clauses
 exit: 0
 
-$ govctl clause new RFC-0001:C-TEST Test Clause -s Specification -k normative
+$ govctl clause new RFC-0001:C-TEST Original Title -s Specification -k normative
 Created clause: gov/rfc/RFC-0001/clauses/C-TEST.toml
   Added to section 'Specification', path: clauses/C-TEST.toml
 exit: 0
 
-$ govctl clause edit RFC-0001:C-TEST --text Updated clause text
-Updated clause: RFC-0001:C-TEST
+$ govctl clause edit RFC-0001:C-TEST title --set New Title
+Set RFC-0001:C-TEST.title = New Title
 exit: 0
 
 $ govctl clause show RFC-0001:C-TEST
-### [RFC-0001:C-TEST] Test Clause (Normative)
+### [RFC-0001:C-TEST] New Title (Normative)
 
-Updated clause text
+TODO: Add clause text here.
 exit: 0

--- a/tests/snapshots/test_edit__clause_set_text_sugar.snap
+++ b/tests/snapshots/test_edit__clause_set_text_sugar.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/test_edit.rs
-assertion_line: 217
+assertion_line: 391
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl rfc new Test RFC
@@ -13,12 +13,12 @@ Created clause: gov/rfc/RFC-0001/clauses/C-TEST.toml
   Added to section 'Specification', path: clauses/C-TEST.toml
 exit: 0
 
-$ govctl clause edit RFC-0001:C-TEST --text Updated clause text
-Updated clause: RFC-0001:C-TEST
+$ govctl clause set RFC-0001:C-TEST text new text
+Set RFC-0001:C-TEST.text = new text
 exit: 0
 
 $ govctl clause show RFC-0001:C-TEST
 ### [RFC-0001:C-TEST] Test Clause (Normative)
 
-Updated clause text
+new text
 exit: 0

--- a/tests/snapshots/test_edit__rfc_get_nonexistent.snap
+++ b/tests/snapshots/test_edit__rfc_get_nonexistent.snap
@@ -1,7 +1,8 @@
 ---
 source: tests/test_edit.rs
+assertion_line: 181
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl rfc get RFC-9999 title
-Error: RFC not found: RFC-9999
+error[E0102]: RFC not found: RFC-9999 (gov/rfc)
 exit: 1

--- a/tests/snapshots/test_edit__tick_rejects_nested_path.snap
+++ b/tests/snapshots/test_edit__tick_rejects_nested_path.snap
@@ -12,5 +12,5 @@ Added 'add: Criterion 1' to WI-<DATE>-001.acceptance_criteria
 exit: 0
 
 $ govctl work tick WI-<DATE>-001 ac[0].text Criterion 1 -s done
-error[E0817]: tick does not support nested paths (WI-<DATE>-001)
+error[E0817]: tick only supports checklist root paths or indexed checklist items (WI-<DATE>-001)
 exit: 1

--- a/tests/snapshots/test_edit__work_get_nested_scalar_rejects_index.snap
+++ b/tests/snapshots/test_edit__work_get_nested_scalar_rejects_index.snap
@@ -13,5 +13,5 @@ Added 'Did something' to WI-<DATE>-001.journal
 exit: 0
 
 $ govctl work get WI-<DATE>-001 journal[0].content[0]
-error[E0817]: Cannot index into scalar field 'content' (WI-<DATE>-001)
+error[E0817]: Cannot index into non-list field 'content' at 'journal[0].content[0]' (WI-<DATE>-001)
 exit: 1

--- a/tests/snapshots/test_edit__work_get_nonexistent.snap
+++ b/tests/snapshots/test_edit__work_get_nonexistent.snap
@@ -1,7 +1,8 @@
 ---
 source: tests/test_edit.rs
+assertion_line: 987
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl work get WI-9999-99-999 title
-Error: Work item not found: WI-9999-99-999
+error[E0402]: Work item not found: WI-9999-99-999 (gov/work)
 exit: 1

--- a/tests/snapshots/test_lifecycle__accept_already_accepted_fails.snap
+++ b/tests/snapshots/test_lifecycle__accept_already_accepted_fails.snap
@@ -1,9 +1,14 @@
 ---
 source: tests/test_lifecycle.rs
+assertion_line: 427
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl adr new Test Decision
 Created ADR: gov/adr/ADR-XXXX-test-decision.toml
+exit: 0
+
+$ govctl adr set ADR-0001 selected_option Option A
+Set ADR-0001.selected_option = Option A
 exit: 0
 
 $ govctl adr accept ADR-0001

--- a/tests/snapshots/test_lifecycle__accept_proposed_adr.snap
+++ b/tests/snapshots/test_lifecycle__accept_proposed_adr.snap
@@ -1,9 +1,14 @@
 ---
 source: tests/test_lifecycle.rs
+assertion_line: 382
 expression: "normalize_output(&output, temp_dir.path(), &date)"
 ---
 $ govctl adr new Test Decision
 Created ADR: gov/adr/ADR-XXXX-test-decision.toml
+exit: 0
+
+$ govctl adr set ADR-0001 selected_option Option A
+Set ADR-0001.selected_option = Option A
 exit: 0
 
 $ govctl adr list

--- a/tests/snapshots/test_lifecycle__accept_proposed_adr_requires_selected_option.snap
+++ b/tests/snapshots/test_lifecycle__accept_proposed_adr_requires_selected_option.snap
@@ -1,0 +1,12 @@
+---
+source: tests/test_lifecycle.rs
+assertion_line: 394
+expression: "normalize_output(&output, temp_dir.path(), &date)"
+---
+$ govctl adr new Test Decision
+Created ADR: gov/adr/ADR-XXXX-test-decision.toml
+exit: 0
+
+$ govctl adr accept ADR-0001
+error[E0301]: Accepted ADRs require content.selected_option before acceptance (hint: `govctl adr set ADR-0001 selected_option "..."`) (ADR-0001)
+exit: 1

--- a/tests/test_display_paths.rs
+++ b/tests/test_display_paths.rs
@@ -87,8 +87,9 @@ refs = []
 [content]
 context = "Test context"
 decision = "Test decision"
-consequences = "Test consequences"
 alternatives = []
+
+[content.consequences]
 "#,
     )
     .unwrap();

--- a/tests/test_display_paths.rs
+++ b/tests/test_display_paths.rs
@@ -141,6 +141,33 @@ notes = []
     insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
 }
 
+#[test]
+fn test_render_rfc_missing_returns_scope_context() {
+    let temp_dir = init_project();
+    let date = today();
+
+    let output = run_commands(temp_dir.path(), &[&["rfc", "render", "RFC-9999"]]);
+    insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
+}
+
+#[test]
+fn test_render_adr_missing_returns_scope_context() {
+    let temp_dir = init_project();
+    let date = today();
+
+    let output = run_commands(temp_dir.path(), &[&["adr", "render", "ADR-9999"]]);
+    insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
+}
+
+#[test]
+fn test_render_work_missing_returns_scope_context() {
+    let temp_dir = init_project();
+    let date = today();
+
+    let output = run_commands(temp_dir.path(), &[&["work", "render", "WI-9999-01-01-001"]]);
+    insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
+}
+
 /// Test: Delete work item dry-run shows relative path
 #[test]
 fn test_delete_work_dry_run_display_path() {

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -92,6 +92,38 @@ fn test_rfc_add_ref() {
 }
 
 #[test]
+fn test_rfc_edit_set_title_canonical() {
+    let temp_dir = init_project();
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[
+            &["rfc", "new", "Original Title"],
+            &[
+                "rfc",
+                "edit",
+                "RFC-0001",
+                "title",
+                "--set",
+                "Canonical Title",
+            ],
+            &["rfc", "get", "RFC-0001", "title"],
+        ],
+    );
+
+    assert!(
+        output.contains("Set RFC-0001.title = Canonical Title"),
+        "output: {}",
+        output
+    );
+    assert!(
+        output.contains("$ govctl rfc get RFC-0001 title\nCanonical Title"),
+        "output: {}",
+        output
+    );
+}
+
+#[test]
 fn test_rfc_set_nonexistent_field() {
     let temp_dir = init_project();
     let date = today();
@@ -388,7 +420,7 @@ fn test_adr_set_status_rejected() {
 }
 
 #[test]
-fn test_adr_set_alternative_status_rejected() {
+fn test_adr_set_alternative_status_field_rejected() {
     let temp_dir = init_project();
 
     let output = run_commands(
@@ -405,8 +437,8 @@ fn test_adr_set_alternative_status_rejected() {
             ],
         ],
     );
-    assert!(output.contains("error[E0804]"), "output: {}", output);
-    assert!(output.contains("govctl adr tick"), "output: {}", output);
+    assert!(output.contains("error[E0815]"), "output: {}", output);
+    assert!(output.contains("status"), "output: {}", output);
 }
 
 #[test]
@@ -423,6 +455,51 @@ fn test_adr_add_ref() {
         ],
     );
     insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
+}
+
+#[test]
+fn test_adr_edit_add_nested_path_canonical() {
+    let temp_dir = init_project();
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[
+            &["adr", "new", "Canonical Edit ADR"],
+            &[
+                "adr",
+                "edit",
+                "ADR-0001",
+                "content.alternatives",
+                "--add",
+                "Option A",
+            ],
+            &[
+                "adr",
+                "edit",
+                "ADR-0001",
+                "content.alternatives[0].pros",
+                "--add",
+                "Readable",
+            ],
+            &["adr", "get", "ADR-0001", "alternatives[0].pros"],
+        ],
+    );
+
+    assert!(
+        output.contains("Added 'Option A' to ADR-0001.alternatives"),
+        "output: {}",
+        output
+    );
+    assert!(
+        output.contains("Added 'Readable' to ADR-0001.alternatives[0].pros"),
+        "output: {}",
+        output
+    );
+    assert!(
+        output.contains("$ govctl adr get ADR-0001 alternatives[0].pros\nReadable"),
+        "output: {}",
+        output
+    );
 }
 
 #[test]
@@ -474,10 +551,27 @@ fn test_adr_set_consequences() {
             &["adr", "new", "Test Decision"],
             &[
                 "adr",
-                "set",
+                "edit",
                 "ADR-0001",
-                "consequences",
-                "Good: faster. Bad: more memory.",
+                "content.consequences.positive",
+                "--add",
+                "Faster reads",
+            ],
+            &[
+                "adr",
+                "edit",
+                "ADR-0001",
+                "content.consequences.negative",
+                "--add",
+                "More memory use",
+            ],
+            &[
+                "adr",
+                "edit",
+                "ADR-0001",
+                "content.consequences.negative[0].mitigations",
+                "--add",
+                "Cache only hot paths",
             ],
             &["adr", "show", "ADR-0001"],
         ],
@@ -648,6 +742,52 @@ fn test_work_tick_acceptance_criteria() {
         ],
     );
     insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
+}
+
+#[test]
+fn test_work_edit_tick_indexed_path_canonical() {
+    let temp_dir = init_project();
+    let date = today();
+    let wi_id = format!("WI-{}-001", date);
+
+    let commands = vec![
+        vec![
+            "work".to_string(),
+            "new".to_string(),
+            "Canonical Tick".to_string(),
+        ],
+        vec![
+            "work".to_string(),
+            "edit".to_string(),
+            wi_id.clone(),
+            "content.acceptance_criteria".to_string(),
+            "--add".to_string(),
+            "add: Criterion 1".to_string(),
+        ],
+        vec![
+            "work".to_string(),
+            "edit".to_string(),
+            wi_id.clone(),
+            "content.acceptance_criteria[0]".to_string(),
+            "--tick".to_string(),
+            "done".to_string(),
+        ],
+        vec!["work".to_string(), "show".to_string(), wi_id],
+    ];
+
+    let output = common::run_dynamic_commands(temp_dir.path(), &commands);
+
+    assert!(
+        output.contains("Added 'add: Criterion 1' to WI-"),
+        "output: {}",
+        output
+    );
+    assert!(
+        output.contains("Marked 'Criterion 1' as done"),
+        "output: {}",
+        output
+    );
+    assert!(output.contains("- ✓ Criterion 1"), "output: {}", output);
 }
 
 #[test]
@@ -1146,6 +1286,46 @@ fn test_adr_remove_nested_path_requires_selector() {
         ],
     );
     insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
+}
+
+#[test]
+fn test_adr_edit_tick_rejects_alternative_root() {
+    let temp_dir = init_project();
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[
+            &["adr", "new", "Tick Reject Test"],
+            &["adr", "add", "ADR-0001", "alternatives", "Option A"],
+            &["adr", "edit", "ADR-0001", "alternatives", "--tick", "done"],
+        ],
+    );
+    assert!(
+        output.contains("Unknown field for tick: alternatives"),
+        "output: {}",
+        output
+    );
+    assert!(output.contains("exit: 1"), "output: {}", output);
+}
+
+#[test]
+fn test_adr_edit_tick_rejects_indexed_alternative_item() {
+    let temp_dir = init_project();
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[
+            &["adr", "new", "Indexed Tick Reject Test"],
+            &["adr", "add", "ADR-0001", "alternatives", "Option A"],
+            &["adr", "edit", "ADR-0001", "alt[0]", "--tick", "done"],
+        ],
+    );
+    assert!(
+        output.contains("Unknown field for tick: alternatives"),
+        "output: {}",
+        output
+    );
+    assert!(output.contains("exit: 1"), "output: {}", output);
 }
 
 #[test]

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -1368,7 +1368,7 @@ fn test_adr_edit_tick_rejects_alternative_root() {
         ],
     );
     assert!(
-        output.contains("Unknown field for tick: alternatives"),
+        output.contains("Tick only works for work items: ADR-0001"),
         "output: {}",
         output
     );
@@ -1388,7 +1388,7 @@ fn test_adr_edit_tick_rejects_indexed_alternative_item() {
         ],
     );
     assert!(
-        output.contains("Unknown field for tick: alternatives"),
+        output.contains("Tick only works for work items: ADR-0001"),
         "output: {}",
         output
     );

--- a/tests/test_edit.rs
+++ b/tests/test_edit.rs
@@ -218,6 +218,39 @@ fn test_clause_set_text() {
 }
 
 #[test]
+fn test_clause_edit_text_canonical() {
+    let temp_dir = init_project();
+    let date = today();
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[
+            &["rfc", "new", "Test RFC"],
+            &[
+                "clause",
+                "new",
+                "RFC-0001:C-TEST",
+                "Test Clause",
+                "-s",
+                "Specification",
+                "-k",
+                "normative",
+            ],
+            &[
+                "clause",
+                "edit",
+                "RFC-0001:C-TEST",
+                "text",
+                "--set",
+                "Updated clause text",
+            ],
+            &["clause", "show", "RFC-0001:C-TEST"],
+        ],
+    );
+    insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
+}
+
+#[test]
 fn test_clause_set_title() {
     let temp_dir = init_project();
     let date = today();
@@ -237,6 +270,39 @@ fn test_clause_set_title() {
                 "normative",
             ],
             &["clause", "set", "RFC-0001:C-TEST", "title", "New Title"],
+            &["clause", "show", "RFC-0001:C-TEST"],
+        ],
+    );
+    insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
+}
+
+#[test]
+fn test_clause_edit_title_canonical() {
+    let temp_dir = init_project();
+    let date = today();
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[
+            &["rfc", "new", "Test RFC"],
+            &[
+                "clause",
+                "new",
+                "RFC-0001:C-TEST",
+                "Original Title",
+                "-s",
+                "Specification",
+                "-k",
+                "normative",
+            ],
+            &[
+                "clause",
+                "edit",
+                "RFC-0001:C-TEST",
+                "title",
+                "--set",
+                "New Title",
+            ],
             &["clause", "show", "RFC-0001:C-TEST"],
         ],
     );
@@ -300,8 +366,9 @@ fn test_clause_set_since_rejected() {
 }
 
 #[test]
-fn test_clause_set_text_rejected() {
+fn test_clause_set_text_sugar() {
     let temp_dir = init_project();
+    let date = today();
 
     let output = run_commands(
         temp_dir.path(),
@@ -318,10 +385,10 @@ fn test_clause_set_text_rejected() {
                 "normative",
             ],
             &["clause", "set", "RFC-0001:C-TEST", "text", "new text"],
+            &["clause", "show", "RFC-0001:C-TEST"],
         ],
     );
-    assert!(output.contains("error[E0804]"), "output: {}", output);
-    assert!(output.contains("govctl clause edit"), "output: {}", output);
+    insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
 }
 
 #[test]

--- a/tests/test_errors.rs
+++ b/tests/test_errors.rs
@@ -527,8 +527,10 @@ date = "2026-01-01"
 [content]
 context = "Context"
 decision = "Decision"
-consequences = "Consequences"
 unexpected = "should fail schema validation"
+
+[content.consequences]
+positive = ["Consequences"]
 "#,
     )
     .unwrap();

--- a/tests/test_guard.rs
+++ b/tests/test_guard.rs
@@ -177,6 +177,56 @@ fn test_guard_set_timeout_secs() {
     assert!(output.contains("30"), "output: {}", output);
 }
 
+#[test]
+fn test_guard_nested_object_root_edit_paths() {
+    let temp_dir = init_project();
+    write_guard(temp_dir.path(), "GUARD-ECHO", "echo old");
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[
+            &[
+                "guard",
+                "set",
+                "GUARD-ECHO",
+                "check.command",
+                "echo nested legacy",
+            ],
+            &[
+                "guard",
+                "edit",
+                "GUARD-ECHO",
+                "check.timeout_secs",
+                "--set",
+                "45",
+            ],
+            &["guard", "get", "GUARD-ECHO", "command"],
+            &["guard", "get", "GUARD-ECHO", "timeout_secs"],
+        ],
+    );
+
+    assert!(
+        output.contains("Set GUARD-ECHO.check.command = echo nested legacy"),
+        "output: {}",
+        output
+    );
+    assert!(
+        output.contains("Set GUARD-ECHO.check.timeout_secs = 45"),
+        "output: {}",
+        output
+    );
+    assert!(
+        output.contains("$ govctl guard get GUARD-ECHO command\necho nested legacy"),
+        "output: {}",
+        output
+    );
+    assert!(
+        output.contains("$ govctl guard get GUARD-ECHO timeout_secs\n45"),
+        "output: {}",
+        output
+    );
+}
+
 // --- Helpers ---
 
 fn write_guard(dir: &Path, guard_id: &str, command: &str) {

--- a/tests/test_guard.rs
+++ b/tests/test_guard.rs
@@ -43,6 +43,15 @@ fn test_guard_new_duplicate_rejected() {
 }
 
 #[test]
+fn test_guard_new_invalid_title_rejected_with_code() {
+    let temp_dir = init_project();
+
+    let output = run_commands(temp_dir.path(), &[&["guard", "new", "123 !!!"]]);
+    assert!(output.contains("exit: 1"), "output: {}", output);
+    assert!(output.contains("error[E1006]"), "output: {}", output);
+}
+
+#[test]
 fn test_guard_list() {
     let temp_dir = init_project();
     write_guard(temp_dir.path(), "GUARD-ALPHA", "true");
@@ -63,6 +72,28 @@ fn test_guard_show() {
     assert!(output.contains("exit: 0"), "output: {}", output);
     assert!(output.contains("GUARD-ECHO"), "output: {}", output);
     assert!(output.contains("echo hello"), "output: {}", output);
+}
+
+#[test]
+fn test_guard_show_json_output() {
+    let temp_dir = init_project();
+    write_guard(temp_dir.path(), "GUARD-ECHO", "echo hello");
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[&["guard", "show", "GUARD-ECHO", "-o", "json"]],
+    );
+    assert!(output.contains("\"id\": \"GUARD-ECHO\""), "output: {}", output);
+    assert!(output.contains("\"command\": \"echo hello\""), "output: {}", output);
+}
+
+#[test]
+fn test_guard_show_missing_returns_coded_error() {
+    let temp_dir = init_project();
+
+    let output = run_commands(temp_dir.path(), &[&["guard", "show", "GUARD-MISSING"]]);
+    assert!(output.contains("exit: 1"), "output: {}", output);
+    assert!(output.contains("error[E1002]"), "output: {}", output);
 }
 
 #[test]
@@ -160,6 +191,15 @@ fn test_guard_delete_force_does_not_bypass_reference_checks() {
         "force should not bypass reference checks: {}",
         output
     );
+}
+
+#[test]
+fn test_guard_delete_missing_returns_coded_error() {
+    let temp_dir = init_project();
+
+    let output = run_commands(temp_dir.path(), &[&["guard", "delete", "GUARD-MISSING"]]);
+    assert!(output.contains("exit: 1"), "output: {}", output);
+    assert!(output.contains("error[E1002]"), "output: {}", output);
 }
 
 #[test]

--- a/tests/test_guard.rs
+++ b/tests/test_guard.rs
@@ -83,8 +83,16 @@ fn test_guard_show_json_output() {
         temp_dir.path(),
         &[&["guard", "show", "GUARD-ECHO", "-o", "json"]],
     );
-    assert!(output.contains("\"id\": \"GUARD-ECHO\""), "output: {}", output);
-    assert!(output.contains("\"command\": \"echo hello\""), "output: {}", output);
+    assert!(
+        output.contains("\"id\": \"GUARD-ECHO\""),
+        "output: {}",
+        output
+    );
+    assert!(
+        output.contains("\"command\": \"echo hello\""),
+        "output: {}",
+        output
+    );
 }
 
 #[test]

--- a/tests/test_happy_path.rs
+++ b/tests/test_happy_path.rs
@@ -68,6 +68,7 @@ refs = ["RFC-0001"]
 [content]
 context = "We need to test ADR functionality."
 decision = "We will create a test ADR."
+selected_option = "Create a test ADR"
 
 [content.consequences]
 positive = ["Tests will pass."]

--- a/tests/test_happy_path.rs
+++ b/tests/test_happy_path.rs
@@ -68,7 +68,9 @@ refs = ["RFC-0001"]
 [content]
 context = "We need to test ADR functionality."
 decision = "We will create a test ADR."
-consequences = "Tests will pass."
+
+[content.consequences]
+positive = ["Tests will pass."]
 "#,
     )
     .unwrap();

--- a/tests/test_lifecycle.rs
+++ b/tests/test_lifecycle.rs
@@ -373,10 +373,23 @@ fn test_accept_proposed_adr() {
         temp_dir.path(),
         &[
             &["adr", "new", "Test Decision"],
+            &["adr", "set", "ADR-0001", "selected_option", "Option A"],
             &["adr", "list"],
             &["adr", "accept", "ADR-0001"],
             &["adr", "list"],
         ],
+    );
+    insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
+}
+
+#[test]
+fn test_accept_proposed_adr_requires_selected_option() {
+    let temp_dir = init_project();
+    let date = today();
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[&["adr", "new", "Test Decision"], &["adr", "accept", "ADR-0001"]],
     );
     insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
 }
@@ -406,6 +419,7 @@ fn test_accept_already_accepted_fails() {
         temp_dir.path(),
         &[
             &["adr", "new", "Test Decision"],
+            &["adr", "set", "ADR-0001", "selected_option", "Option A"],
             &["adr", "accept", "ADR-0001"],
             &["adr", "accept", "ADR-0001"],
         ],

--- a/tests/test_lifecycle.rs
+++ b/tests/test_lifecycle.rs
@@ -389,7 +389,10 @@ fn test_accept_proposed_adr_requires_selected_option() {
 
     let output = run_commands(
         temp_dir.path(),
-        &[&["adr", "new", "Test Decision"], &["adr", "accept", "ADR-0001"]],
+        &[
+            &["adr", "new", "Test Decision"],
+            &["adr", "accept", "ADR-0001"],
+        ],
     );
     insta::assert_snapshot!(normalize_output(&output, temp_dir.path(), &date));
 }

--- a/tests/test_lock.rs
+++ b/tests/test_lock.rs
@@ -316,3 +316,13 @@ acceptance_criteria = []
     );
     assert!(output.contains("Created work item"));
 }
+
+#[test]
+fn test_write_command_without_init_reports_missing_gov_root() {
+    let temp_dir = tempfile::TempDir::new().expect("temp dir");
+
+    let output = run_commands(temp_dir.path(), &[&["work", "new", "Needs init"]]);
+    assert!(output.contains("exit: 1"), "output: {}", output);
+    assert!(output.contains("error[E0502]"), "output: {}", output);
+    assert!(output.contains("Run 'govctl init' first"), "output: {}", output);
+}

--- a/tests/test_lock.rs
+++ b/tests/test_lock.rs
@@ -7,6 +7,7 @@ mod common;
 use common::{init_project, run_commands, today};
 use std::fs;
 use std::process::Command;
+use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -324,5 +325,117 @@ fn test_write_command_without_init_reports_missing_gov_root() {
     let output = run_commands(temp_dir.path(), &[&["work", "new", "Needs init"]]);
     assert!(output.contains("exit: 1"), "output: {}", output);
     assert!(output.contains("error[E0502]"), "output: {}", output);
-    assert!(output.contains("Run 'govctl init' first"), "output: {}", output);
+    assert!(
+        output.contains("Run 'govctl init' first"),
+        "output: {}",
+        output
+    );
+}
+
+#[test]
+fn test_concurrent_tick_commands_persist_all_acceptance_criteria_updates() {
+    let temp_dir = init_project();
+    create_config_with_timeout(temp_dir.path(), 30);
+
+    let today = today();
+    let wi_id = format!("WI-{today}-001");
+
+    let create_output = run_commands(
+        temp_dir.path(),
+        &[&["work", "new", "Concurrent tick persistence", "--active"]],
+    );
+    assert!(
+        create_output.contains(&wi_id),
+        "expected work item id in output: {create_output}"
+    );
+
+    let setup_output = run_commands(
+        temp_dir.path(),
+        &[
+            &[
+                "work",
+                "add",
+                wi_id.as_str(),
+                "acceptance_criteria",
+                "test: criterion one",
+            ],
+            &[
+                "work",
+                "add",
+                wi_id.as_str(),
+                "acceptance_criteria",
+                "test: criterion two",
+            ],
+            &[
+                "work",
+                "add",
+                wi_id.as_str(),
+                "acceptance_criteria",
+                "test: criterion three",
+            ],
+        ],
+    );
+    assert!(
+        setup_output.contains("exit: 0"),
+        "setup output: {setup_output}"
+    );
+
+    let barrier = Arc::new(Barrier::new(3));
+    let mut handles = Vec::new();
+    for index in 0..3 {
+        let dir = temp_dir.path().to_path_buf();
+        let wi_id = wi_id.clone();
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            Command::new(env!("CARGO_BIN_EXE_govctl"))
+                .args([
+                    "work",
+                    "edit",
+                    &wi_id,
+                    &format!("acceptance_criteria[{index}]"),
+                    "--tick",
+                    "done",
+                ])
+                .current_dir(dir)
+                .env("NO_COLOR", "1")
+                .env("GOVCTL_DEFAULT_OWNER", "@test-user")
+                .output()
+                .expect("failed to run concurrent tick command")
+        }));
+    }
+
+    for handle in handles {
+        let output = handle.join().expect("tick thread panicked");
+        assert!(
+            output.status.success(),
+            "concurrent tick failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let get_output = Command::new(env!("CARGO_BIN_EXE_govctl"))
+        .args(["work", "get", &wi_id, "acceptance_criteria"])
+        .current_dir(temp_dir.path())
+        .env("NO_COLOR", "1")
+        .env("GOVCTL_DEFAULT_OWNER", "@test-user")
+        .output()
+        .expect("failed to read acceptance criteria");
+    assert!(
+        get_output.status.success(),
+        "work get failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&get_output.stdout),
+        String::from_utf8_lossy(&get_output.stderr)
+    );
+    let criteria = String::from_utf8_lossy(&get_output.stdout);
+    let done_count = criteria
+        .lines()
+        .filter(|line| line.starts_with("[done]"))
+        .count();
+    assert_eq!(
+        done_count, 3,
+        "expected all criteria to persist as done, got:\n{}",
+        criteria
+    );
 }

--- a/tests/test_migrate.rs
+++ b/tests/test_migrate.rs
@@ -51,6 +51,48 @@ fn write_legacy_rfc_project(dir: &std::path::Path) {
     .unwrap();
 }
 
+fn write_legacy_v2_adr(dir: &std::path::Path) {
+    let adr_dir = dir.join("gov/adr");
+    fs::create_dir_all(&adr_dir).unwrap();
+    fs::write(
+        adr_dir.join("ADR-0001-legacy-decision.toml"),
+        r#"#:schema ../schema/adr.schema.json
+
+[govctl]
+id = "ADR-0001"
+title = "Legacy Decision"
+status = "accepted"
+date = "2026-01-01"
+refs = ["RFC-0001"]
+
+[content]
+context = "Legacy context"
+decision = "Legacy decision"
+consequences = """
+### Positive
+
+- Easier rollout
+
+### Negative
+
+- More memory use
+"""
+
+[[content.alternatives]]
+text = "Option A"
+status = "accepted"
+pros = ["Matches current rollout plan"]
+cons = ["Requires more memory"]
+
+[[content.alternatives]]
+text = "Option B"
+status = "considered"
+pros = ["Cheaper to operate"]
+"#,
+    )
+    .unwrap();
+}
+
 #[test]
 fn test_migrate_converts_json_rfc_and_upgrades_releases() {
     let temp_dir = init_project_v1();
@@ -88,8 +130,8 @@ date = "2026-01-01"
 
     let config = fs::read_to_string(temp_dir.path().join("gov/config.toml")).unwrap();
     assert!(
-        config.contains("version = 2"),
-        "schema version should be bumped to 2: {}",
+        config.contains("version = 3"),
+        "schema version should be bumped to 3: {}",
         config
     );
 }
@@ -141,7 +183,7 @@ fn test_migrate_is_noop_on_current_version() {
     // Second migrate should be a noop
     let output = run_commands(temp_dir.path(), &[&["migrate"]]);
     assert!(
-        output.contains("already at schema version 2"),
+        output.contains("already at schema version 3"),
         "output: {}",
         output
     );
@@ -160,15 +202,15 @@ fn test_migrate_bumps_version_even_without_file_changes() {
 
     let output = run_commands(temp_dir.path(), &[&["migrate"]]);
     assert!(
-        output.contains("Schema version bumped to 2"),
+        output.contains("Schema version bumped to 3"),
         "should bump version even with no file ops: {}",
         output
     );
 
     let config = fs::read_to_string(temp_dir.path().join("gov/config.toml")).unwrap();
     assert!(
-        config.contains("version = 2"),
-        "config should now be version 2: {}",
+        config.contains("version = 3"),
+        "config should now be version 3: {}",
         config
     );
 }
@@ -218,4 +260,46 @@ fn test_migrate_failure_leaves_legacy_repo_unchanged() {
         "version should not be bumped on failure: {}",
         config
     );
+}
+
+#[test]
+fn test_migrate_rewrites_legacy_adr_to_v3_shape() {
+    let temp_dir = init_project();
+    let config_path = temp_dir.path().join("gov/config.toml");
+    let config = fs::read_to_string(&config_path)
+        .unwrap()
+        .replace("version = 3", "version = 2");
+    fs::write(&config_path, config).unwrap();
+
+    write_legacy_v2_adr(temp_dir.path());
+
+    let output = run_commands(temp_dir.path(), &[&["migrate"], &["check"]]);
+    assert!(output.contains("exit: 0"), "output: {}", output);
+
+    let adr = fs::read_to_string(
+        temp_dir
+            .path()
+            .join("gov/adr/ADR-0001-legacy-decision.toml"),
+    )
+    .unwrap();
+    assert!(
+        adr.contains("selected_option = \"Option A\""),
+        "adr: {}",
+        adr
+    );
+    assert!(adr.contains("[content.consequences]"), "adr: {}", adr);
+    assert!(!adr.contains("status = \"considered\""), "adr: {}", adr);
+    assert!(
+        adr.contains("state = \"needs_review\""),
+        "migration warning metadata should be preserved: {}",
+        adr
+    );
+    assert!(
+        adr.contains("rejection_reason = \"Not selected; exact rejection rationale was not recoverable during migration.\""),
+        "considered alternative should gain synthetic rejection_reason: {}",
+        adr
+    );
+
+    let config = fs::read_to_string(config_path).unwrap();
+    assert!(config.contains("version = 3"), "config: {}", config);
 }


### PR DESCRIPTION
## Summary

This PR collects the full ADR/edit-surface refactor completed today on `adr-refactor`.

It does five main things:

- introduces a canonical field-mutation surface across artifacts via `govctl <resource> edit <ID> <path> --set/--add/--remove/--tick`
- redesigns the ADR model around `selected_option` and structured consequences, then migrates the full repository to ADR v3
- unifies clause field editing onto the same canonical edit surface while keeping lifecycle verbs separate
- closes governance/documentation drift across skills, guides, schema docs, and RFC-0000
- replaces a large set of remaining user-facing temporary `anyhow` errors with coded diagnostics

## What Changed

### 1. Canonical edit surface

- Added canonical `edit` entry points for RFC, ADR, work item, guard, and clause commands.
- Normalized path-first mutation syntax to `edit <ID> <path> --set/--add/--remove/--tick`.
- Kept legacy verb forms as sugar where appropriate, but moved the model to a single canonical mutation grammar.
- Extended the edit engine/runtime/path handling to support the nested path cases needed by the new surface.

### 2. ADR v3 redesign and migration

- Introduced ADR v3 with:
  - `content.selected_option`
  - structured `content.consequences.{positive,negative,neutral}`
  - structured negative mitigations
  - `govctl.migration` metadata
- Removed the old `accepted alternative` model and `alternatives[].status` from ADRs.
- Added ADR acceptance enforcement so accepted/superseded ADRs require `selected_option` unless they are explicitly in migration review state.
- Migrated all repository ADRs to the new shape and cleaned up historical migration debt.

### 3. Clause editing unification

- Unified clause field editing onto canonical `clause edit <ID> <path> ...`.
- `text`, `title`, and `kind` are now addressed consistently as editable fields.
- Existing clause lifecycle/resource-management verbs remain dedicated (`new/delete/deprecate/supersede`).

### 4. Governance docs / skills / agents alignment

- Accepted and landed ADR-0036 and ADR-0037.
- Updated skills and agents to match ADR v3 and the canonical edit model.
- Updated guides and schema docs to remove stale ADR v2 examples.
- Updated RFC-0000 and bumped it to reflect the new ADR definition and selected-option requirements.
- Added/updated work items for the major refactor tasks and recorded the implementation trail.

### 5. Diagnostic cleanup

- Replaced many remaining user-facing temporary `anyhow` errors on direct CLI paths with structured `Diagnostic` values and stable codes.
- Cleaned up repeated not-found formatting so messages do not duplicate identifiers in the trailing context.
- Updated snapshots and error tests to the new coded diagnostic output.

## Key Files / Areas

- CLI and routing: `src/cli.rs`, `src/command_router.rs`
- Edit engine/runtime: `src/cmd/edit/*`, `gov/schema/edit-ops.json`, `gov/schema/edit-ops.schema.json`
- ADR model/render/validation: `src/model.rs`, `src/render.rs`, `src/validate.rs`, `gov/schema/adr.schema.json`
- Migration flow: `src/cmd/migrate.rs`
- Lifecycle enforcement: `src/cmd/lifecycle.rs`
- Diagnostics: `src/diagnostic.rs`, `src/cmd/guard.rs`, `src/cmd/render.rs`, `src/cmd/list.rs`, `src/lock.rs`, `src/main.rs`, `src/tui/mod.rs`
- Governance docs: `docs/guide/*`, `docs/rfc/RFC-0000.md`, `gov/schema/SCHEMA.md`, `.claude/skills/*`, `.claude/agents/*`

## Validation

- `cargo test -q`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run --quiet -- check`
- `cargo run --quiet -- render`

## Commit Breakdown

- `30c4b23e` refactor(adr): add canonical edit surface and migrate ADR v3
- `7563e82f` refactor(clause): unify field editing on canonical edit surface
- `79936811` fix(adr): enforce selected-option acceptance rules
- `41042a71` docs(gov): align ADR guidance with v3 model
- `dfa6710f` fix(router): eliminate strict clippy warning
- `5bcf33ed` fix(diag): replace temporary anyhow errors with coded diagnostics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canonical path-first edit command for RFC/ADR/Work/Guard with unified set/add/remove/tick and deeper nested-field editing.
  * ADR migration that rewrites legacy ADRs into the new model and surfaces review warnings.

* **Breaking Changes**
  * ADR schema v2→v3: ADRs use selected_option plus structured consequences (positive/negative/neutral); accepted ADRs must record selected_option or be marked for review.
  * Clause/RFC edit examples now require an explicit text subcommand for stdin edits.

* **Quality**
  * User-facing coded diagnostics and clearer error codes; expanded validation and regression tests (including concurrent tick scenarios).

* **Documentation**
  * Guides, CLI examples, and changelog updated for new ADR/CLI semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->