### PR TITLE
Fix reference and project support upgrade checks

### DIFF
--- a/.claude/agents/wi-reviewer.md
+++ b/.claude/agents/wi-reviewer.md
@@ -30,7 +30,8 @@ When invoked:
 
 ### Working Memory Fields
 
-- [ ] `notes`, if present, record durable learnings, constraints, decisions, or retry rules
+- [ ] `notes`, if present, record closure-worthy durable learnings, constraints, decisions, or retry rules
+- [ ] `notes` do not contain progress updates, commands run, validation output, review status, current plans, next actions, temporary blockers, hypotheses, or "remember to do X" TODOs
 - [ ] Missing `notes` is acceptable for very small work items
 
 ### Acceptance Criteria
@@ -86,4 +87,4 @@ Overall: [PASS / NEEDS WORK / MAJOR ISSUES]
 
 If no findings exist, say so explicitly and still include the overall status.
 
-The most common failures: placeholder descriptions left unchanged, vague acceptance criteria like "Feature works", description fields that were abused as execution logs, work items that invent requirements locally, and batches split into mechanical noise. Flag those as Critical.
+The most common failures: placeholder descriptions left unchanged, vague acceptance criteria like "Feature works", description or notes fields that were abused as execution logs, work items that invent requirements locally, and batches split into mechanical noise. Flag those as Critical.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: "Commit changes with govctl integration — check work item status, update notes when needed, and run govctl check"
+description: "Commit changes with govctl integration — check work item status, preserve durable notes only when needed, and run govctl check"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
 argument-hint: [optional commit message hint]
 ---
@@ -18,7 +18,7 @@ Commit changes using the project's version control system, with govctl-aware che
 **CRITICAL: Steps MUST be executed in exact order. Do NOT skip ahead.**
 
 1. This is the only workflow that should issue raw `jj` or `git` commit commands.
-2. Do not perform RFC/ADR lifecycle verbs here, except work-item notes/tick/move updates that belong to commit bookkeeping.
+2. Do not perform RFC/ADR lifecycle verbs here, except work-item tick/move updates and rare durable notes that belong to commit bookkeeping.
 3. Implementation-bearing commits should belong to an active work item.
 4. Spec-only governance commits may proceed without a work item only when the diff is limited to governance artifacts, rendered governance docs, embedded skill/agent templates, or related metadata.
 
@@ -60,7 +60,7 @@ govctl work list pending
 1. Determine whether the active work item actually matches this diff.
 2. If the diff is spec-only governance maintenance unrelated to the active work item, the commit may remain work-item-free even while another work item is active.
 3. If the active work item applies, then:
-   - Ask whether any durable `notes` should be recorded
+   - Ask whether any closure-worthy durable `notes` should be recorded; skip notes for progress, validation output, review status, next actions, temporary blockers, or TODOs
    - Check whether any acceptance criteria can be ticked:
      ```bash
      govctl work show <WI-ID>
@@ -152,11 +152,13 @@ git commit -m "<type>(<area>): <summary>"
 
 After successful commit, if work item exists:
 
-1. **Add notes only when there is a durable constraint, retry rule, or learning to preserve**:
+1. **Add notes only when there is a closure-worthy durable constraint, retry rule, or learning to preserve after the work item is done**:
 
    ```bash
-   govctl work add <WI-ID> notes "Do not retry X; it fails because Y"
+   govctl work add <WI-ID> notes "Do not retry parser path X; it cannot preserve normalized arrays"
    ```
+
+   Do not add notes for commands run, tests passed, review findings addressed, current plans, next actions, or temporary blockers.
 
 2. **Tick acceptance criteria** (if applicable)
 
@@ -192,7 +194,7 @@ git diff --stat
 1. Detect active WI-XXXX
 2. govctl check → passes
 3. Confirm the active WI actually matches this diff
-4. If yes: ask about durable notes and criterion ticks
+4. If yes: ask about closure-worthy durable notes and criterion ticks
 5. If no, but diff is spec-only: proceed without attaching the commit to that WI
 6. If no and diff is implementation-bearing: switch/create the correct WI first
 7. Commit changes

--- a/.claude/skills/gov/SKILL.md
+++ b/.claude/skills/gov/SKILL.md
@@ -37,7 +37,6 @@ govctl work new --active "<title>"
 govctl work move <WI-ID> <status>
 govctl work set <WI-ID> description "Scope and why"
 govctl work add <WI-ID> acceptance_criteria "add: Implement feature X"
-govctl work add <WI-ID> notes "Do not retry old fixture path; it fails because snapshots are stale"
 govctl work add <WI-ID> refs RFC-0001
 govctl work add <WI-ID> tags <tag>
 govctl work add <WI-ID> depends_on <BLOCKING-WI-ID>
@@ -69,28 +68,29 @@ govctl render
 6. In source comments, reference artifacts with `[[artifact-id]]`.
 7. Use work item fields correctly:
    - `description`: task scope and why; set once, rarely change
-   - `notes`: durable learnings; record constraints, decisions, retry rules, and failure causes
+   - `notes`: closure-worthy durable facts only; record stable constraints, decisions, and retry rules that should still matter after the work item is done
 8. Avoid retry cycles. If the same approach already failed, do not repeat it unchanged.
 9. Spec-only governance maintenance does not belong here. Use `/spec` when no implementation work is required.
 10. Work items are operational memory, not normative authority. If implementation needs a new requirement or design decision, amend the RFC or ADR instead of stuffing it into `description` or `notes`.
 11. Create work items for durable, reader-useful outcomes only. Do not create separate work items for mechanical helper extraction, fixture sharing, file moves, formatting, or cleanup substeps.
 12. Do not invent loop IDs. Omit `--id` when starting a loop; use the generated `LOOP-YYYY-MM-DD-NNN` ID printed by the command for later `run`, `show`, `replan`, `add`, or `remove`.
 
-## Working Memory
+## Work Item Context
 
-The active work item is persistent working memory. Read it with `govctl work show <WI-ID>`; do not rely on raw TOML.
+The active work item is durable outcome context. Read it with `govctl work show <WI-ID>`; do not rely on raw TOML.
 
 ### Read order
 
 1. `description` tells you the scope.
-2. `notes` tells you what to remember before the next attempt.
+2. `notes` tells you closure-worthy constraints or lessons that should survive future sessions.
 3. `acceptance_criteria` tells you what must be true before closure.
 
 ### Write rules
 
-- Add a `notes` entry when you learn something future steps must obey.
-- Record execution trace in loop state when available.
-- On failure, put durable retry rules in `notes`.
+- Do not add `notes` by default. Add one only when the fact should remain useful after the work item is closed.
+- Never put progress, command output, review status, current plan, next action, temporary blocker, hypothesis, or "remember to do X" TODOs in `notes`.
+- Record execution trace, failed attempts, blockers, and next actions in loop state and round artifacts. If no loop exists, report them in the final response instead of writing them to the work item.
+- On failure, add a note only when you discovered a stable retry rule such as "Do not retry parser path X; it cannot preserve normalized arrays."
 
 ### Loop usage
 
@@ -211,10 +211,10 @@ Implementation rules:
 1. Keep changes focused.
 2. Follow RFC clauses and cite them in source comments when useful.
 3. After each substantive change, run the relevant validation.
-4. Update durable working memory as you go:
+4. Add durable work-item notes only when a closure-worthy fact exists:
 
 ```bash
-govctl work add <WI-ID> notes "Do not retry Y; it fails because Z"
+govctl work add <WI-ID> notes "Do not retry parser path X; it cannot preserve normalized arrays"
 ```
 
 ### 4. Test
@@ -229,8 +229,8 @@ Run the relevant verification for the change:
 
 If a check fails:
 
-- Record the failed attempt in loop state when available
-- Record the durable lesson or retry rule in `notes`
+- Record the failed attempt in loop state or the final response
+- Add a work-item note only for a stable retry rule that should survive closure
 - Change approach before retrying
 
 Do not continue until green.
@@ -282,12 +282,12 @@ govctl work move <WI-ID> done
 
 ### Otherwise recover and continue
 
-| Problem                       | Recovery                                        |
-| ----------------------------- | ----------------------------------------------- |
-| `govctl check` fails          | Read diagnostics, fix, rerun                    |
-| Tests fail                    | Debug, fix, rerun                               |
-| `work move ... done` rejected | Add or tick acceptance criteria first           |
-| Same failure repeats          | Read `notes`; record a new plan or stop and ask |
+| Problem                       | Recovery                                                                                   |
+| ----------------------------- | ------------------------------------------------------------------------------------------ |
+| `govctl check` fails          | Read diagnostics, fix, rerun                                                               |
+| Tests fail                    | Debug, fix, rerun                                                                          |
+| `work move ... done` rejected | Add or tick acceptance criteria first                                                      |
+| Same failure repeats          | Read durable `notes`; record the new plan in loop state or final response, or stop and ask |
 
 ## Commit Conventions
 

--- a/.claude/skills/quick/SKILL.md
+++ b/.claude/skills/quick/SKILL.md
@@ -22,7 +22,7 @@ Do not use this for new behavior, RFC-governed work, or architecture decisions. 
 3. If using a work item, read it with `govctl work show <WI-ID>`.
 4. Use work item fields correctly:
    - `description`: scope and why
-   - `notes`: constraints or lessons future steps must remember
+   - `notes`: closure-worthy durable constraints or lessons only
 5. If the change becomes behavioral, ambiguous, or architectural, stop using `/quick` and switch to `/gov`.
 6. Use `/commit` for raw VCS operations. Do not embed `jj` or `git` procedures here.
 7. Do not create multiple work items for trivial cleanup batches. Use the commit diff as the record, or one coarse work item only when durable tracking is explicitly valuable.
@@ -81,13 +81,13 @@ Run the relevant validation:
 govctl check
 ```
 
-If using a work item, update work-item memory only when there is a durable lesson:
+If using a work item, add a note only when there is a durable lesson that should remain useful after closure:
 
 ```bash
-govctl work add <WI-ID> notes "Do not use old command name in examples"
+govctl work add <WI-ID> notes "Do not use the old command name in generated examples; it was removed in v0.9"
 ```
 
-Add `notes` only when there is something future steps should remember. Transient execution progress belongs in loop state and round artifacts, not in work item fields.
+Do not write progress, command output, review status, current plans, next actions, temporary blockers, or TODOs to `notes`. Transient execution progress belongs in loop state and round artifacts, not in work item fields.
 When a tracked cleanup batch gains or loses durable roots, use `govctl loop add <LOOP-ID> work <ROOT-WI-ID>`, `govctl loop remove <LOOP-ID> work <ROOT-WI-ID>`, or `govctl loop replan <LOOP-ID>` rather than creating a new loop for each small item. `wi` is accepted as a short alias for the loop `work` field, but examples should prefer `work`.
 
 ### 4. Record

--- a/.claude/skills/wi-writer/SKILL.md
+++ b/.claude/skills/wi-writer/SKILL.md
@@ -25,7 +25,7 @@ They are operational memory, not normative authority and not decision records.
 govctl work new --active "<title>"
 govctl work set <WI-ID> description "Task scope description"
 govctl work add <WI-ID> acceptance_criteria "<category>: <description>"
-govctl work add <WI-ID> notes "Key observation"
+govctl work add <WI-ID> notes "Durable constraint or retry rule"
 govctl work add <WI-ID> refs RFC-NNNN
 govctl work add <WI-ID> depends_on <BLOCKING-WI-ID>
 govctl work add <WI-ID> tags <tag>
@@ -52,7 +52,7 @@ Replace the placeholder immediately. One paragraph explaining:
 - Why it's needed
 - Any relevant context
 
-**Important:** Description is for task scope, NOT execution tracking. Use loop state and round artifacts for execution trace when available, and `notes` for durable learnings that belong on the work item.
+**Important:** Description is for task scope, NOT execution tracking. Use loop state and round artifacts for execution trace, and `notes` only for closure-worthy durable learnings that belong on the work item.
 It must not introduce new product behavior requirements that are missing from the governing RFC or ADR.
 
 ### Execution Trace
@@ -60,24 +60,25 @@ It must not introduce new product behavior requirements that are missing from th
 **Where execution information goes now:**
 
 - Round-by-round execution trace belongs in loop state and round artifacts.
-- Durable lessons, constraints, retry rules, and future-facing observations belong in `notes`.
+- Durable lessons, constraints, and retry rules that should still matter after closure belong in `notes`.
 - Acceptance progress belongs in `acceptance_criteria` status.
 
 ### Notes
 
-**Purpose:** Durable learnings — constraints, decisions, and retry rules to remember before the next step.
+**Purpose:** Closure-worthy durable context — stable constraints, decisions, and retry rules that should remain useful after the work item is done.
 
-Notes are concise points recorded anytime, not just at completion. Use for:
+Use notes sparingly for:
 
-- Why an approach failed
-- What not to retry
-- Constraints or decisions future steps must obey
+- Why an approach must not be retried because of a stable technical reason
+- Constraints or decisions future maintainers must obey
+- Important implementation facts that are not obvious from the final diff
 
 These notes may explain local execution constraints, but they do not override RFCs or accepted ADRs.
+Do not use notes for progress updates, commands run, validation output, current plans, next actions, temporary blockers, hypotheses, review status, or "remember to do X" TODOs.
 
 ```bash
-govctl work add <WI-ID> notes "Remember to update migration guide"
-govctl work add <WI-ID> notes "API is now async"
+govctl work add <WI-ID> notes "Do not retry the legacy JSON migration path; v0.9 intentionally rejects it"
+govctl work add <WI-ID> notes "Legacy inline journal entries must remain render-only for older work items"
 ```
 
 ### Acceptance Criteria
@@ -143,13 +144,13 @@ Do not hand-write descriptive loop IDs or encode time finer than the day in loop
 
 ## Field Semantics Summary
 
-| Field                 | Purpose                | Update Pattern                                |
-| --------------------- | ---------------------- | --------------------------------------------- |
-| `description`         | Task scope declaration | Define once, rarely change                    |
-| `notes`               | Durable learnings      | Add when future steps must remember something |
-| `acceptance_criteria` | Completion criteria    | Define then tick                              |
+| Field                 | Purpose                | Update Pattern                               |
+| --------------------- | ---------------------- | -------------------------------------------- |
+| `description`         | Task scope declaration | Define once, rarely change                   |
+| `notes`               | Durable learnings      | Add only when useful after work-item closure |
+| `acceptance_criteria` | Completion criteria    | Define then tick                             |
 
-**Per ADR-0047:** Keep description focused on "what", notes on durable "what to remember next", and execution trace outside the work item field surface.
+**Per ADR-0047:** Keep description focused on "what", notes on closure-worthy durable context, and execution trace outside the work item field surface.
 If you discover a missing requirement or unresolved design choice, stop and route that back to RFC/ADR work rather than inventing it inside the work item.
 
 ## Writing Rules
@@ -206,14 +207,15 @@ Keep `chore:` criteria for validation summaries, especially when the validation 
 
 ## Common Mistakes
 
-| Mistake                            | Fix                                                                                  |
-| ---------------------------------- | ------------------------------------------------------------------------------------ |
-| Missing category prefix            | Always use `add:`, `fix:`, `chore:`, etc.                                            |
-| Placeholder description left in    | Replace immediately with real description                                            |
-| Vague criteria: "Feature works"    | Specific: "add: CLI returns exit code 0 on success"                                  |
-| No `chore:` criterion              | Add "chore: govctl check passes" or "chore: all tests pass"                          |
-| No refs to governing artifacts     | Link RFCs/ADRs with `work add <WI-ID> refs`                                          |
-| Description used for tracking      | Use loop state and round artifacts for execution trace or `notes` for durable memory |
-| Progress details stored as notes   | Keep `notes` durable; put transient round logs in loop state and round artifacts     |
-| Mechanical substeps become WIs     | Use no WI or one coarse WI; leave helper/test/file-move details to the commit diff   |
-| Work item invents new requirements | Move those requirements into an RFC or ADR first                                     |
+| Mistake                            | Fix                                                                                                      |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Missing category prefix            | Always use `add:`, `fix:`, `chore:`, etc.                                                                |
+| Placeholder description left in    | Replace immediately with real description                                                                |
+| Vague criteria: "Feature works"    | Specific: "add: CLI returns exit code 0 on success"                                                      |
+| No `chore:` criterion              | Add "chore: govctl check passes" or "chore: all tests pass"                                              |
+| No refs to governing artifacts     | Link RFCs/ADRs with `work add <WI-ID> refs`                                                              |
+| Description used for tracking      | Use loop state and round artifacts for execution trace                                                   |
+| Progress details stored as notes   | Keep `notes` durable; put transient round logs in loop state and round artifacts                         |
+| TODOs or next actions stored notes | Put next actions in loop state or the final response; use acceptance criteria for completion obligations |
+| Mechanical substeps become WIs     | Use no WI or one coarse WI; leave helper/test/file-move details to the commit diff                       |
+| Work item invents new requirements | Move those requirements into an RFC or ADR first                                                         |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Release entries are curated summaries for readers. Work item traceability remain
 
 ## [Unreleased]
 
+### Fixed
+
+- govctl check rejects invalid RFC/ADR hierarchy references even when the artifact ID appears as bare governed text (WI-2026-06-04-003)
+- govctl check reports stale bundled schema files and tells users to run govctl migrate (WI-2026-06-04-003)
+- govctl migrate adds missing .govctl local state entries to .gitignore for existing repositories (WI-2026-06-04-004)
+- govctl check warns when local .govctl state entries are missing from .gitignore (WI-2026-06-04-004)
+
 ## [0.9.0] - 2026-06-04
 
 ### Added

--- a/docs/guide/work-items.md
+++ b/docs/guide/work-items.md
@@ -181,11 +181,13 @@ Waivers are per-work-item only. They do not disable the guard globally, and they
 
 ## Notes
 
-Add durable notes for future steps:
+Add closure-worthy durable notes for constraints or retry rules that should remain useful after the work item is done:
 
 ```bash
 govctl work add WI-2026-01-17-001 notes "Do not retry the old validation path; it fails on missing refs"
 ```
+
+Do not use notes for progress updates, commands run, validation output, current plans, next actions, temporary blockers, or TODOs. Put transient execution trace in local loop state and round artifacts instead.
 
 Nested path edits are also available for structured fields:
 

--- a/docs/rfc/RFC-0000.md
+++ b/docs/rfc/RFC-0000.md
@@ -1,9 +1,9 @@
 <!-- GENERATED: do not edit. Source: RFC-0000 -->
-<!-- SIGNATURE: sha256:a5b8d41770bf67b4cdf25121579d42fe50be05571231d27211e77e7567590898 -->
+<!-- SIGNATURE: sha256:496196ed1073947f867c6730c56c34da58f1b045bf939d98b7804511f8feea9a -->
 
 # RFC-0000: govctl Governance Framework
 
-> **Version:** 1.3.0 | **Status:** normative | **Phase:** stable
+> **Version:** 1.3.2 | **Status:** normative | **Phase:** stable
 
 ---
 
@@ -102,15 +102,6 @@ Phase rules:
 
 ### [RFC-0000:C-REFERENCE-HIERARCHY] Artifact Reference Hierarchy (Normative) <a id="rfc-0000c-reference-hierarchy"></a>
 
-[govctl]
-id = "C-REFERENCE-HIERARCHY"
-title = "Artifact Reference Hierarchy"
-kind = "normative"
-status = "active"
-since = "1.0.1"
-
-[content]
-text = """
 Governance artifacts follow a strict authority hierarchy. References between artifact types MUST respect this hierarchy.
 
 **Authority Order (highest to lowest):**
@@ -118,23 +109,25 @@ Governance artifacts follow a strict authority hierarchy. References between art
 2. **ADR** — Interpretation. Documents decisions implementing RFCs.
 3. **Work Item** — Execution. Tracks work implementing ADRs and RFCs.
 
-**Structured reference rules (refs fields and [[...]] link targets):**
+**Structured reference rules:**
 
 Implementations MUST validate these rules during project validation (for example `govctl check`).
 
-- RFC `refs` entries and `[[...]]` link targets MUST NOT identify an ADR or a Work Item. RFCs MUST link only to RFCs and RFC clause references (`RFC-ID:C-CLAUSE`).
+- RFC `refs` entries, `[[...]]` link targets, and known artifact-ID mentions in governed RFC clause text MUST NOT identify an ADR or a Work Item.
 
-- ADR `refs` entries and `[[...]]` link targets MUST NOT identify a Work Item. ADRs MAY link to RFCs (including clause references) and to ADRs.
+- ADR `refs` entries, `[[...]]` link targets, and known artifact-ID mentions in governed ADR content fields MUST NOT identify a Work Item.
 
 - Work Item `refs` entries and `[[...]]` link targets MAY identify any artifact type.
 
+This clause only defines the RFC/ADR/Work Item authority hierarchy. It does not impose additional target-kind restrictions for artifact types outside that hierarchy.
+
 **Rationale:**
 
-This hierarchy prevents circular dependencies and maintains clear authority chains. An RFC that links to an ADR or Work Item in `refs` or `[[...]]` inverts the dependency direction — lower layers become authorities over the specification.
+This hierarchy prevents circular dependencies and maintains clear authority chains. An RFC that links to or names an ADR or Work Item as a governed reference inverts the dependency direction — lower layers become authorities over the specification.
 
-**Prose outside refs and [[...]]:**
+**Prose outside governed reference surfaces:**
 
-Normative RFC clause text SHOULD remain self-contained. Plain prose (without `[[...]]`) MAY cite artifact identifiers for explanation; that form is not governed by the structured rules above."""
+Normative RFC clause text SHOULD remain self-contained. Non-governed explanatory text MAY mention artifact identifier shapes as examples, but known lower-authority artifact identifiers in governed RFC clause text and governed ADR content fields are validated as references even without `[[...]]` delimiters.
 
 > **Tags:** `core`, `validation`
 
@@ -322,6 +315,22 @@ A guard check MUST pass only when the command exits successfully. If `pattern` i
 ---
 
 ## Changelog
+
+### v1.3.2 (2026-06-04)
+
+Align reference hierarchy wording
+
+#### Changed
+
+- reference hierarchy wording now describes only the RFC-to-ADR-or-Work Item and ADR-to-Work Item prohibitions
+
+### v1.3.1 (2026-06-04)
+
+Close plain-text reference hierarchy loophole
+
+#### Changed
+
+- Known lower-authority artifact IDs in governed RFC/ADR prose are validated even without [[...]] delimiters
 
 ### v1.3.0 (2026-06-04)
 

--- a/docs/rfc/RFC-0002.md
+++ b/docs/rfc/RFC-0002.md
@@ -1,9 +1,9 @@
 <!-- GENERATED: do not edit. Source: RFC-0002 -->
-<!-- SIGNATURE: sha256:19ba6bf36bcbad55cf36d2e7d56993ed9e8d67ed98c6fe598ceb9ad86007fecf -->
+<!-- SIGNATURE: sha256:8c6259a92889fd5cb0a87ca5798ca004168631bb63e824eb9c006dc9c90e369a -->
 
 # RFC-0002: CLI Resource Model and Command Architecture
 
-> **Version:** 0.9.0 | **Status:** normative | **Phase:** test
+> **Version:** 0.9.4 | **Status:** normative | **Phase:** test
 
 ---
 
@@ -83,14 +83,14 @@ Manages RFC specifications (normative documents defining system behavior).
 
 Manages ADRs (records of architectural decisions).
 
-- ID Format: `ADR-NNNN` (e.g., ADR-0001)
+- ID Format: `ADR-NNNN` (e.g., ADR-NNNN-style IDs)
 - Lifecycle: proposed → accepted → superseded, or proposed → rejected (per RFC-0001:C-ADR-STATUS)
 
 **3. `work` - Work Item**
 
 Manages work items (tasks, features, bugs).
 
-- ID Format: `WI-YYYY-MM-DD-NNN` (e.g., WI-2026-01-19-001)
+- ID Format: `WI-YYYY-MM-DD-NNN` (e.g., WI-YYYY-MM-DD-NNN)
 - Lifecycle: queue → active → done, with cancellation at any stage (per RFC-0001:C-WORK-STATUS)
 
 **4. `clause` - RFC Clause**
@@ -199,17 +199,17 @@ Field names exposed via `get <id> <field>` MUST be stable identifiers defined by
 
 **4. `edit` - Update Resource**
 
-Syntax: `govctl <resource> edit <id> <field> [value]`
+Syntax: `govctl <resource> edit <id> <path> --set <value>` or `govctl <resource> edit <id> <path> --set --stdin`
 
-Updates a single field on a resource. Value can be provided as argument or via stdin.
+Updates a single field addressed by a deterministic path expression. Values can be provided through an explicit mutation flag or via stdin for multiline content.
 
 MUST support for: rfc, adr, work, clause, guard
 Behavior:
-- Simple fields: replace value
-- Array fields: special syntax (see ADR-0017 for implementation details)
-- MUST validate field names per resource schema
-- MUST validate values per field type
-- MUST support `--stdin` flag for multiline content
+- Simple fields: replace the value at the addressed path
+- Arrays and nested fields: MUST use deterministic path-based addressing, including indexed path expressions such as `content.alternatives[0].text`
+- MUST validate path syntax and reject unknown fields, invalid indices, and paths whose operation is not allowed by the resource schema
+- MUST validate values per field type before writing
+- MUST support `--stdin` with the explicit set operation for multiline content
 
 **5. `delete` - Delete Resource**
 
@@ -443,6 +443,8 @@ Behavior:
 - Validates the semantic correctness of the optional `[verification]` section in `gov/config.toml`, including that configured default guard IDs resolve
 - Scans source code for references (if enabled in config)
 - If legacy JSON RFC or clause storage files are detected, MUST fail with a migration-required diagnostic that instructs users to run `govctl migrate` with a govctl version earlier than 0.9 before upgrading
+- If any bundled JSON Schema file under `gov/schema/` is missing or differs from the current bundled schema, MUST report a schema-outdated diagnostic that instructs users to run `govctl migrate`
+- If any govctl-managed local-state `.gitignore` entry is missing or outdated, MUST report a project-support-outdated diagnostic that instructs users to run `govctl migrate`
 - Returns exit code 0 if valid, non-zero if errors
 - With `--deny-warnings`: treats warnings as errors
 
@@ -516,7 +518,8 @@ Behavior:
 - MUST leave the repository unchanged if any step fails
 - MUST be safe to run on an already-migrated repository and report a no-op result
 - MUST NOT perform heuristic project discovery or broad adoption tasks
-- MUST ensure all bundled JSON Schema files exist in `gov/schema/`, overwriting with the latest version regardless of schema version (per ADR-0035)
+- MUST ensure all bundled JSON Schema files exist in `gov/schema/`, overwriting with the latest version regardless of schema version
+- MUST ensure local govctl state ignore entries are present in `.gitignore`, including `.govctl.lock` and `.govctl/`, regardless of schema version
 - In govctl 0.9 and later, MUST NOT convert legacy JSON RFC or clause storage; repositories with those files MUST be migrated with a govctl version earlier than 0.9 before upgrading
 
 **8. `govctl verify`**
@@ -540,7 +543,7 @@ Behavior:
 
 **9. `govctl init-skills`**
 
-Installs agent skills and agents into the project's agent directory (per ADR-0035).
+Installs agent skills and agents into the project's agent directory.
 
 Syntax: `govctl init-skills [--force] [--format <claude|codex>] [--dir PATH]`
 
@@ -680,6 +683,38 @@ A self-update command provides a single canonical update path that works regardl
 ---
 
 ## Changelog
+
+### v0.9.4 (2026-06-04)
+
+Narrow project support diagnostics
+
+#### Changed
+
+- project-support diagnostics are scoped to govctl-managed local-state .gitignore entries
+
+### v0.9.3 (2026-06-04)
+
+Clarify edit path addressing
+
+#### Changed
+
+- edit operations use deterministic path-based addressing for arrays and nested fields
+
+### v0.9.2 (2026-06-04)
+
+Clarify project support file sync
+
+#### Changed
+
+- govctl check and migrate cover project support file freshness
+
+### v0.9.1 (2026-06-04)
+
+Require check to surface stale bundled schemas
+
+#### Changed
+
+- govctl check reports missing or stale bundled schema files and instructs users to run govctl migrate
 
 ### v0.9.0 (2026-06-04)
 

--- a/gov/adr/ADR-0014-release-management-with-releases-toml.toml
+++ b/gov/adr/ADR-0014-release-management-with-releases-toml.toml
@@ -5,9 +5,11 @@ id = "ADR-0014"
 title = "Release management with releases.toml"
 status = "accepted"
 date = "2026-01-17"
-refs = ["ADR-0013", "RFC-0000:C-WORK-DEF"]
+refs = [
+    "ADR-0013",
+    "RFC-0000:C-WORK-DEF",
+]
 tags = ["release"]
-
 
 [content]
 context = "To generate a CHANGELOG.md from work items, we need version information. Work items have `completed` dates but no version. Version is a release-time concept, not a work-time concept. We need a way to track which work items belong to which release without mutating completed work items."
@@ -18,7 +20,7 @@ Store release history in a single `gov/releases.toml` file with explicit work it
 [[releases]]
 version = "0.2.0"
 date = "2026-01-17"
-refs = ["WI-2026-01-17-029", "WI-2026-01-17-008"]
+refs = ["WI-YYYY-MM-DD-029", "WI-YYYY-MM-DD-008"]
 ```
 
 The `govctl release <version>` command collects all done work items not yet in any release and adds them to a new release entry. The `govctl render changelog` command generates CHANGELOG.md grouped by release version and category."""

--- a/gov/adr/ADR-0017-cli-command-implementation-details.toml
+++ b/gov/adr/ADR-0017-cli-command-implementation-details.toml
@@ -174,7 +174,7 @@ error[E0102]: RFC not found: RFC-9999
 
 **Prompt format:**
 ```
-Delete work item WI-2026-01-19-001? [y/N]
+Delete work item WI-YYYY-MM-DD-NNN? [y/N]
 ```
 
 **Behavior:**
@@ -269,3 +269,16 @@ consequences = """
 - **Discoverability over uniformity:** Four clear verbs are better than one verb with special syntax that requires documentation.
 
 - **Safety over speed:** Confirmation prompts slow down destructive operations. This is intentional to prevent accidents."""
+
+[[content.alternatives]]
+text = "Document shared CLI implementation conventions."
+status = "accepted"
+pros = ["Keeps command behavior consistent across resources"]
+cons = ["Requires maintaining a single convention document"]
+
+[[content.alternatives]]
+text = "Leave CLI implementation details undocumented per command."
+status = "rejected"
+pros = ["No extra ADR maintenance"]
+cons = ["Commands drift in flags, prompts, errors, and help shape"]
+rejection_reason = "Inconsistent command behavior undermines RFC-0002's stable interface contract."

--- a/gov/adr/ADR-0020-configurable-work-item-id-strategies-for-multi-person-collaboration.toml
+++ b/gov/adr/ADR-0020-configurable-work-item-id-strategies-for-multi-person-collaboration.toml
@@ -6,7 +6,10 @@ title = "Configurable work item ID strategies for multi-person collaboration"
 status = "accepted"
 date = "2026-01-26"
 refs = ["RFC-0000"]
-tags = ["collaboration", "work-items"]
+tags = [
+    "collaboration",
+    "work-items",
+]
 
 [content]
 context = """
@@ -15,8 +18,8 @@ The current work item ID format (`WI-YYYY-MM-DD-NNN`) uses local sequential numb
 **Problem:** When multiple people work on parallel branches and both create work items on the same day, they get the same ID:
 
 ```
-Alice: scans → max=002 → creates WI-2026-01-26-003
-Bob:   scans → max=002 → creates WI-2026-01-26-003 (collision!)
+Alice: scans → max=002 → creates WI-YYYY-MM-DD-003
+Bob:   scans → max=002 → creates WI-YYYY-MM-DD-003 (collision!)
 ```
 
 On merge, these IDs collide. This blocks multi-person teams from adopting govctl.

--- a/gov/adr/ADR-0037-canonical-edit-surface-for-nested-artifact-mutation.toml
+++ b/gov/adr/ADR-0037-canonical-edit-surface-for-nested-artifact-mutation.toml
@@ -78,7 +78,7 @@ where:
 govctl adr edit ADR-0001 content.decision --set "We will ..."
 govctl adr edit ADR-0001 content.alternatives --add "Option A"
 govctl adr edit ADR-0001 content.alternatives[0].pros --add "Readable"
-govctl work edit WI-2026-04-06-001 content.acceptance_criteria[0] --tick done
+govctl work edit WI-YYYY-MM-DD-NNN content.acceptance_criteria[0] --tick done
 ```
 
 This keeps resource-first organization intact while giving both humans and agents a single canonical grammar for mutation.
@@ -87,8 +87,7 @@ This keeps resource-first organization intact while giving both humans and agent
 
 - Gives humans and agents one stable canonical mutation grammar
 - Lets existing verbs converge onto the same EditPlan without immediate breakage
-- Keeps the target path visually primary when reading or typing commands
-"""
+- Keeps the target path visually primary when reading or typing commands"""
 consequences = """
 ### Positive
 

--- a/gov/rfc/RFC-0000/clauses/C-REFERENCE-HIERARCHY.toml
+++ b/gov/rfc/RFC-0000/clauses/C-REFERENCE-HIERARCHY.toml
@@ -6,16 +6,10 @@ title = "Artifact Reference Hierarchy"
 kind = "normative"
 status = "active"
 since = "1.0.1"
-tags = ["core", "validation"]
-
-[content]
-text = '''
-[govctl]
-id = "C-REFERENCE-HIERARCHY"
-title = "Artifact Reference Hierarchy"
-kind = "normative"
-status = "active"
-since = "1.0.1"
+tags = [
+    "core",
+    "validation",
+]
 
 [content]
 text = """
@@ -26,20 +20,22 @@ Governance artifacts follow a strict authority hierarchy. References between art
 2. **ADR** — Interpretation. Documents decisions implementing RFCs.
 3. **Work Item** — Execution. Tracks work implementing ADRs and RFCs.
 
-**Structured reference rules (refs fields and [[...]] link targets):**
+**Structured reference rules:**
 
 Implementations MUST validate these rules during project validation (for example `govctl check`).
 
-- RFC `refs` entries and `[[...]]` link targets MUST NOT identify an ADR or a Work Item. RFCs MUST link only to RFCs and RFC clause references (`RFC-ID:C-CLAUSE`).
+- RFC `refs` entries, `[[...]]` link targets, and known artifact-ID mentions in governed RFC clause text MUST NOT identify an ADR or a Work Item.
 
-- ADR `refs` entries and `[[...]]` link targets MUST NOT identify a Work Item. ADRs MAY link to RFCs (including clause references) and to ADRs.
+- ADR `refs` entries, `[[...]]` link targets, and known artifact-ID mentions in governed ADR content fields MUST NOT identify a Work Item.
 
 - Work Item `refs` entries and `[[...]]` link targets MAY identify any artifact type.
 
+This clause only defines the RFC/ADR/Work Item authority hierarchy. It does not impose additional target-kind restrictions for artifact types outside that hierarchy.
+
 **Rationale:**
 
-This hierarchy prevents circular dependencies and maintains clear authority chains. An RFC that links to an ADR or Work Item in `refs` or `[[...]]` inverts the dependency direction — lower layers become authorities over the specification.
+This hierarchy prevents circular dependencies and maintains clear authority chains. An RFC that links to or names an ADR or Work Item as a governed reference inverts the dependency direction — lower layers become authorities over the specification.
 
-**Prose outside refs and [[...]]:**
+**Prose outside governed reference surfaces:**
 
-Normative RFC clause text SHOULD remain self-contained. Plain prose (without `[[...]]`) MAY cite artifact identifiers for explanation; that form is not governed by the structured rules above."""'''
+Normative RFC clause text SHOULD remain self-contained. Non-governed explanatory text MAY mention artifact identifier shapes as examples, but known lower-authority artifact identifiers in governed RFC clause text and governed ADR content fields are validated as references even without `[[...]]` delimiters."""

--- a/gov/rfc/RFC-0000/rfc.toml
+++ b/gov/rfc/RFC-0000/rfc.toml
@@ -3,7 +3,7 @@
 [govctl]
 id = "RFC-0000"
 title = "govctl Governance Framework"
-version = "1.3.0"
+version = "1.3.2"
 status = "normative"
 phase = "stable"
 owners = ["@govctl-org"]
@@ -15,7 +15,7 @@ tags = [
     "validation",
     "lifecycle",
 ]
-signature = "a5b8d41770bf67b4cdf25121579d42fe50be05571231d27211e77e7567590898"
+signature = "496196ed1073947f867c6730c56c34da58f1b045bf939d98b7804511f8feea9a"
 
 [[sections]]
 title = "Summary"
@@ -49,6 +49,18 @@ clauses = ["clauses/C-RELEASE-DEF.toml"]
 [[sections]]
 title = "Verification Guard Specification"
 clauses = ["clauses/C-GUARD-DEF.toml"]
+
+[[changelog]]
+version = "1.3.2"
+date = "2026-06-04"
+notes = "Align reference hierarchy wording"
+changed = ["reference hierarchy wording now describes only the RFC-to-ADR-or-Work Item and ADR-to-Work Item prohibitions"]
+
+[[changelog]]
+version = "1.3.1"
+date = "2026-06-04"
+notes = "Close plain-text reference hierarchy loophole"
+changed = ["Known lower-authority artifact IDs in governed RFC/ADR prose are validated even without [[...]] delimiters"]
 
 [[changelog]]
 version = "1.3.0"

--- a/gov/rfc/RFC-0002/clauses/C-CRUD-VERBS.toml
+++ b/gov/rfc/RFC-0002/clauses/C-CRUD-VERBS.toml
@@ -6,7 +6,10 @@ title = "Universal CRUD Verbs"
 kind = "normative"
 status = "active"
 since = "0.1.0"
-tags = ["cli", "editing"]
+tags = [
+    "cli",
+    "editing",
+]
 
 [content]
 text = """
@@ -60,17 +63,17 @@ Field names exposed via `get <id> <field>` MUST be stable identifiers defined by
 
 **4. `edit` - Update Resource**
 
-Syntax: `govctl <resource> edit <id> <field> [value]`
+Syntax: `govctl <resource> edit <id> <path> --set <value>` or `govctl <resource> edit <id> <path> --set --stdin`
 
-Updates a single field on a resource. Value can be provided as argument or via stdin.
+Updates a single field addressed by a deterministic path expression. Values can be provided through an explicit mutation flag or via stdin for multiline content.
 
 MUST support for: rfc, adr, work, clause, guard
 Behavior:
-- Simple fields: replace value
-- Array fields: special syntax (see ADR-0017 for implementation details)
-- MUST validate field names per resource schema
-- MUST validate values per field type
-- MUST support `--stdin` flag for multiline content
+- Simple fields: replace the value at the addressed path
+- Arrays and nested fields: MUST use deterministic path-based addressing, including indexed path expressions such as `content.alternatives[0].text`
+- MUST validate path syntax and reject unknown fields, invalid indices, and paths whose operation is not allowed by the resource schema
+- MUST validate values per field type before writing
+- MUST support `--stdin` with the explicit set operation for multiline content
 
 **5. `delete` - Delete Resource**
 

--- a/gov/rfc/RFC-0002/clauses/C-GLOBAL-COMMANDS.toml
+++ b/gov/rfc/RFC-0002/clauses/C-GLOBAL-COMMANDS.toml
@@ -43,6 +43,8 @@ Behavior:
 - Validates the semantic correctness of the optional `[verification]` section in `gov/config.toml`, including that configured default guard IDs resolve
 - Scans source code for references (if enabled in config)
 - If legacy JSON RFC or clause storage files are detected, MUST fail with a migration-required diagnostic that instructs users to run `govctl migrate` with a govctl version earlier than 0.9 before upgrading
+- If any bundled JSON Schema file under `gov/schema/` is missing or differs from the current bundled schema, MUST report a schema-outdated diagnostic that instructs users to run `govctl migrate`
+- If any govctl-managed local-state `.gitignore` entry is missing or outdated, MUST report a project-support-outdated diagnostic that instructs users to run `govctl migrate`
 - Returns exit code 0 if valid, non-zero if errors
 - With `--deny-warnings`: treats warnings as errors
 
@@ -116,7 +118,8 @@ Behavior:
 - MUST leave the repository unchanged if any step fails
 - MUST be safe to run on an already-migrated repository and report a no-op result
 - MUST NOT perform heuristic project discovery or broad adoption tasks
-- MUST ensure all bundled JSON Schema files exist in `gov/schema/`, overwriting with the latest version regardless of schema version (per ADR-0035)
+- MUST ensure all bundled JSON Schema files exist in `gov/schema/`, overwriting with the latest version regardless of schema version
+- MUST ensure local govctl state ignore entries are present in `.gitignore`, including `.govctl.lock` and `.govctl/`, regardless of schema version
 - In govctl 0.9 and later, MUST NOT convert legacy JSON RFC or clause storage; repositories with those files MUST be migrated with a govctl version earlier than 0.9 before upgrading
 
 **8. `govctl verify`**
@@ -140,7 +143,7 @@ Behavior:
 
 **9. `govctl init-skills`**
 
-Installs agent skills and agents into the project's agent directory (per ADR-0035).
+Installs agent skills and agents into the project's agent directory.
 
 Syntax: `govctl init-skills [--force] [--format <claude|codex>] [--dir PATH]`
 

--- a/gov/rfc/RFC-0002/clauses/C-RESOURCES.toml
+++ b/gov/rfc/RFC-0002/clauses/C-RESOURCES.toml
@@ -6,7 +6,10 @@ title = "Resource Types"
 kind = "normative"
 status = "active"
 since = "0.1.0"
-tags = ["cli", "schema"]
+tags = [
+    "cli",
+    "schema",
+]
 
 [content]
 text = """
@@ -24,14 +27,14 @@ Manages RFC specifications (normative documents defining system behavior).
 
 Manages ADRs (records of architectural decisions).
 
-- ID Format: `ADR-NNNN` (e.g., ADR-0001)
+- ID Format: `ADR-NNNN` (e.g., ADR-NNNN-style IDs)
 - Lifecycle: proposed → accepted → superseded, or proposed → rejected (per RFC-0001:C-ADR-STATUS)
 
 **3. `work` - Work Item**
 
 Manages work items (tasks, features, bugs).
 
-- ID Format: `WI-YYYY-MM-DD-NNN` (e.g., WI-2026-01-19-001)
+- ID Format: `WI-YYYY-MM-DD-NNN` (e.g., WI-YYYY-MM-DD-NNN)
 - Lifecycle: queue → active → done, with cancellation at any stage (per RFC-0001:C-WORK-STATUS)
 
 **4. `clause` - RFC Clause**

--- a/gov/rfc/RFC-0002/rfc.toml
+++ b/gov/rfc/RFC-0002/rfc.toml
@@ -3,7 +3,7 @@
 [govctl]
 id = "RFC-0002"
 title = "CLI Resource Model and Command Architecture"
-version = "0.9.0"
+version = "0.9.4"
 status = "normative"
 phase = "test"
 owners = ["@govctl-org"]
@@ -16,7 +16,7 @@ tags = [
     "validation",
     "release",
 ]
-signature = "19ba6bf36bcbad55cf36d2e7d56993ed9e8d67ed98c6fe598ceb9ad86007fecf"
+signature = "8c6259a92889fd5cb0a87ca5798ca004168631bb63e824eb9c006dc9c90e369a"
 
 [[sections]]
 title = "Summary"
@@ -34,6 +34,30 @@ clauses = [
     "clauses/C-VERIFY-CONFIG.toml",
     "clauses/C-SELF-UPDATE.toml",
 ]
+
+[[changelog]]
+version = "0.9.4"
+date = "2026-06-04"
+notes = "Narrow project support diagnostics"
+changed = ["project-support diagnostics are scoped to govctl-managed local-state .gitignore entries"]
+
+[[changelog]]
+version = "0.9.3"
+date = "2026-06-04"
+notes = "Clarify edit path addressing"
+changed = ["edit operations use deterministic path-based addressing for arrays and nested fields"]
+
+[[changelog]]
+version = "0.9.2"
+date = "2026-06-04"
+notes = "Clarify project support file sync"
+changed = ["govctl check and migrate cover project support file freshness"]
+
+[[changelog]]
+version = "0.9.1"
+date = "2026-06-04"
+notes = "Require check to surface stale bundled schemas"
+changed = ["govctl check reports missing or stale bundled schema files and instructs users to run govctl migrate"]
 
 [[changelog]]
 version = "0.9.0"

--- a/gov/work/2026-06-04-fix-migrate-local-state-gitignore-sync.toml
+++ b/gov/work/2026-06-04-fix-migrate-local-state-gitignore-sync.toml
@@ -1,0 +1,31 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-06-04-004"
+title = "Fix migrate local state gitignore sync"
+status = "done"
+created = "2026-06-04"
+started = "2026-06-04"
+completed = "2026-06-04"
+refs = [
+    "RFC-0002",
+    "ADR-0043",
+]
+
+[content]
+description = "Ensure existing projects upgraded through govctl migrate also get local .govctl state ignored by git. New projects already receive .govctl.lock and .govctl/ entries during init; migrate should sync the same entries for pre-0.9 repositories."
+
+[[content.acceptance_criteria]]
+text = "govctl migrate adds missing .govctl local state entries to .gitignore for existing repositories"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "targeted migrate/init tests pass"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "govctl check warns when local .govctl state entries are missing from .gitignore"
+status = "done"
+category = "fixed"

--- a/gov/work/2026-06-04-fix-reference-and-schema-upgrade-checks.toml
+++ b/gov/work/2026-06-04-fix-reference-and-schema-upgrade-checks.toml
@@ -1,0 +1,37 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-06-04-003"
+title = "Fix reference and schema upgrade checks"
+status = "done"
+created = "2026-06-04"
+started = "2026-06-04"
+completed = "2026-06-04"
+refs = [
+    "RFC-0000",
+    "RFC-0002",
+    "RFC-0006",
+]
+
+[content]
+description = "Fix two 0.9 validation gaps: governed RFC/ADR text must not be able to evade reference hierarchy checks by removing [[...]], and govctl check must prompt migration when bundled schema files such as work.schema.json are stale even if config schema version is current."
+
+[[content.acceptance_criteria]]
+text = "govctl check rejects invalid RFC/ADR hierarchy references even when the artifact ID appears as bare governed text"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "govctl check reports stale bundled schema files and tells users to run govctl migrate"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "targeted validation tests pass"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "govctl check passes"
+status = "done"
+category = "chore"

--- a/src/cli/resources/work.rs
+++ b/src/cli/resources/work.rs
@@ -80,13 +80,13 @@ VALID FIELDS:
   Array fields (use 'add'/'remove' instead):
     - refs: Cross-references to RFCs/ADRs
     - depends_on: Blocking dependencies on other work items
-    - notes: Ad-hoc key points (short strings)
+    - notes: Durable constraints or retry rules (short strings)
     - acceptance_criteria: Completion criteria with category
 
 FIELD SEMANTICS:
   - description: Task scope - define once, rarely change
   - depends_on: Work item IDs that must complete before this item starts
-  - notes: Ad-hoc points - add anytime, keep concise
+  - notes: Closure-worthy durable context only; do not store progress, commands run, next actions, temporary blockers, or TODOs
 
 EXAMPLES:
     govctl work set WI-001 description \"New description\"
@@ -104,13 +104,13 @@ Use dedicated verbs instead of `set` for:
 VALID ARRAY FIELDS:
     - refs: Cross-references to RFCs/ADRs (e.g., \"RFC-0001\", \"ADR-0002\")
     - depends_on: Blocking dependencies on work items (e.g., \"WI-2026-04-06-001\")
-    - notes: Ad-hoc key points (short strings)
+    - notes: Durable constraints or retry rules (short strings)
     - acceptance_criteria: Completion criteria with category prefix
 
 FIELD SEMANTICS:
   - description: Task scope - define once, rarely change
   - depends_on: Work item IDs only; cyclic dependencies are rejected
-  - notes: Ad-hoc points - add anytime, keep concise
+  - notes: Closure-worthy durable context only; do not store progress, commands run, next actions, temporary blockers, or TODOs
 
 ACCEPTANCE CRITERIA FORMAT:
     Use category prefix for changelog generation:
@@ -123,7 +123,7 @@ EXAMPLES:
     govctl work add WI-001 refs RFC-0001
     govctl work add WI-001 depends_on WI-2026-04-06-002
     govctl work add WI-001 acceptance_criteria \"add: Implement feature\"
-    govctl work add WI-001 notes \"Remember to test edge cases\"
+    govctl work add WI-001 notes \"Do not retry parser path X; it cannot preserve normalized arrays\"
 ")]
     Add(WorkAddArgs),
     /// Remove value from work item array field

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -8,22 +8,18 @@ use crate::load::load_project_with_warnings;
 use crate::model::WorkItemStatus;
 use crate::parse::{load_guards_with_warnings, load_releases, load_work_items};
 use crate::scan::scan_source_refs;
+use crate::schema::installed_schema_diagnostics;
 use crate::ui;
 use crate::validate::{validate_project, validate_releases};
 use crate::verification;
 
 /// Validate all governed documents
 pub fn check_all(config: &Config) -> DiagnosticResult<Diagnostics> {
-    // Load project (with warnings for parse errors)
-    let load_result = match load_project_with_warnings(config) {
-        Ok(result) => result,
-        Err(diags) => return Ok(diags),
-    };
+    let mut all_diagnostics = Vec::new();
 
-    let index = load_result.index;
-    let mut all_diagnostics = load_result.warnings;
-
-    // Check schema version
+    // Pre-load support checks implement [[RFC-0002:C-GLOBAL-COMMANDS]].
+    // They run before artifact loading because stale local schemas can reject
+    // newer artifact fields before users see the migrate hint.
     let current_schema = config.schema.version;
     let latest_schema = crate::cmd::migrate::CURRENT_SCHEMA_VERSION;
     if current_schema < latest_schema {
@@ -36,6 +32,20 @@ pub fn check_all(config: &Config) -> DiagnosticResult<Diagnostics> {
             "gov/config.toml",
         ));
     }
+    all_diagnostics.extend(installed_schema_diagnostics(config));
+    all_diagnostics.extend(crate::cmd::project_support::local_state_gitignore_diagnostics());
+
+    // Load project (with warnings for parse errors)
+    let load_result = match load_project_with_warnings(config) {
+        Ok(result) => result,
+        Err(diags) => {
+            all_diagnostics.extend(diags);
+            return Ok(all_diagnostics);
+        }
+    };
+
+    let index = load_result.index;
+    all_diagnostics.extend(load_result.warnings);
 
     // Validate governance artifacts
     let result = validate_project(&index, config);

--- a/src/cmd/migrate/mod.rs
+++ b/src/cmd/migrate/mod.rs
@@ -46,13 +46,40 @@ pub fn migrate(config: &Config, op: WriteOp) -> DiagnosticResult<Diagnostics> {
 
     // Always sync bundled JSON Schemas regardless of schema version. [[ADR-0035]]
     let schemas_synced = sync_schemas(config, op)?;
+    let gitignore_entries_synced =
+        crate::cmd::project_support::ensure_local_state_gitignore_entries(op)?;
 
     let current = config.schema.version;
     if current >= CURRENT_SCHEMA_VERSION {
-        if schemas_synced > 0 {
-            ui::success(format!(
-                "Synced {schemas_synced} schema file(s); already at schema version {CURRENT_SCHEMA_VERSION}"
-            ));
+        if schemas_synced > 0 || gitignore_entries_synced > 0 {
+            let mut parts = Vec::new();
+            if schemas_synced > 0 {
+                parts.push(format!("{schemas_synced} schema file(s)"));
+            }
+            if gitignore_entries_synced > 0 {
+                let label = if gitignore_entries_synced == 1 {
+                    "gitignore entry"
+                } else {
+                    "gitignore entries"
+                };
+                parts.push(format!("{gitignore_entries_synced} {label}"));
+            }
+            let message = if op.is_preview() {
+                format!(
+                    "Would sync {}; already at schema version {CURRENT_SCHEMA_VERSION}",
+                    parts.join(", ")
+                )
+            } else {
+                format!(
+                    "Synced {}; already at schema version {CURRENT_SCHEMA_VERSION}",
+                    parts.join(", ")
+                )
+            };
+            if op.is_preview() {
+                ui::info(message);
+            } else {
+                ui::success(message);
+            }
         } else {
             ui::info(format!(
                 "Repository already at schema version {CURRENT_SCHEMA_VERSION}"

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -14,6 +14,7 @@ pub mod migrate;
 pub mod move_;
 pub mod new;
 pub(crate) mod output;
+pub(crate) mod project_support;
 pub mod render;
 pub mod self_update;
 pub mod status;

--- a/src/cmd/new/mod.rs
+++ b/src/cmd/new/mod.rs
@@ -5,7 +5,6 @@ use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticResult, Diagnostic
 use crate::schema::ARTIFACT_SCHEMA_TEMPLATES;
 use crate::ui;
 use crate::write::{WriteOp, create_dir_all, write_file};
-use std::path::PathBuf;
 
 mod artifacts;
 mod skills;
@@ -73,8 +72,8 @@ pub fn init_project(config: &Config, force: bool, op: WriteOp) -> DiagnosticResu
         }
     }
 
-    // Ensure .gitignore contains local govctl state entries
-    ensure_gitignore_lock_entry(op)?;
+    // Ensure .gitignore contains local govctl state entries.
+    crate::cmd::project_support::ensure_local_state_gitignore_entries(op)?;
 
     if !op.is_preview() {
         ui::success("Project initialized");
@@ -84,46 +83,4 @@ pub fn init_project(config: &Config, force: bool, op: WriteOp) -> DiagnosticResu
         );
     }
     Ok(vec![])
-}
-
-/// Ensure .gitignore contains local govctl state entries.
-fn ensure_gitignore_lock_entry(op: WriteOp) -> DiagnosticResult<()> {
-    const LOCAL_STATE_ENTRIES: &[&str] = &[".govctl.lock", ".govctl/"];
-    let gitignore_path = PathBuf::from(".gitignore");
-
-    if gitignore_path.exists() {
-        let content = std::fs::read_to_string(&gitignore_path).map_err(|err| {
-            Diagnostic::io_error("read .gitignore", err, gitignore_path.display().to_string())
-        })?;
-        let missing_entries: Vec<&str> = LOCAL_STATE_ENTRIES
-            .iter()
-            .copied()
-            .filter(|entry| !content.lines().any(|line| line.trim() == *entry))
-            .collect();
-
-        if missing_entries.is_empty() {
-            return Ok(());
-        }
-
-        let missing_content = missing_entries.join("\n");
-        let new_content = if content.ends_with('\n') {
-            format!("{content}{missing_content}\n")
-        } else {
-            format!("{content}\n{missing_content}\n")
-        };
-        write_file(&gitignore_path, &new_content, op, None)?;
-        if !op.is_preview() {
-            ui::info(format!(
-                "Added local govctl state entries to .gitignore: {}",
-                missing_entries.join(", ")
-            ));
-        }
-    } else {
-        let content = format!("# govctl local state\n{}\n", LOCAL_STATE_ENTRIES.join("\n"));
-        write_file(&gitignore_path, &content, op, None)?;
-        if !op.is_preview() {
-            ui::created_path(&gitignore_path);
-        }
-    }
-    Ok(())
 }

--- a/src/cmd/project_support.rs
+++ b/src/cmd/project_support.rs
@@ -1,0 +1,98 @@
+//! Project support file synchronization shared by init, migrate, and check.
+
+use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticResult, Diagnostics};
+use crate::ui;
+use crate::write::{WriteOp, write_file};
+use std::io::ErrorKind;
+use std::path::PathBuf;
+
+// Implements [[RFC-0002:C-GLOBAL-COMMANDS]]: init/migrate maintain local-state ignore entries.
+const LOCAL_STATE_GITIGNORE_ENTRIES: &[&str] = &[".govctl.lock", ".govctl/"];
+
+// Implements [[RFC-0002:C-GLOBAL-COMMANDS]]: migrate refreshes local-state
+// .gitignore entries regardless of schema version.
+pub(crate) fn ensure_local_state_gitignore_entries(op: WriteOp) -> DiagnosticResult<usize> {
+    let gitignore_path = gitignore_path();
+
+    match std::fs::read_to_string(&gitignore_path) {
+        Ok(content) => {
+            let missing_entries = missing_local_state_gitignore_entries(&content);
+            if missing_entries.is_empty() {
+                return Ok(0);
+            }
+
+            let missing_content = missing_entries.join("\n");
+            let new_content = if content.ends_with('\n') {
+                format!("{content}{missing_content}\n")
+            } else {
+                format!("{content}\n{missing_content}\n")
+            };
+            write_file(&gitignore_path, &new_content, op, None)?;
+            if !op.is_preview() {
+                ui::info(format!(
+                    "Added local govctl state entries to .gitignore: {}",
+                    missing_entries.join(", ")
+                ));
+            }
+            Ok(missing_entries.len())
+        }
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            let content = format!(
+                "# govctl local state\n{}\n",
+                LOCAL_STATE_GITIGNORE_ENTRIES.join("\n")
+            );
+            write_file(&gitignore_path, &content, op, None)?;
+            if !op.is_preview() {
+                ui::created_path(&gitignore_path);
+            }
+            Ok(LOCAL_STATE_GITIGNORE_ENTRIES.len())
+        }
+        Err(err) => Err(Diagnostic::io_error(
+            "read .gitignore",
+            err,
+            gitignore_path.display().to_string(),
+        )),
+    }
+}
+
+// Implements [[RFC-0002:C-GLOBAL-COMMANDS]]: check warns when govctl-managed
+// local-state .gitignore entries are missing or outdated.
+pub(crate) fn local_state_gitignore_diagnostics() -> Diagnostics {
+    let gitignore_path = gitignore_path();
+    let missing_entries = match std::fs::read_to_string(&gitignore_path) {
+        Ok(content) => missing_local_state_gitignore_entries(&content),
+        Err(err) if err.kind() == ErrorKind::NotFound => LOCAL_STATE_GITIGNORE_ENTRIES.to_vec(),
+        Err(err) => {
+            return vec![Diagnostic::io_error(
+                "read .gitignore",
+                err,
+                gitignore_path.display().to_string(),
+            )];
+        }
+    };
+
+    if missing_entries.is_empty() {
+        return vec![];
+    }
+
+    vec![Diagnostic::new(
+        DiagnosticCode::W0111ProjectSupportOutdated,
+        format!(
+            "Local govctl state entries missing from .gitignore: {}. Run `govctl migrate` to refresh local-state .gitignore entries.",
+            missing_entries.join(", ")
+        ),
+        gitignore_path.display().to_string(),
+    )]
+}
+
+fn gitignore_path() -> PathBuf {
+    PathBuf::from(".gitignore")
+}
+
+fn missing_local_state_gitignore_entries(content: &str) -> Vec<&'static str> {
+    LOCAL_STATE_GITIGNORE_ENTRIES
+        .iter()
+        .copied()
+        .filter(|entry| !content.lines().any(|line| line.trim() == *entry))
+        .collect()
+}

--- a/src/diagnostic/code/metadata.rs
+++ b/src/diagnostic/code/metadata.rs
@@ -9,7 +9,8 @@ pub(super) fn level(code: &DiagnosticCode) -> DiagnosticLevel {
         | DiagnosticCode::W0107SourceRefOutdated
         | DiagnosticCode::W0108WorkPlaceholderDescription
         | DiagnosticCode::W0109WorkNoActive
-        | DiagnosticCode::W0110SchemaOutdated => DiagnosticLevel::Warning,
+        | DiagnosticCode::W0110SchemaOutdated
+        | DiagnosticCode::W0111ProjectSupportOutdated => DiagnosticLevel::Warning,
         DiagnosticCode::I0401WorkLegacyInlineHistory => DiagnosticLevel::Info,
         _ => DiagnosticLevel::Error,
     }
@@ -136,6 +137,7 @@ pub(super) fn code(code: &DiagnosticCode) -> &'static str {
         DiagnosticCode::W0108WorkPlaceholderDescription => "W0108",
         DiagnosticCode::W0109WorkNoActive => "W0109",
         DiagnosticCode::W0110SchemaOutdated => "W0110",
+        DiagnosticCode::W0111ProjectSupportOutdated => "W0111",
         // I04xx - Work Item info
         DiagnosticCode::I0401WorkLegacyInlineHistory => "I0401",
     }

--- a/src/diagnostic/code/mod.rs
+++ b/src/diagnostic/code/mod.rs
@@ -151,6 +151,7 @@ pub enum DiagnosticCode {
     W0108WorkPlaceholderDescription,
     W0109WorkNoActive,
     W0110SchemaOutdated,
+    W0111ProjectSupportOutdated,
 
     // Informational diagnostics (I04xx)
     I0401WorkLegacyInlineHistory,
@@ -184,6 +185,7 @@ mod tests {
         assert_eq!(DiagnosticCode::E1101TagInvalidFormat.code(), "E1101");
         assert_eq!(DiagnosticCode::E1201LoopStateInvalid.code(), "E1201");
         assert_eq!(DiagnosticCode::W0101RfcNoChangelog.code(), "W0101");
+        assert_eq!(DiagnosticCode::W0111ProjectSupportOutdated.code(), "W0111");
         assert_eq!(DiagnosticCode::I0401WorkLegacyInlineHistory.code(), "I0401");
     }
 
@@ -199,6 +201,10 @@ mod tests {
         );
         assert_eq!(
             DiagnosticCode::W0110SchemaOutdated.level(),
+            DiagnosticLevel::Warning
+        );
+        assert_eq!(
+            DiagnosticCode::W0111ProjectSupportOutdated.level(),
             DiagnosticLevel::Warning
         );
         assert_eq!(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,7 +1,7 @@
 //! Runtime JSON Schema validation for governance artifacts.
 
 use crate::config::Config;
-use crate::diagnostic::{Diagnostic, DiagnosticCode};
+use crate::diagnostic::{Diagnostic, DiagnosticCode, Diagnostics};
 use serde_json::Value;
 use std::borrow::Cow;
 use std::io::ErrorKind;
@@ -120,6 +120,35 @@ pub const ARTIFACT_SCHEMA_TEMPLATES: &[SchemaTemplate] = &[
         content: include_str!("../gov/schema/loop-round.schema.json"),
     },
 ];
+
+// Implements [[RFC-0002:C-GLOBAL-COMMANDS]]: check reports stale bundled schemas
+// with W0110 so users can refresh project support files via `govctl migrate`.
+pub fn installed_schema_diagnostics(config: &Config) -> Diagnostics {
+    let mut diagnostics = Vec::new();
+    for template in ARTIFACT_SCHEMA_TEMPLATES {
+        let path = config.schema_dir().join(template.filename);
+        let display = config.display_path(&path).display().to_string();
+        match std::fs::read_to_string(&path) {
+            Ok(existing) if existing == template.content => {}
+            Ok(_) => diagnostics.push(stale_schema_diagnostic(&display)),
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                diagnostics.push(stale_schema_diagnostic(&display));
+            }
+            Err(err) => diagnostics.push(Diagnostic::io_error("read schema file", err, display)),
+        }
+    }
+    diagnostics
+}
+
+fn stale_schema_diagnostic(display_path: &str) -> Diagnostic {
+    Diagnostic::new(
+        DiagnosticCode::W0110SchemaOutdated,
+        format!(
+            "Bundled schema file '{display_path}' is missing or outdated. Run `govctl migrate` to refresh bundled schemas."
+        ),
+        display_path,
+    )
+}
 
 pub fn validate_toml_value(
     kind: ArtifactSchema,

--- a/src/validate/bracket_refs.rs
+++ b/src/validate/bracket_refs.rs
@@ -1,17 +1,27 @@
 use super::ValidationResult;
 use super::reference_hierarchy::{ReferenceSurface, check_ref_hierarchy};
+use crate::artifact_index::artifact_ref_ids;
 use crate::config::Config;
 use crate::diagnostic::{Diagnostic, DiagnosticCode};
 use crate::model::ProjectIndex;
 use regex::Regex;
+use std::collections::HashSet;
 
-/// Validate `[[...]]` link targets in RFC and ADR content per [[RFC-0000:C-REFERENCE-HIERARCHY]].
+const BARE_ARTIFACT_ID_PATTERN: &str = r"\b(RFC-\d{4}(?::C-[A-Z][A-Z0-9-]*)?|ADR-\d{4}|WI-\d{4}-\d{2}-\d{2}-(?:[a-f0-9]{4}(?:-\d{3})?|\d{3}))\b";
+
+struct ReferenceScanner {
+    bracket_re: Regex,
+    bare_re: Regex,
+    known_ids: HashSet<String>,
+}
+
+/// Validate references in RFC and ADR content per [[RFC-0000:C-REFERENCE-HIERARCHY]].
 pub(super) fn validate_bracket_reference_hierarchy(
     index: &ProjectIndex,
     config: &Config,
     result: &mut ValidationResult,
 ) {
-    let re = match Regex::new(&config.source_scan.pattern) {
+    let bracket_re = match Regex::new(&config.source_scan.pattern) {
         Ok(r) => r,
         Err(e) => {
             result.diagnostics.push(Diagnostic::new(
@@ -22,17 +32,40 @@ pub(super) fn validate_bracket_reference_hierarchy(
             return;
         }
     };
+    let bare_re = match Regex::new(BARE_ARTIFACT_ID_PATTERN) {
+        Ok(r) => r,
+        Err(e) => {
+            result.diagnostics.push(Diagnostic::new(
+                DiagnosticCode::E0903UnexpectedError,
+                format!("Invalid built-in bare artifact reference scan pattern: {e}"),
+                "internal",
+            ));
+            return;
+        }
+    };
+    let scanner = ReferenceScanner {
+        bracket_re,
+        bare_re,
+        known_ids: artifact_ref_ids(index),
+    };
 
     for rfc in &index.rfcs {
         let rfc_path = config.display_path(&rfc.path).display().to_string();
         let rid = rfc.rfc.rfc_id.as_str();
         for clause in &rfc.clauses {
             let clause_path = config.display_path(&clause.path).display().to_string();
-            scan_rfc_bracket_refs(&re, &clause.spec.text, rid, &clause_path, result);
+            scan_rfc_reference_hierarchy(
+                &scanner,
+                &clause.spec.text,
+                rid,
+                &clause_path,
+                true,
+                result,
+            );
         }
         for entry in &rfc.rfc.changelog {
             if let Some(ref notes) = entry.notes {
-                scan_rfc_bracket_refs(&re, notes, rid, &rfc_path, result);
+                scan_rfc_reference_hierarchy(&scanner, notes, rid, &rfc_path, false, result);
             }
             for line in entry
                 .added
@@ -43,7 +76,7 @@ pub(super) fn validate_bracket_reference_hierarchy(
                 .chain(entry.fixed.iter())
                 .chain(entry.security.iter())
             {
-                scan_rfc_bracket_refs(&re, line, rid, &rfc_path, result);
+                scan_rfc_reference_hierarchy(&scanner, line, rid, &rfc_path, false, result);
             }
         }
     }
@@ -52,60 +85,169 @@ pub(super) fn validate_bracket_reference_hierarchy(
         let adr_path = config.display_path(&adr.path).display().to_string();
         let aid = adr.meta().id.as_str();
         let c = &adr.spec.content;
-        scan_adr_bracket_refs(&re, &c.context, aid, &adr_path, result);
-        scan_adr_bracket_refs(&re, &c.decision, aid, &adr_path, result);
-        scan_adr_bracket_refs(&re, &c.consequences, aid, &adr_path, result);
+        scan_adr_reference_hierarchy(&scanner, &c.context, aid, &adr_path, result);
+        scan_adr_reference_hierarchy(&scanner, &c.decision, aid, &adr_path, result);
+        scan_adr_reference_hierarchy(&scanner, &c.consequences, aid, &adr_path, result);
         for alt in &c.alternatives {
-            scan_adr_bracket_refs(&re, &alt.text, aid, &adr_path, result);
+            scan_adr_reference_hierarchy(&scanner, &alt.text, aid, &adr_path, result);
             for p in &alt.pros {
-                scan_adr_bracket_refs(&re, p, aid, &adr_path, result);
+                scan_adr_reference_hierarchy(&scanner, p, aid, &adr_path, result);
             }
             for cons in &alt.cons {
-                scan_adr_bracket_refs(&re, cons, aid, &adr_path, result);
+                scan_adr_reference_hierarchy(&scanner, cons, aid, &adr_path, result);
             }
             if let Some(ref rr) = alt.rejection_reason {
-                scan_adr_bracket_refs(&re, rr, aid, &adr_path, result);
+                scan_adr_reference_hierarchy(&scanner, rr, aid, &adr_path, result);
             }
         }
     }
 }
 
-fn scan_rfc_bracket_refs(
-    re: &Regex,
+fn scan_rfc_reference_hierarchy(
+    scanner: &ReferenceScanner,
     text: &str,
     rfc_id: &str,
     path: &str,
+    scan_bare_text: bool,
     result: &mut ValidationResult,
 ) {
-    for caps in re.captures_iter(text) {
-        let Some(m) = caps.get(1) else {
-            continue;
-        };
-        let target = m.as_str();
-        if let Err(diagnostic) =
-            check_ref_hierarchy(rfc_id, target, path, ReferenceSurface::BracketLink)
-        {
-            result.diagnostics.push(diagnostic);
-        }
-    }
+    scan_reference_hierarchy(scanner, text, rfc_id, path, scan_bare_text, result);
 }
 
-fn scan_adr_bracket_refs(
-    re: &Regex,
+fn scan_adr_reference_hierarchy(
+    scanner: &ReferenceScanner,
     text: &str,
     adr_id: &str,
     path: &str,
     result: &mut ValidationResult,
 ) {
-    for caps in re.captures_iter(text) {
+    scan_reference_hierarchy(scanner, text, adr_id, path, true, result);
+}
+
+fn scan_reference_hierarchy(
+    scanner: &ReferenceScanner,
+    text: &str,
+    owner_id: &str,
+    path: &str,
+    scan_bare_text: bool,
+    result: &mut ValidationResult,
+) {
+    let mut bracket_ranges = Vec::new();
+    for caps in scanner.bracket_re.captures_iter(text) {
+        if let Some(full) = caps.get(0) {
+            bracket_ranges.push(full.range());
+        }
         let Some(m) = caps.get(1) else {
             continue;
         };
         let target = m.as_str();
         if let Err(diagnostic) =
-            check_ref_hierarchy(adr_id, target, path, ReferenceSurface::BracketLink)
+            check_ref_hierarchy(owner_id, target, path, ReferenceSurface::BracketLink)
         {
             result.diagnostics.push(diagnostic);
         }
+    }
+
+    if !scan_bare_text {
+        return;
+    }
+
+    for caps in scanner.bare_re.captures_iter(text) {
+        let Some(m) = caps.get(1) else {
+            continue;
+        };
+        if bracket_ranges
+            .iter()
+            .any(|range| range.start <= m.start() && m.end() <= range.end)
+        {
+            continue;
+        }
+        let target = m.as_str();
+        if !scanner.known_ids.contains(target) {
+            continue;
+        }
+        if let Err(diagnostic) =
+            check_ref_hierarchy(owner_id, target, path, ReferenceSurface::BareText)
+        {
+            result.diagnostics.push(diagnostic);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostic::DiagnosticResult;
+
+    fn bracket_re() -> DiagnosticResult<Regex> {
+        Regex::new(
+            r"\[\[(RFC-\d{4}(?::C-[A-Z][A-Z0-9-]*)?|ADR-\d{4}|WI-\d{4}-\d{2}-\d{2}-(?:[a-f0-9]{4}(?:-\d{3})?|\d{3}))\]\]",
+        )
+        .map_err(|err| {
+            Diagnostic::new(
+                DiagnosticCode::E0903UnexpectedError,
+                format!("test bracket regex must compile: {err}"),
+                "test",
+            )
+        })
+    }
+
+    fn bare_re() -> DiagnosticResult<Regex> {
+        Regex::new(BARE_ARTIFACT_ID_PATTERN).map_err(|err| {
+            Diagnostic::new(
+                DiagnosticCode::E0903UnexpectedError,
+                format!("test bare regex must compile: {err}"),
+                "test",
+            )
+        })
+    }
+
+    fn scanner(known_ids: HashSet<String>) -> DiagnosticResult<ReferenceScanner> {
+        Ok(ReferenceScanner {
+            bracket_re: bracket_re()?,
+            bare_re: bare_re()?,
+            known_ids,
+        })
+    }
+
+    #[test]
+    fn bare_known_adr_in_rfc_text_violates_hierarchy() -> DiagnosticResult<()> {
+        let mut known_ids = HashSet::new();
+        known_ids.insert("ADR-0001".to_string());
+        let mut result = ValidationResult::default();
+
+        scan_reference_hierarchy(
+            &scanner(known_ids)?,
+            "This mentions ADR-0001 without brackets.",
+            "RFC-0001",
+            "f",
+            true,
+            &mut result,
+        );
+
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(
+            result.diagnostics[0].code,
+            DiagnosticCode::E0112RfcReferenceHierarchy
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn bare_unknown_artifact_shape_in_rfc_text_is_not_a_reference() -> DiagnosticResult<()> {
+        let known_ids = HashSet::new();
+        let mut result = ValidationResult::default();
+
+        scan_reference_hierarchy(
+            &scanner(known_ids)?,
+            "This mentions ADR-0001 only as an example shape.",
+            "RFC-0001",
+            "f",
+            true,
+            &mut result,
+        );
+
+        assert!(result.diagnostics.is_empty());
+        Ok(())
     }
 }

--- a/src/validate/reference_hierarchy.rs
+++ b/src/validate/reference_hierarchy.rs
@@ -4,6 +4,7 @@ use crate::diagnostic::{Diagnostic, DiagnosticCode};
 pub(super) enum ReferenceSurface {
     StructuredRef,
     BracketLink,
+    BareText,
 }
 
 /// Enforce [[RFC-0000:C-REFERENCE-HIERARCHY]] across refs and inline links.
@@ -50,11 +51,17 @@ fn hierarchy_message(
         ("RFC", ReferenceSurface::BracketLink) => format!(
             "RFC '{owner_id}' links to [[{target_id}]], but RFCs are higher authority than ADRs and Work Items — remove this link (the ADR or Work Item should reference the RFC, not the other way around)"
         ),
+        ("RFC", ReferenceSurface::BareText) => format!(
+            "RFC '{owner_id}' mentions {target_id}, but RFCs are higher authority than ADRs and Work Items — remove or rephrase this mention (the ADR or Work Item should reference the RFC, not the other way around)"
+        ),
         ("ADR", ReferenceSurface::StructuredRef) => format!(
             "ADR '{owner_id}' references {target_id}, but ADRs are higher authority than Work Items — remove this reference (the Work Item should reference the ADR, not the other way around)"
         ),
         ("ADR", ReferenceSurface::BracketLink) => format!(
             "ADR '{owner_id}' links to [[{target_id}]], but ADRs are higher authority than Work Items — remove this link (the Work Item should reference the ADR, not the other way around)"
+        ),
+        ("ADR", ReferenceSurface::BareText) => format!(
+            "ADR '{owner_id}' mentions {target_id}, but ADRs are higher authority than Work Items — remove or rephrase this mention (the Work Item should reference the ADR, not the other way around)"
         ),
         _ => unreachable!("only RFC and ADR hierarchy violations are diagnosable"),
     }
@@ -175,6 +182,19 @@ mod tests {
                 format!(
                     "ADR 'ADR-0001' links to [[{target_id}]], but ADRs are higher authority than Work Items — remove this link (the Work Item should reference the ADR, not the other way around)"
                 )
+            );
+        }
+    }
+
+    #[test]
+    fn bare_text_diagnostic_names_the_plain_identifier() {
+        let result = check_ref_hierarchy("RFC-0001", "ADR-0001", "f", ReferenceSurface::BareText);
+
+        assert!(result.is_err(), "RFC to ADR bare mention should fail");
+        if let Err(err) = result {
+            assert_eq!(
+                err.message,
+                "RFC 'RFC-0001' mentions ADR-0001, but RFCs are higher authority than ADRs and Work Items — remove or rephrase this mention (the ADR or Work Item should reference the RFC, not the other way around)"
             );
         }
     }

--- a/tests/error_tests/rfc_clause_cases/check.rs
+++ b/tests/error_tests/rfc_clause_cases/check.rs
@@ -22,6 +22,14 @@ fn write_clause_toml(
     Ok(())
 }
 
+fn write_adr_toml(project_dir: &std::path::Path, content: &str) -> common::TestResult {
+    fs::write(
+        project_dir.join("gov/adr/ADR-0001-lower-authority.toml"),
+        content,
+    )?;
+    Ok(())
+}
+
 #[test]
 fn test_broken_superseded_check() -> common::TestResult {
     let (temp_dir, date) = init_project_with_date()?;
@@ -133,5 +141,323 @@ text = "A test clause in an invalid RFC."
 
     let output = run_commands(temp_dir.path(), &[&["check"]])?;
     assert_error_snapshot!(normalize_output(&output, temp_dir.path(), &date)?);
+    Ok(())
+}
+
+#[test]
+fn test_rfc_plain_text_adr_reference_violates_hierarchy() -> common::TestResult {
+    let temp_dir = init_project()?;
+
+    write_rfc_toml(
+        temp_dir.path(),
+        r#"[govctl]
+schema = 1
+id = "RFC-0001"
+title = "Plain ADR Reference"
+version = "1.0.0"
+status = "normative"
+phase = "stable"
+owners = ["test@example.com"]
+created = "2026-01-01"
+
+[[sections]]
+title = "Overview"
+clauses = ["clauses/C-TEST.toml"]
+
+[[changelog]]
+version = "1.0.0"
+date = "2026-01-01"
+added = ["Initial release"]
+"#,
+    )?;
+
+    write_clause_toml(
+        temp_dir.path(),
+        "C-TEST.toml",
+        r#"[govctl]
+schema = 1
+id = "C-TEST"
+title = "Test Clause"
+kind = "normative"
+status = "active"
+since = "1.0.0"
+
+[content]
+text = "This RFC tries to cite ADR-0001 without brackets."
+"#,
+    )?;
+
+    write_adr_toml(
+        temp_dir.path(),
+        r#"[govctl]
+schema = 1
+id = "ADR-0001"
+title = "Lower Authority"
+status = "accepted"
+date = "2026-01-01"
+refs = ["RFC-0001"]
+
+[content]
+context = "Context"
+decision = "Decision"
+consequences = "Consequences"
+"#,
+    )?;
+
+    let output = run_commands(temp_dir.path(), &[&["check"]])?;
+    assert!(output.contains("error[E0112]"), "output: {}", output);
+    assert!(output.contains("mentions ADR-0001"), "output: {}", output);
+    Ok(())
+}
+
+#[test]
+fn test_rfc_plain_text_nonexistent_adr_is_allowed() -> common::TestResult {
+    let temp_dir = init_project()?;
+
+    write_rfc_toml(
+        temp_dir.path(),
+        r#"[govctl]
+schema = 1
+id = "RFC-0001"
+title = "Nonexistent ADR Mention"
+version = "1.0.0"
+status = "normative"
+phase = "stable"
+owners = ["test@example.com"]
+created = "2026-01-01"
+
+[[sections]]
+title = "Overview"
+clauses = ["clauses/C-TEST.toml"]
+
+[[changelog]]
+version = "1.0.0"
+date = "2026-01-01"
+added = ["Initial release"]
+"#,
+    )?;
+
+    write_clause_toml(
+        temp_dir.path(),
+        "C-TEST.toml",
+        r#"[govctl]
+schema = 1
+id = "C-TEST"
+title = "Test Clause"
+kind = "normative"
+status = "active"
+since = "1.0.0"
+
+[content]
+text = "This RFC mentions ADR-9999 as a nonexistent example."
+"#,
+    )?;
+
+    let output = run_commands(temp_dir.path(), &[&["check"]])?;
+    assert!(!output.contains("error[E0112]"), "output: {}", output);
+    assert!(!output.contains("error[E0306]"), "output: {}", output);
+    assert!(!output.contains("mentions ADR-9999"), "output: {}", output);
+    Ok(())
+}
+
+#[test]
+fn test_rfc_changelog_plain_text_adr_reference_is_allowed() -> common::TestResult {
+    let temp_dir = init_project()?;
+
+    write_rfc_toml(
+        temp_dir.path(),
+        r#"[govctl]
+schema = 1
+id = "RFC-0001"
+title = "Changelog ADR Mention"
+version = "1.0.0"
+status = "normative"
+phase = "stable"
+owners = ["test@example.com"]
+created = "2026-01-01"
+
+[[sections]]
+title = "Overview"
+clauses = ["clauses/C-TEST.toml"]
+
+[[changelog]]
+version = "1.0.0"
+date = "2026-01-01"
+notes = "This release note mentions ADR-0001 as prose."
+added = ["Initial release mentions ADR-0001 as prose"]
+"#,
+    )?;
+
+    write_clause_toml(
+        temp_dir.path(),
+        "C-TEST.toml",
+        r#"[govctl]
+schema = 1
+id = "C-TEST"
+title = "Test Clause"
+kind = "normative"
+status = "active"
+since = "1.0.0"
+
+[content]
+text = "This RFC clause does not cite lower authority artifacts."
+"#,
+    )?;
+
+    write_adr_toml(
+        temp_dir.path(),
+        r#"[govctl]
+schema = 1
+id = "ADR-0001"
+title = "Lower Authority"
+status = "accepted"
+date = "2026-01-01"
+refs = ["RFC-0001"]
+
+[content]
+context = "Context"
+decision = "Decision"
+consequences = "Consequences"
+"#,
+    )?;
+
+    let output = run_commands(temp_dir.path(), &[&["check"]])?;
+    assert!(!output.contains("error[E0112]"), "output: {}", output);
+    Ok(())
+}
+
+#[test]
+fn test_rfc_bracketed_adr_reference_reports_once() -> common::TestResult {
+    let temp_dir = init_project()?;
+
+    write_rfc_toml(
+        temp_dir.path(),
+        r#"[govctl]
+schema = 1
+id = "RFC-0001"
+title = "Bracket ADR Reference"
+version = "1.0.0"
+status = "normative"
+phase = "stable"
+owners = ["test@example.com"]
+created = "2026-01-01"
+
+[[sections]]
+title = "Overview"
+clauses = ["clauses/C-TEST.toml"]
+
+[[changelog]]
+version = "1.0.0"
+date = "2026-01-01"
+added = ["Initial release"]
+"#,
+    )?;
+
+    write_clause_toml(
+        temp_dir.path(),
+        "C-TEST.toml",
+        r#"[govctl]
+schema = 1
+id = "C-TEST"
+title = "Test Clause"
+kind = "normative"
+status = "active"
+since = "1.0.0"
+
+[content]
+text = "This RFC links to [[ADR-0001]]."
+"#,
+    )?;
+
+    write_adr_toml(
+        temp_dir.path(),
+        r#"[govctl]
+schema = 1
+id = "ADR-0001"
+title = "Lower Authority"
+status = "accepted"
+date = "2026-01-01"
+refs = ["RFC-0001"]
+
+[content]
+context = "Context"
+decision = "Decision"
+consequences = "Consequences"
+"#,
+    )?;
+
+    let output = run_commands(temp_dir.path(), &[&["check"]])?;
+    assert_eq!(
+        output.matches("error[E0112]").count(),
+        1,
+        "output: {output}"
+    );
+    assert_eq!(
+        output.matches("links to [[ADR-0001]]").count(),
+        1,
+        "output: {output}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_adr_plain_text_work_reference_violates_hierarchy() -> common::TestResult {
+    let temp_dir = init_project()?;
+
+    write_rfc_toml(
+        temp_dir.path(),
+        r#"[govctl]
+schema = 1
+id = "RFC-0001"
+title = "Governing RFC"
+version = "1.0.0"
+status = "normative"
+phase = "stable"
+owners = ["test@example.com"]
+created = "2026-01-01"
+
+[[sections]]
+title = "Overview"
+"#,
+    )?;
+
+    write_adr_toml(
+        temp_dir.path(),
+        r#"[govctl]
+schema = 1
+id = "ADR-0001"
+title = "Plain Work Reference"
+status = "accepted"
+date = "2026-01-01"
+refs = ["RFC-0001"]
+
+[content]
+context = "Context"
+decision = "This ADR tries to cite WI-2026-01-01-001 without brackets."
+consequences = "Consequences"
+"#,
+    )?;
+
+    fs::write(
+        temp_dir.path().join("gov/work/2026-01-01-task.toml"),
+        r#"[govctl]
+schema = 1
+id = "WI-2026-01-01-001"
+title = "Execution task"
+status = "queue"
+created = "2026-01-01"
+
+[content]
+description = "Work description"
+"#,
+    )?;
+
+    let output = run_commands(temp_dir.path(), &[&["check"]])?;
+    assert!(output.contains("error[E0306]"), "output: {}", output);
+    assert!(
+        output.contains("mentions WI-2026-01-01-001"),
+        "output: {}",
+        output
+    );
     Ok(())
 }

--- a/tests/error_tests/schema.rs
+++ b/tests/error_tests/schema.rs
@@ -176,3 +176,74 @@ unexpected = "should fail schema validation"
     assert!(output.contains("guard.schema.json"), "output: {}", output);
     Ok(())
 }
+
+#[test]
+fn test_check_reports_stale_schema_file_even_when_schema_version_is_current() -> common::TestResult
+{
+    let temp_dir = init_project()?;
+
+    fs::write(
+        temp_dir.path().join("gov/schema/work.schema.json"),
+        r#"{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["govctl", "content"],
+  "properties": {
+    "govctl": {
+      "type": "object",
+      "required": ["id", "title", "status"],
+      "properties": {
+        "id": { "type": "string" },
+        "title": { "type": "string" },
+        "status": { "type": "string" },
+        "created": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "description": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}
+"#,
+    )?;
+
+    fs::write(
+        temp_dir.path().join("gov/work/2026-01-01-dependency.toml"),
+        r#"[govctl]
+schema = 1
+id = "WI-2026-01-01-001"
+title = "Dependency field"
+status = "queue"
+created = "2026-01-01"
+depends_on = ["WI-2026-01-01-002"]
+
+[content]
+description = "Work description"
+"#,
+    )?;
+
+    let output = run_commands(temp_dir.path(), &[&["check"]])?;
+    assert!(output.contains("warning[W0110]"), "output: {}", output);
+    assert!(output.contains("work.schema.json"), "output: {}", output);
+    assert!(output.contains("govctl migrate"), "output: {}", output);
+    Ok(())
+}
+
+#[test]
+fn test_check_reports_missing_local_state_gitignore_entry() -> common::TestResult {
+    let temp_dir = init_project()?;
+    fs::write(temp_dir.path().join(".gitignore"), ".govctl.lock\n")?;
+
+    let output = run_commands(temp_dir.path(), &[&["check"]])?;
+    assert!(output.contains("warning[W0111]"), "output: {}", output);
+    assert!(output.contains(".gitignore"), "output: {}", output);
+    assert!(output.contains(".govctl/"), "output: {}", output);
+    assert!(output.contains("govctl migrate"), "output: {}", output);
+    Ok(())
+}

--- a/tests/test_migrate.rs
+++ b/tests/test_migrate.rs
@@ -4,6 +4,29 @@ mod common;
 
 use common::{TestResult, init_project, init_project_v1, run_commands};
 use std::fs;
+use std::io;
+use std::path::Path;
+
+fn current_schema_version(dir: &Path) -> Result<u32, Box<dyn std::error::Error>> {
+    let config = fs::read_to_string(dir.join("gov/config.toml"))?;
+    let parsed: toml::Value = toml::from_str(&config)?;
+    let version = parsed
+        .get("schema")
+        .and_then(|schema| schema.get("version"))
+        .and_then(toml::Value::as_integer)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "missing gov/config.toml schema.version",
+            )
+        })?;
+    Ok(u32::try_from(version)?)
+}
+
+fn latest_schema_version() -> Result<u32, Box<dyn std::error::Error>> {
+    let temp_dir = init_project()?;
+    current_schema_version(temp_dir.path())
+}
 
 fn write_legacy_rfc_project(dir: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     let rfc_dir = dir.join("gov/rfc/RFC-0001");
@@ -144,6 +167,7 @@ fn test_migrate_dry_run_previews_config_version_bump_without_artifact_changes() 
 #[test]
 fn test_migrate_is_noop_on_current_version() -> TestResult {
     let temp_dir = init_project()?;
+    let expected_version = current_schema_version(temp_dir.path())?;
 
     // Create an RFC so the project isn't empty, then migrate to bump version
     run_commands(
@@ -165,7 +189,7 @@ fn test_migrate_is_noop_on_current_version() -> TestResult {
     // Second migrate should be a noop
     let output = run_commands(temp_dir.path(), &[&["migrate"]])?;
     assert!(
-        output.contains("already at schema version 2"),
+        output.contains(&format!("already at schema version {expected_version}")),
         "output: {}",
         output
     );
@@ -174,8 +198,83 @@ fn test_migrate_is_noop_on_current_version() -> TestResult {
 }
 
 #[test]
+fn test_migrate_syncs_stale_schema_file_at_current_version() -> TestResult {
+    let temp_dir = init_project()?;
+    let expected_version = current_schema_version(temp_dir.path())?;
+    let schema_path = temp_dir.path().join("gov/schema/work.schema.json");
+    fs::write(&schema_path, "{}\n")?;
+
+    let output = run_commands(temp_dir.path(), &[&["migrate"]])?;
+    assert!(
+        output.contains(&format!(
+            "Synced 1 schema file(s); already at schema version {expected_version}"
+        )),
+        "output: {}",
+        output
+    );
+    assert_eq!(
+        fs::read_to_string(schema_path)?,
+        include_str!("../gov/schema/work.schema.json")
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_migrate_dry_run_reports_would_sync_at_current_version() -> TestResult {
+    let temp_dir = init_project()?;
+    let expected_version = current_schema_version(temp_dir.path())?;
+    let schema_path = temp_dir.path().join("gov/schema/work.schema.json");
+    fs::write(&schema_path, "{}\n")?;
+
+    let output = run_commands(temp_dir.path(), &[&["--dry-run", "migrate"]])?;
+    assert!(
+        output.contains(&format!(
+            "Would sync 1 schema file(s); already at schema version {expected_version}"
+        )),
+        "output: {}",
+        output
+    );
+    assert_eq!(fs::read_to_string(schema_path)?, "{}\n");
+
+    Ok(())
+}
+
+#[test]
+fn test_migrate_syncs_missing_local_state_gitignore_entry_at_current_version() -> TestResult {
+    let temp_dir = init_project()?;
+    let expected_version = current_schema_version(temp_dir.path())?;
+    let gitignore_path = temp_dir.path().join(".gitignore");
+    fs::write(&gitignore_path, ".govctl.lock\n")?;
+
+    let output = run_commands(temp_dir.path(), &[&["migrate"]])?;
+    assert!(
+        output.contains(&format!(
+            "Synced 1 gitignore entry; already at schema version {expected_version}"
+        )),
+        "output: {}",
+        output
+    );
+
+    let gitignore = fs::read_to_string(gitignore_path)?;
+    assert_eq!(
+        gitignore.matches(".govctl.lock").count(),
+        1,
+        "migrate should not duplicate existing lock ignore entry"
+    );
+    assert!(
+        gitignore.lines().any(|line| line.trim() == ".govctl/"),
+        "migrate should add .govctl/ to .gitignore: {}",
+        gitignore
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_migrate_bumps_version_even_without_file_changes() -> TestResult {
     let temp_dir = init_project_v1()?;
+    let expected_version = latest_schema_version()?;
 
     // Create artifacts using govctl (already in new format with headers)
     run_commands(temp_dir.path(), &[&["rfc", "new", "New Format RFC"]])?;
@@ -186,15 +285,15 @@ fn test_migrate_bumps_version_even_without_file_changes() -> TestResult {
 
     let output = run_commands(temp_dir.path(), &[&["migrate"]])?;
     assert!(
-        output.contains("Schema version bumped to 2"),
+        output.contains(&format!("Schema version bumped to {expected_version}")),
         "should bump version even with no file ops: {}",
         output
     );
 
     let config = fs::read_to_string(temp_dir.path().join("gov/config.toml"))?;
     assert!(
-        config.contains("version = 2"),
-        "config should now be version 2: {}",
+        config.contains(&format!("version = {expected_version}")),
+        "config should now be version {expected_version}: {}",
         config
     );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * check now warns when bundled JSON schemas are missing/outdated and when local govctl .gitignore entries for local state are missing; reference-hierarchy validation also flags plain-text artifact-ID mentions in governed RFC/ADR text.
  * migrate always refreshes bundled schemas and ensures local-state .gitignore entries; messages report synced counts.

* **Documentation**
  * Clarified RFC/ADR reference-hierarchy and edit/addressing guidance; CLI help tightened notes/depends_on semantics.

* **Tests**
  * Added integration and unit tests for diagnostics and migration behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->