### PR TITLE
feat(search): add local artifact catalog and search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Release entries are curated summaries for readers. Work item traceability remain
 
 ## [Unreleased]
 
+### Added
+
+- Search output supports table, JSON, and plain formats with stable result fields (WI-2026-06-04-006)
+- Search index sync updates changed artifacts, removes deleted artifacts, and refuses stale results when freshness cannot be established (WI-2026-06-04-006)
+- govctl search provides ranked search across RFCs, clauses, ADRs, work items, and guards (WI-2026-06-04-006)
+
+### Changed
+
+- Single-artifact RFC, ADR, work item, guard, and clause lookup paths use direct path resolution or artifact catalog lookup instead of full collection scans where possible (WI-2026-06-04-005)
+- Stale or missing catalog entries are repaired or bypassed without operating on the wrong artifact (WI-2026-06-04-005)
+
 ## [0.9.1] - 2026-06-04
 
 0.9.1 is a patch release for upgrade safety after 0.9.0. It tightens

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1160,7 @@ dependencies = [
  "rand 0.10.0",
  "ratatui",
  "regex",
+ "rusqlite",
  "self_update",
  "semver",
  "serde",
@@ -1202,6 +1215,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1700,6 +1722,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,6 +2634,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,6 +3067,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3659,6 +3735,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "govctl"
 version = "0.9.1"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.96"
 description = "Project governance CLI for RFC, ADR, and Work Item management"
 license = "MIT"
 repository = "https://github.com/govctl-org/govctl"
@@ -68,6 +68,7 @@ slug = "0.1"
 strum = { version = "0.28", features = ["derive"] }
 winnow = "0.7"
 pulldown-cmark = "0.13"
+rusqlite = { version = "0.40", features = ["bundled"] }
 
 # File system traversal
 walkdir = "2"

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -4,7 +4,7 @@ This guide walks you through installing govctl and creating your first governed 
 
 ## Requirements
 
-- **Rust 1.88+** (per `Cargo.toml` `rust-version`)
+- **Rust 1.96+** (per `Cargo.toml` `rust-version`)
 
 ## Installation
 

--- a/docs/rfc/RFC-0002.md
+++ b/docs/rfc/RFC-0002.md
@@ -1,9 +1,9 @@
 <!-- GENERATED: do not edit. Source: RFC-0002 -->
-<!-- SIGNATURE: sha256:8c6259a92889fd5cb0a87ca5798ca004168631bb63e824eb9c006dc9c90e369a -->
+<!-- SIGNATURE: sha256:f77cd633c97a2b62f7d830fdb04bb0de811727ebe2c3d9abfdc2dd9c4983eed7 -->
 
 # RFC-0002: CLI Resource Model and Command Architecture
 
-> **Version:** 0.9.4 | **Status:** normative | **Phase:** test
+> **Version:** 0.10.1 | **Status:** normative | **Phase:** test
 
 ---
 
@@ -57,7 +57,9 @@ The resource-first structure (noun-first) provides several advantages over verb-
 
 **Exceptions:**
 
-Commands that operate across all resource types (init, check, status, render) remain at the global level as they don't belong to a specific resource namespace.
+Global command exceptions are governed by [RFC-0002:C-GLOBAL-COMMANDS](../rfc/RFC-0002.md#rfc-0002c-global-commands). A command MAY remain at the global namespace when it operates across multiple resource types, performs project-level or CLI-level work, or manages local execution state that coordinates governed resources without becoming a governed artifact resource.
+
+Resource-specific CRUD, field-editing, and lifecycle operations MUST remain resource-first unless an RFC explicitly defines a global command exception.
 
 **Implementation Note:**
 
@@ -571,8 +573,8 @@ Behavior:
 - `list`: displays all registered tags with usage counts (how many artifacts reference each tag).
 
 Artifact-level tagging uses existing resource verbs on taggable types (rfc, clause, adr, work, guard):
-- `govctl {rfc|clause|adr|work|guard} add <ID> tags <tag>` — assign a tag to an artifact
-- `govctl {rfc|clause|adr|work|guard} remove <ID> tags <tag>` — remove a tag from an artifact
+- `govctl {rfc|clause|adr|work|guard} add <ID> tags <tag>` - assign a tag to an artifact
+- `govctl {rfc|clause|adr|work|guard} remove <ID> tags <tag>` - remove a tag from an artifact
 
 **11. `govctl self-update`**
 
@@ -598,6 +600,17 @@ Behavior:
 - MUST keep work item lifecycle transitions routed through `govctl work` semantics
 - MUST use stable subcommand and argument semantics defined by [RFC-0006:C-LOOP-COMMAND-SURFACE](../rfc/RFC-0006.md#rfc-0006c-loop-command-surface)
 
+**13. `govctl search`**
+
+Searches governed artifacts across the project by user-provided query text.
+
+Syntax: `govctl search <query>... [--type <rfc|clause|adr|work|guard>]... [--tag <tag>]... [-n <limit>] [-o <table|json|plain>] [--reindex]`
+
+Behavior:
+- Operates across RFCs, clauses, ADRs, work items, and verification guards according to [RFC-0002:C-SEARCH-COMMAND](../rfc/RFC-0002.md#rfc-0002c-search-command)
+- MUST remain at the global namespace because it is project-level discovery across multiple governed resource types, not a resource-specific CRUD operation
+- MUST NOT be required as a universal resource verb under each artifact namespace unless a future RFC amendment explicitly adds scoped search aliases
+
 **Rationale:**
 
 These commands are global because they:
@@ -618,6 +631,8 @@ These commands are global because they:
 `govctl self-update` qualifies because it provides meta-information about the CLI itself and performs binary lifecycle management (criterion 3).
 
 `govctl loop` qualifies because it manages local execution state that coordinates work items and verification guards without making loop state a governed resource (criterion 5).
+
+`govctl search` qualifies because it performs project-level discovery across multiple governed resource types (criterion 1).
 
 **Future Additions:**
 
@@ -680,9 +695,57 @@ A self-update command provides a single canonical update path that works regardl
 
 *Since: v0.8.0*
 
+### [RFC-0002:C-SEARCH-COMMAND] Search Command (Normative) <a id="rfc-0002c-search-command"></a>
+
+`govctl search` searches governed artifacts by user-provided query text.
+
+Syntax:
+
+- `govctl search <query>... [--type <rfc|clause|adr|work|guard>]... [--tag <tag>]... [-n <limit>] [-o <table|json|plain>] [--reindex]`
+
+Behavior:
+
+- The command MUST operate at the global command namespace as an explicit [RFC-0002:C-RESOURCE-MODEL](../rfc/RFC-0002.md#rfc-0002c-resource-model) exception listed in [RFC-0002:C-GLOBAL-COMMANDS](../rfc/RFC-0002.md#rfc-0002c-global-commands), because it searches across multiple governed resource types and is project-level discovery rather than a resource-specific CRUD operation.
+- The command MUST search RFCs, clauses, ADRs, work items, and verification guards unless one or more `--type` filters are provided.
+- Positional `<query>...` values MUST be interpreted as user search terms by default, not as backend-specific raw query syntax.
+- The command MUST support artifact ID lookup as a search use case. A query containing an existing artifact ID SHOULD rank that artifact ahead of lower-confidence full-text matches.
+- The command MUST support `--tag <tag>` filters. When multiple tags are provided, returned artifacts MUST contain all requested tags.
+- The command MUST support `-n, --limit <limit>` and MUST apply a finite default limit when the flag is omitted.
+- The command MUST support `--reindex`, which forces a rebuild of any local derived search index before returning results.
+- The command MUST NOT modify governed artifact files or rendered documentation.
+- If the implementation persists a search index, it MUST store that index under `.govctl/` local state and MUST NOT store it under `gov/` or the rendered docs directory.
+- A persisted search index is derived local state and MUST NOT be treated as an authoritative artifact source. TOML governance artifacts remain the source of truth.
+- The command MUST establish index freshness before returning indexed results. If freshness cannot be established, the command MUST rebuild the index, perform an uncached authoritative scan, or return a diagnostic. It MUST NOT silently return stale indexed results.
+- Search index synchronization MAY mutate `.govctl/` local state. This local-state mutation MUST NOT require the RFC-0004 gov-root exclusive write lock because it does not mutate governed artifacts or rendered documentation.
+- Output rows MUST include at least artifact kind, artifact ID, title, source path, and a match snippet or equivalent human-readable context.
+- JSON output MUST expose stable result fields including `kind`, `id`, `title`, `path`, and `snippet`. It MAY include ranking score and status metadata.
+- Plain output MUST emit one artifact ID per line in result order.
+
+**Rationale:**
+
+Search is discovery across the governance corpus, not a resource-specific CRUD operation. Keeping indexes under `.govctl/` preserves the boundary between authoritative governed artifacts and disposable local execution or cache state. Requiring freshness before returning results prevents the local index from becoming a misleading second source of truth.
+
+*Since: v0.10.1*
+
 ---
 
 ## Changelog
+
+### v0.10.1 (2026-06-04)
+
+Set search clause version metadata
+
+#### Fixed
+
+- C-SEARCH-COMMAND has derived since version metadata
+
+### v0.10.0 (2026-06-04)
+
+Add search command contract
+
+#### Added
+
+- C-SEARCH-COMMAND clause for govctl search
 
 ### v0.9.4 (2026-06-04)
 

--- a/gov/adr/ADR-0039-use-sqlite-fts5-as-read-only-search-index-for-governance-artifacts.toml
+++ b/gov/adr/ADR-0039-use-sqlite-fts5-as-read-only-search-index-for-governance-artifacts.toml
@@ -3,11 +3,12 @@
 [govctl]
 id = "ADR-0039"
 title = "Use SQLite FTS5 as read-only search index for governance artifacts"
-status = "proposed"
+status = "accepted"
 date = "2026-04-09"
 refs = [
     "RFC-0002",
     "RFC-0004",
+    "ADR-0048",
 ]
 tags = ["cli"]
 
@@ -32,52 +33,51 @@ None of these scale or provide relevance-ranked results.
 - The index must work offline with no external services
 - Rebuild must be fast enough to run transparently on every search query"""
 decision = """
-We will use **SQLite FTS5 with lazy incremental sync** as the search backend for `govctl search`.
+Use SQLite FTS5 with lazy incremental sync as the search backend for `govctl search`, stored as derived local state under `.govctl/index.db`.
 
 ### Design
 
-1. **Index location:** `gov/.search.db` (gitignored, along with WAL sidecars `gov/.search.db-wal` and `gov/.search.db-shm`). Disposable — can be deleted and rebuilt transparently.
+1. **Index location:** `.govctl/index.db`, with SQLite sidecars such as `.govctl/index.db-wal` and `.govctl/index.db-shm` when WAL mode is active. The database is disposable local state and is covered by the existing `.govctl/` gitignore invariant.
 
-2. **Indexed content:** All artifact types (RFCs, clauses, ADRs, work items, guards). Each entry stores the artifact ID, type, title, and a concatenation of all human-readable text fields. Tokenized with Porter stemming for English morphological matching.
+2. **Catalog separation:** The database may contain shared artifact catalog tables for ID-to-path lookup and freshness metadata per [[ADR-0048]]. Those catalog tables are shared lookup infrastructure. Search-specific FTS tables, ranking data, and snippets remain derived search data.
 
-3. **Sync strategy — lazy incremental:**
-   - On every `govctl search`, compare content hashes of `gov/` TOML files against an index-side manifest
-   - New/changed files: parse and upsert into the search index
-   - Deleted files: remove from index
-   - Unchanged files: skip
-   - Missing or corrupt index: full rebuild (no error, just slower first query)
+3. **Indexed content:** RFCs, clauses, ADRs, work items, and guards. Each search document stores artifact ID, type, title, source path, stable status metadata where applicable, tags, refs, and a curated concatenation of searchable content fields. Work item descriptions, acceptance criteria, and notes are searchable; legacy inline journal entries remain render-only compatibility data and are not indexed. Raw TOML is not the search document.
 
-4. **No write-through optimization.** The lazy scan is correct in all cases and fast enough (~10ms at current scale). Adding write-through coupling between the artifact write path and the index is premature complexity.
+4. **Sync strategy — lazy incremental:** On every `govctl search`, compare current artifact path and freshness metadata against the local index manifest. New or changed files are parsed and upserted into the search projection. Deleted files are removed. Missing, corrupt, or incompatible index state is rebuilt.
 
-5. **Concurrency:** SQLite WAL mode handles concurrent search invocations safely. If two `govctl search` calls trigger a sync simultaneously, both will complete without corruption.
+5. **Freshness rule:** `govctl search` must not return results from an index whose freshness cannot be established. If freshness cannot be established, it must rebuild, fall back to an uncached scan where possible, or return a diagnostic instead of silently returning stale results.
 
-6. **Explicit escape hatch:** `govctl search --reindex` forces a full rebuild.
+6. **No write-through optimization:** Artifact write commands do not need to update the search FTS tables directly. Lazy sync remains correct for manual edits, branch switches, and govctl writes.
+
+7. **Concurrency:** SQLite WAL mode and transactions protect the local index from corruption during concurrent search invocations. The search index is not a governed artifact and does not participate in the RFC-0004 gov-root write lock.
+
+8. **Explicit escape hatch:** `govctl search --reindex` forces a full rebuild before querying.
 
 ### Why This Design
 
-- Lazy sync avoids coupling between the write path and the index — files changed by manual editing, VCS operations, or govctl all sync identically
-- A single read-only cache file is simpler than a persistent daemon or event-driven index
-- The index is not covered by [[RFC-0004]] file locking because it is a derived cache, not a governance artifact
-- `govctl init` should add `gov/.search.db*` to `.gitignore` to cover the database and WAL sidecars"""
+- `.govctl/` is the existing local-state boundary for loop execution and other derived state.
+- Keeping the index out of `gov/` avoids treating disposable search data as a governed artifact mutation.
+- Lazy sync avoids coupling between artifact write paths and search indexing.
+- SQLite FTS5 provides BM25 ranking and snippets without a daemon or external service."""
 consequences = """
 ### Positive
 
-- Users can find artifacts by content with relevance ranking — "which ADR discussed caching?" returns ranked results instantly
-- Porter stemming handles morphological variants (cache/caching/cached) without exact-match frustration
-- Index is disposable and self-healing — delete `gov/.search.db` and the next search rebuilds it
-- No daemon, no external service, no network — works fully offline
-- Lazy sync means zero ceremony — no separate index-build step, no cache invalidation protocol
+- Users can find artifacts by content with relevance ranking instead of relying on raw grep, title-only lists, or memorized IDs.
+- The index is disposable and self-healing: deleting `.govctl/index.db` only removes local cache state, and the next search can rebuild it.
+- Lazy sync keeps search correct across manual edits, branch switches, and govctl writes without coupling every artifact mutation to the search backend.
+- Using `.govctl/` keeps derived search data out of governed artifacts and rendered outputs.
+- Shared catalog metadata from [[ADR-0048]] lets search avoid duplicating path and freshness discovery logic.
 
 ### Negative
 
-- Adds `rusqlite` (bundled) as a dependency, increasing binary size by ~3MB (mitigation: feature-gate search behind a default-on cargo feature if binary size becomes a concern)
-- First search after bulk file changes (e.g., `git checkout` switching branches, large merge) will be slower due to lazy-sync catch-up cost (mitigation: rebuild is still sub-second for 1000 artifacts; `--reindex` makes this explicit when needed)
-- CJK text requires additional tokenizer configuration beyond the default Porter stemmer (mitigation: defer to a follow-up if CJK projects adopt govctl)
-- The index file must be gitignored — if a user commits it accidentally, it will cause noisy diffs (mitigation: `govctl init` adds `gov/.search.db` to `.gitignore` by default)
+- Adds `rusqlite` with bundled SQLite, increasing binary size and build complexity.
+- First search after a large branch switch or cache deletion may be slower while the local index rebuilds.
+- CJK text may require tokenizer improvements beyond the default English-oriented stemming setup.
+- Search must guard freshness carefully; returning stale results would be worse than a slower rebuild or diagnostic.
 
 ### Neutral
 
-- The search index introduces a second file format (SQLite) into the `gov/` directory alongside TOML, but it is explicitly non-authoritative and disposable"""
+- The local SQLite database is a cache, not a new artifact storage format. TOML files remain the source of truth."""
 
 [[content.alternatives]]
 text = "SQLite FTS5 with lazy incremental sync: single-file read-only index using rusqlite (bundled), Porter stemming, BM25 ranking, and content-hash-based incremental updates on each search query."

--- a/gov/adr/ADR-0048-use-local-artifact-catalog-for-direct-lookup.toml
+++ b/gov/adr/ADR-0048-use-local-artifact-catalog-for-direct-lookup.toml
@@ -1,0 +1,54 @@
+#:schema ../schema/adr.schema.json
+
+[govctl]
+id = "ADR-0048"
+title = "Use local artifact catalog for direct lookup"
+status = "accepted"
+date = "2026-06-04"
+refs = [
+    "RFC-0002",
+    "RFC-0004",
+    "ADR-0039",
+]
+
+[content]
+context = """
+Many govctl commands that operate on one artifact currently load an entire artifact collection and then search in memory for the requested ID. This is simple and correct at small scale, but it makes common commands such as `work show`, `work edit`, `verify --work`, and loop execution pay full-directory scan and parse costs even when the filesystem layout or a small local index could identify the target path directly.
+
+The search feature planned by [[ADR-0039]] needs similar file freshness metadata. If search owns the only cache, core CLI lookup would become accidentally coupled to full-text search. If every command continues to scan independently, search does not solve the broader performance problem.
+
+The key constraint is authority: governed TOML artifacts remain the source of truth. Any cache used for lookup must be derived local state, and commands must still read and validate the target artifact before acting."""
+decision = """
+Use a project-local derived artifact catalog for direct artifact lookup.
+
+The catalog records artifact kind, ID, source path, and file freshness metadata. It is stored under `.govctl/` as local state and is not a governed artifact. Commands may use the catalog to find a candidate path for an ID, but the catalog never authorizes mutations by itself: the command must read the target file and verify that the artifact's stored ID matches the requested ID before it acts.
+
+The catalog is conceptually separate from full-text search. Search may reuse the catalog's path and freshness metadata, but search ranking, snippets, and FTS tables remain search-specific derived data.
+
+For artifact kinds with deterministic source paths, such as RFCs and clauses, commands should resolve paths directly and avoid the catalog when a simple path check is sufficient. For artifact kinds whose filenames are not fully determined by ID, such as work items and ADRs, commands should use the catalog first and fall back to a bounded collection rescan that repairs stale or missing catalog entries."""
+consequences = """
+### Positive
+
+- Single-artifact commands can avoid full collection scans in the common case.
+- Search can reuse shared freshness metadata without owning core CLI lookup.
+- Stale cache entries are recoverable because authoritative artifact content is still read from TOML.
+- The `.govctl/` local-state boundary keeps derived lookup state out of governed artifacts and rendered output.
+
+### Negative
+
+- Adds a local cache invalidation path that must be tested carefully.
+- Commands that use the catalog must verify ID/path agreement before mutation, or stale entries could become unsafe.
+- The first command after a branch switch or large artifact edit may still need a bounded rescan to repair catalog metadata.
+
+### Neutral
+
+- Full-project commands such as `check`, `status`, and bulk `render` still need broad loading. The catalog optimizes targeted lookup, not semantic validation."""
+
+[[content.alternatives]]
+text = "Derived local artifact catalog: Maintain a .govctl local-state catalog for ID-to-path lookup and freshness metadata, while still validating the target artifact before any read or mutation result is trusted."
+status = "accepted"
+
+[[content.alternatives]]
+text = "Keep full collection scans: Continue loading each whole artifact collection for single-ID commands and rely on search indexing only for search queries."
+status = "rejected"
+rejection_reason = "This preserves correctness but leaves the common single-artifact command path slow and lets search solve only one symptom instead of the shared lookup problem."

--- a/gov/rfc/RFC-0002/clauses/C-GLOBAL-COMMANDS.toml
+++ b/gov/rfc/RFC-0002/clauses/C-GLOBAL-COMMANDS.toml
@@ -171,8 +171,8 @@ Behavior:
 - `list`: displays all registered tags with usage counts (how many artifacts reference each tag).
 
 Artifact-level tagging uses existing resource verbs on taggable types (rfc, clause, adr, work, guard):
-- `govctl {rfc|clause|adr|work|guard} add <ID> tags <tag>` — assign a tag to an artifact
-- `govctl {rfc|clause|adr|work|guard} remove <ID> tags <tag>` — remove a tag from an artifact
+- `govctl {rfc|clause|adr|work|guard} add <ID> tags <tag>` - assign a tag to an artifact
+- `govctl {rfc|clause|adr|work|guard} remove <ID> tags <tag>` - remove a tag from an artifact
 
 **11. `govctl self-update`**
 
@@ -198,6 +198,17 @@ Behavior:
 - MUST keep work item lifecycle transitions routed through `govctl work` semantics
 - MUST use stable subcommand and argument semantics defined by [[RFC-0006:C-LOOP-COMMAND-SURFACE]]
 
+**13. `govctl search`**
+
+Searches governed artifacts across the project by user-provided query text.
+
+Syntax: `govctl search <query>... [--type <rfc|clause|adr|work|guard>]... [--tag <tag>]... [-n <limit>] [-o <table|json|plain>] [--reindex]`
+
+Behavior:
+- Operates across RFCs, clauses, ADRs, work items, and verification guards according to [[RFC-0002:C-SEARCH-COMMAND]]
+- MUST remain at the global namespace because it is project-level discovery across multiple governed resource types, not a resource-specific CRUD operation
+- MUST NOT be required as a universal resource verb under each artifact namespace unless a future RFC amendment explicitly adds scoped search aliases
+
 **Rationale:**
 
 These commands are global because they:
@@ -218,6 +229,8 @@ These commands are global because they:
 `govctl self-update` qualifies because it provides meta-information about the CLI itself and performs binary lifecycle management (criterion 3).
 
 `govctl loop` qualifies because it manages local execution state that coordinates work items and verification guards without making loop state a governed resource (criterion 5).
+
+`govctl search` qualifies because it performs project-level discovery across multiple governed resource types (criterion 1).
 
 **Future Additions:**
 

--- a/gov/rfc/RFC-0002/clauses/C-RESOURCE-MODEL.toml
+++ b/gov/rfc/RFC-0002/clauses/C-RESOURCE-MODEL.toml
@@ -34,7 +34,9 @@ The resource-first structure (noun-first) provides several advantages over verb-
 
 **Exceptions:**
 
-Commands that operate across all resource types (init, check, status, render) remain at the global level as they don't belong to a specific resource namespace.
+Global command exceptions are governed by [[RFC-0002:C-GLOBAL-COMMANDS]]. A command MAY remain at the global namespace when it operates across multiple resource types, performs project-level or CLI-level work, or manages local execution state that coordinates governed resources without becoming a governed artifact resource.
+
+Resource-specific CRUD, field-editing, and lifecycle operations MUST remain resource-first unless an RFC explicitly defines a global command exception.
 
 **Implementation Note:**
 

--- a/gov/rfc/RFC-0002/clauses/C-SEARCH-COMMAND.toml
+++ b/gov/rfc/RFC-0002/clauses/C-SEARCH-COMMAND.toml
@@ -1,0 +1,38 @@
+#:schema ../../../schema/clause.schema.json
+
+[govctl]
+id = "C-SEARCH-COMMAND"
+title = "Search Command"
+kind = "normative"
+status = "active"
+since = "0.10.1"
+
+[content]
+text = """
+`govctl search` searches governed artifacts by user-provided query text.
+
+Syntax:
+
+- `govctl search <query>... [--type <rfc|clause|adr|work|guard>]... [--tag <tag>]... [-n <limit>] [-o <table|json|plain>] [--reindex]`
+
+Behavior:
+
+- The command MUST operate at the global command namespace as an explicit [[RFC-0002:C-RESOURCE-MODEL]] exception listed in [[RFC-0002:C-GLOBAL-COMMANDS]], because it searches across multiple governed resource types and is project-level discovery rather than a resource-specific CRUD operation.
+- The command MUST search RFCs, clauses, ADRs, work items, and verification guards unless one or more `--type` filters are provided.
+- Positional `<query>...` values MUST be interpreted as user search terms by default, not as backend-specific raw query syntax.
+- The command MUST support artifact ID lookup as a search use case. A query containing an existing artifact ID SHOULD rank that artifact ahead of lower-confidence full-text matches.
+- The command MUST support `--tag <tag>` filters. When multiple tags are provided, returned artifacts MUST contain all requested tags.
+- The command MUST support `-n, --limit <limit>` and MUST apply a finite default limit when the flag is omitted.
+- The command MUST support `--reindex`, which forces a rebuild of any local derived search index before returning results.
+- The command MUST NOT modify governed artifact files or rendered documentation.
+- If the implementation persists a search index, it MUST store that index under `.govctl/` local state and MUST NOT store it under `gov/` or the rendered docs directory.
+- A persisted search index is derived local state and MUST NOT be treated as an authoritative artifact source. TOML governance artifacts remain the source of truth.
+- The command MUST establish index freshness before returning indexed results. If freshness cannot be established, the command MUST rebuild the index, perform an uncached authoritative scan, or return a diagnostic. It MUST NOT silently return stale indexed results.
+- Search index synchronization MAY mutate `.govctl/` local state. This local-state mutation MUST NOT require the RFC-0004 gov-root exclusive write lock because it does not mutate governed artifacts or rendered documentation.
+- Output rows MUST include at least artifact kind, artifact ID, title, source path, and a match snippet or equivalent human-readable context.
+- JSON output MUST expose stable result fields including `kind`, `id`, `title`, `path`, and `snippet`. It MAY include ranking score and status metadata.
+- Plain output MUST emit one artifact ID per line in result order.
+
+**Rationale:**
+
+Search is discovery across the governance corpus, not a resource-specific CRUD operation. Keeping indexes under `.govctl/` preserves the boundary between authoritative governed artifacts and disposable local execution or cache state. Requiring freshness before returning results prevents the local index from becoming a misleading second source of truth."""

--- a/gov/rfc/RFC-0002/rfc.toml
+++ b/gov/rfc/RFC-0002/rfc.toml
@@ -3,7 +3,7 @@
 [govctl]
 id = "RFC-0002"
 title = "CLI Resource Model and Command Architecture"
-version = "0.9.4"
+version = "0.10.1"
 status = "normative"
 phase = "test"
 owners = ["@govctl-org"]
@@ -16,7 +16,7 @@ tags = [
     "validation",
     "release",
 ]
-signature = "8c6259a92889fd5cb0a87ca5798ca004168631bb63e824eb9c006dc9c90e369a"
+signature = "681093335724498e211e93fb519c9e16f9990da7986a2f50db914b9e60e88339"
 
 [[sections]]
 title = "Summary"
@@ -33,7 +33,20 @@ clauses = [
     "clauses/C-GLOBAL-COMMANDS.toml",
     "clauses/C-VERIFY-CONFIG.toml",
     "clauses/C-SELF-UPDATE.toml",
+    "clauses/C-SEARCH-COMMAND.toml",
 ]
+
+[[changelog]]
+version = "0.10.1"
+date = "2026-06-04"
+notes = "Set search clause version metadata"
+fixed = ["C-SEARCH-COMMAND has derived since version metadata"]
+
+[[changelog]]
+version = "0.10.0"
+date = "2026-06-04"
+notes = "Add search command contract"
+added = ["C-SEARCH-COMMAND clause for govctl search"]
 
 [[changelog]]
 version = "0.9.4"

--- a/gov/work/2026-06-04-add-governance-artifact-search.toml
+++ b/gov/work/2026-06-04-add-governance-artifact-search.toml
@@ -1,0 +1,38 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-06-04-006"
+title = "Add governance artifact search"
+status = "done"
+created = "2026-06-04"
+started = "2026-06-04"
+completed = "2026-06-04"
+refs = [
+    "RFC-0002",
+    "ADR-0039",
+    "ADR-0048",
+]
+depends_on = ["WI-2026-06-04-005"]
+
+[content]
+description = "Add a global govctl search command for ranked discovery across RFCs, clauses, ADRs, work items, and guards. Search should use the local artifact catalog metadata for freshness checks, store its derived full-text index under .govctl local state, and never return results from an index whose freshness cannot be established."
+
+[[content.acceptance_criteria]]
+text = "Search output supports table, JSON, and plain formats with stable result fields"
+status = "done"
+category = "added"
+
+[[content.acceptance_criteria]]
+text = "govctl check passes"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "Search index sync updates changed artifacts, removes deleted artifacts, and refuses stale results when freshness cannot be established"
+status = "done"
+category = "added"
+
+[[content.acceptance_criteria]]
+text = "govctl search provides ranked search across RFCs, clauses, ADRs, work items, and guards"
+status = "done"
+category = "added"

--- a/gov/work/2026-06-04-add-local-artifact-catalog-for-direct-lookup.toml
+++ b/gov/work/2026-06-04-add-local-artifact-catalog-for-direct-lookup.toml
@@ -1,0 +1,31 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-06-04-005"
+title = "Add local artifact catalog for direct lookup"
+status = "done"
+created = "2026-06-04"
+started = "2026-06-04"
+completed = "2026-06-04"
+refs = [
+    "ADR-0048",
+    "RFC-0004",
+]
+
+[content]
+description = "Add a project-local artifact locator/catalog so single-artifact commands can resolve IDs to paths without loading every artifact in the same collection. The catalog must remain a derived local cache: commands still read and validate the target artifact before acting, and stale catalog entries must trigger repair or fallback rather than becoming authority."
+
+[[content.acceptance_criteria]]
+text = "govctl check passes"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "Single-artifact RFC, ADR, work item, guard, and clause lookup paths use direct path resolution or artifact catalog lookup instead of full collection scans where possible"
+status = "done"
+category = "changed"
+
+[[content.acceptance_criteria]]
+text = "Stale or missing catalog entries are repaired or bypassed without operating on the wrong artifact"
+status = "done"
+category = "changed"

--- a/gov/work/2026-06-05-improve-search-and-catalog-patch-coverage.toml
+++ b/gov/work/2026-06-05-improve-search-and-catalog-patch-coverage.toml
@@ -1,0 +1,27 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-06-05-001"
+title = "Improve search and catalog patch coverage"
+status = "done"
+created = "2026-06-05"
+started = "2026-06-05"
+completed = "2026-06-05"
+
+[content]
+description = "Improve meaningful regression coverage for the newly added artifact catalog and search implementation so Codecov patch coverage reflects real tested behavior rather than uncovered edge branches."
+
+[[content.acceptance_criteria]]
+text = "govctl check passes"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "Targeted search and catalog tests pass"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "Local coverage report identifies and exercises meaningful uncovered search and catalog branches"
+status = "done"
+category = "chore"

--- a/src/artifact_catalog.rs
+++ b/src/artifact_catalog.rs
@@ -1,0 +1,965 @@
+use crate::config::Config;
+use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticResult};
+use crate::model::{AdrEntry, GuardEntry, WorkItemEntry};
+use crate::parse::{load_adr, load_adrs, load_guard, load_guards, load_work_item, load_work_items};
+use rusqlite::{Connection, OptionalExtension, params};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+const CATALOG_SCHEMA_VERSION: i64 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum CatalogKind {
+    Rfc,
+    Clause,
+    Adr,
+    Work,
+    Guard,
+}
+
+impl CatalogKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Rfc => "rfc",
+            Self::Clause => "clause",
+            Self::Adr => "adr",
+            Self::Work => "work",
+            Self::Guard => "guard",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "rfc" => Some(Self::Rfc),
+            "clause" => Some(Self::Clause),
+            "adr" => Some(Self::Adr),
+            "work" => Some(Self::Work),
+            "guard" => Some(Self::Guard),
+            _ => None,
+        }
+    }
+
+    fn dir(self, config: &Config) -> PathBuf {
+        match self {
+            Self::Rfc | Self::Clause => config.rfc_dir(),
+            Self::Adr => config.adr_dir(),
+            Self::Work => config.work_dir(),
+            Self::Guard => config.guard_dir(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogRecord {
+    pub(crate) kind: CatalogKind,
+    pub(crate) id: String,
+    pub(crate) path: String,
+    pub(crate) mtime_ns: i64,
+    pub(crate) size: i64,
+    pub(crate) source_hash: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MissingArtifact {
+    code: DiagnosticCode,
+    label: &'static str,
+}
+
+impl CatalogRecord {
+    pub(crate) fn absolute_path(&self, config: &Config) -> PathBuf {
+        project_root(config).join(&self.path)
+    }
+}
+
+pub(crate) fn load_adr_by_id(config: &Config, id: &str) -> DiagnosticResult<AdrEntry> {
+    load_cataloged_entry(
+        config,
+        CatalogKind::Adr,
+        id,
+        load_adr,
+        load_adrs,
+        |entry| &entry.spec.govctl.id,
+        MissingArtifact {
+            code: DiagnosticCode::E0302AdrNotFound,
+            label: "ADR",
+        },
+    )
+}
+
+pub(crate) fn load_work_item_by_id(config: &Config, id: &str) -> DiagnosticResult<WorkItemEntry> {
+    load_cataloged_entry(
+        config,
+        CatalogKind::Work,
+        id,
+        load_work_item,
+        load_work_items,
+        |entry| &entry.spec.govctl.id,
+        MissingArtifact {
+            code: DiagnosticCode::E0402WorkNotFound,
+            label: "Work item",
+        },
+    )
+}
+
+pub(crate) fn load_guard_by_id(config: &Config, id: &str) -> DiagnosticResult<GuardEntry> {
+    load_cataloged_entry(
+        config,
+        CatalogKind::Guard,
+        id,
+        load_guard,
+        load_guards,
+        |entry| &entry.spec.govctl.id,
+        MissingArtifact {
+            code: DiagnosticCode::E1002GuardNotFound,
+            label: "Guard",
+        },
+    )
+}
+
+fn load_cataloged_entry<T>(
+    config: &Config,
+    kind: CatalogKind,
+    id: &str,
+    load_one: fn(&Config, &Path) -> DiagnosticResult<T>,
+    load_all: fn(&Config) -> DiagnosticResult<Vec<T>>,
+    entry_id: impl Fn(&T) -> &String,
+    missing: MissingArtifact,
+) -> DiagnosticResult<T> {
+    if let Some(entry) = load_from_catalog(config, kind, id, load_one, &entry_id) {
+        return Ok(entry);
+    }
+
+    let entries = load_all(config)?;
+    let found = entries.into_iter().find(|entry| entry_id(entry) == id);
+    let Some(entry) = found else {
+        let location = config.display_path(&kind.dir(config)).display().to_string();
+        return Err(Diagnostic::new(
+            missing.code,
+            format!("{} not found: {id}", missing.label),
+            location,
+        ));
+    };
+
+    // [[RFC-0002:C-SEARCH-COMMAND]]: TOML artifacts are authoritative; refresh
+    // the derived `.govctl/index.db` catalog opportunistically after fallback.
+    let _ = refresh_kind(config, kind);
+    Ok(entry)
+}
+
+fn load_from_catalog<T>(
+    config: &Config,
+    kind: CatalogKind,
+    id: &str,
+    load_one: fn(&Config, &Path) -> DiagnosticResult<T>,
+    entry_id: &impl Fn(&T) -> &String,
+) -> Option<T> {
+    // [[RFC-0002:C-SEARCH-COMMAND]]: cached_path reads the derived local
+    // `.govctl/index.db` catalog, never an authoritative artifact source.
+    let path = cached_path(config, kind, id)?;
+    let entry = load_one(config, &path).ok()?;
+    // [[RFC-0002:C-RESOURCES]]: stable resource IDs are authoritative; reject a
+    // cached path whose loaded TOML entry carries a different ID.
+    if entry_id(&entry) == id {
+        return Some(entry);
+    }
+
+    // [[RFC-0002:C-SEARCH-COMMAND]]: repair stale derived catalog state from
+    // authoritative TOML artifacts before retrying cached_path.
+    let _ = refresh_kind(config, kind);
+    // [[RFC-0002:C-SEARCH-COMMAND]]: retry against the refreshed
+    // `.govctl/index.db` catalog after the repair pass.
+    let path = cached_path(config, kind, id)?;
+    let entry = load_one(config, &path).ok()?;
+    // [[RFC-0002:C-RESOURCES]]: the repaired cached path is accepted only when
+    // the loaded TOML entry ID matches the requested resource ID.
+    (entry_id(&entry) == id).then_some(entry)
+}
+
+fn cached_path(config: &Config, kind: CatalogKind, id: &str) -> Option<PathBuf> {
+    try_cached_path(config, kind, id).ok().flatten()
+}
+
+fn try_cached_path(
+    config: &Config,
+    kind: CatalogKind,
+    id: &str,
+) -> DiagnosticResult<Option<PathBuf>> {
+    let connection = open_catalog(config)?;
+    if let Some(path) = lookup_path(config, &connection, kind, id)?
+        && path.exists()
+    {
+        return Ok(Some(path));
+    }
+
+    refresh_kind_with_connection(config, &connection, kind)?;
+    lookup_path(config, &connection, kind, id)
+}
+
+pub(crate) fn refresh_kind(config: &Config, kind: CatalogKind) -> DiagnosticResult<()> {
+    let connection = open_catalog(config)?;
+    refresh_kind_with_connection(config, &connection, kind)
+}
+
+pub(crate) fn list_records(
+    config: &Config,
+    kinds: &[CatalogKind],
+) -> DiagnosticResult<Vec<CatalogRecord>> {
+    let connection = open_catalog(config)?;
+    let mut records = Vec::new();
+
+    for kind in kinds {
+        let requested_kind = *kind;
+        let mut statement = connection
+            .prepare(
+                "
+                SELECT kind, id, path, mtime_ns, size, source_hash
+                FROM artifact_catalog
+                WHERE kind = ?1
+                ORDER BY id
+                ",
+            )
+            .map_err(|err| {
+                sqlite_diagnostic(
+                    "prepare local artifact catalog listing",
+                    err,
+                    &index_db_path(config),
+                )
+            })?;
+        let rows = statement
+            .query_map(params![kind.as_str()], |row| {
+                let kind_value: String = row.get(0)?;
+                Ok(CatalogRecord {
+                    kind: CatalogKind::from_str(&kind_value).unwrap_or(requested_kind),
+                    id: row.get(1)?,
+                    path: row.get(2)?,
+                    mtime_ns: row.get(3)?,
+                    size: row.get(4)?,
+                    source_hash: row.get(5)?,
+                })
+            })
+            .map_err(|err| {
+                sqlite_diagnostic(
+                    "read local artifact catalog listing",
+                    err,
+                    &index_db_path(config),
+                )
+            })?;
+
+        for row in rows {
+            records.push(row.map_err(|err| {
+                sqlite_diagnostic(
+                    "decode local artifact catalog listing",
+                    err,
+                    &index_db_path(config),
+                )
+            })?);
+        }
+    }
+
+    Ok(records)
+}
+
+fn open_catalog(config: &Config) -> DiagnosticResult<Connection> {
+    let path = index_db_path(config);
+    let parent = path.parent().ok_or_else(|| {
+        Diagnostic::new(
+            DiagnosticCode::E0901IoError,
+            "Local index database path has no parent directory",
+            path.display().to_string(),
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(|err| {
+        Diagnostic::io_error(
+            "create local index directory",
+            err,
+            parent.display().to_string(),
+        )
+    })?;
+    let connection = Connection::open(&path)
+        .map_err(|err| sqlite_diagnostic("open local artifact catalog", err, &path))?;
+    initialize_schema(&connection, &path)?;
+    Ok(connection)
+}
+
+fn initialize_schema(connection: &Connection, path: &Path) -> DiagnosticResult<()> {
+    connection
+        .execute_batch(
+            "
+            PRAGMA journal_mode = WAL;
+            CREATE TABLE IF NOT EXISTS catalog_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS artifact_catalog (
+                kind TEXT NOT NULL,
+                id TEXT NOT NULL,
+                path TEXT NOT NULL,
+                mtime_ns INTEGER NOT NULL,
+                size INTEGER NOT NULL,
+                source_hash TEXT NOT NULL,
+                PRIMARY KEY (kind, id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_artifact_catalog_path
+                ON artifact_catalog(path);
+            ",
+        )
+        .map_err(|err| sqlite_diagnostic("initialize local artifact catalog", err, path))?;
+
+    let version: Option<i64> = connection
+        .query_row(
+            "SELECT value FROM catalog_meta WHERE key = 'catalog_schema_version'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|err| sqlite_diagnostic("read local artifact catalog version", err, path))?
+        .and_then(|value| value.parse::<i64>().ok());
+
+    if version != Some(CATALOG_SCHEMA_VERSION) {
+        connection
+            .execute_batch(
+                "
+                DELETE FROM artifact_catalog;
+                DELETE FROM catalog_meta WHERE key = 'catalog_schema_version';
+                ",
+            )
+            .map_err(|err| sqlite_diagnostic("reset local artifact catalog", err, path))?;
+    }
+
+    connection
+        .execute(
+            "INSERT OR REPLACE INTO catalog_meta(key, value) VALUES('catalog_schema_version', ?1)",
+            params![CATALOG_SCHEMA_VERSION.to_string()],
+        )
+        .map_err(|err| sqlite_diagnostic("write local artifact catalog version", err, path))?;
+    Ok(())
+}
+
+fn refresh_kind_with_connection(
+    config: &Config,
+    connection: &Connection,
+    kind: CatalogKind,
+) -> DiagnosticResult<()> {
+    let entries = scan_kind(config, kind)?;
+    let transaction = connection.unchecked_transaction().map_err(|err| {
+        sqlite_diagnostic(
+            "begin local artifact catalog refresh",
+            err,
+            &index_db_path(config),
+        )
+    })?;
+    transaction
+        .execute(
+            "DELETE FROM artifact_catalog WHERE kind = ?1",
+            params![kind.as_str()],
+        )
+        .map_err(|err| {
+            sqlite_diagnostic(
+                "clear local artifact catalog entries",
+                err,
+                &index_db_path(config),
+            )
+        })?;
+
+    for entry in entries {
+        transaction
+            .execute(
+                "
+                INSERT OR REPLACE INTO artifact_catalog
+                    (kind, id, path, mtime_ns, size, source_hash)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                ",
+                params![
+                    kind.as_str(),
+                    entry.id,
+                    entry.path,
+                    entry.mtime_ns,
+                    entry.size,
+                    entry.source_hash
+                ],
+            )
+            .map_err(|err| {
+                sqlite_diagnostic(
+                    "write local artifact catalog entry",
+                    err,
+                    &index_db_path(config),
+                )
+            })?;
+    }
+
+    transaction.commit().map_err(|err| {
+        sqlite_diagnostic(
+            "commit local artifact catalog refresh",
+            err,
+            &index_db_path(config),
+        )
+    })?;
+    Ok(())
+}
+
+fn lookup_path(
+    config: &Config,
+    connection: &Connection,
+    kind: CatalogKind,
+    id: &str,
+) -> DiagnosticResult<Option<PathBuf>> {
+    let path: Option<String> = connection
+        .query_row(
+            "SELECT path FROM artifact_catalog WHERE kind = ?1 AND id = ?2",
+            params![kind.as_str(), id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|err| {
+            sqlite_diagnostic(
+                "read local artifact catalog entry",
+                err,
+                &index_db_path(config),
+            )
+        })?;
+    Ok(path.map(|path| project_root(config).join(path)))
+}
+
+#[derive(Debug)]
+struct CatalogEntry {
+    id: String,
+    path: String,
+    mtime_ns: i64,
+    size: i64,
+    source_hash: String,
+}
+
+fn scan_kind(config: &Config, kind: CatalogKind) -> DiagnosticResult<Vec<CatalogEntry>> {
+    match kind {
+        CatalogKind::Rfc => return scan_rfc_kind(config),
+        CatalogKind::Clause => return scan_clause_kind(config),
+        CatalogKind::Adr | CatalogKind::Work | CatalogKind::Guard => {}
+    }
+
+    let dir = kind.dir(config);
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let entries = fs::read_dir(&dir).map_err(|err| {
+        Diagnostic::io_error("read artifact directory", err, dir.display().to_string())
+    })?;
+    let mut catalog_entries = Vec::new();
+
+    for entry in entries {
+        let entry = entry.map_err(|err| {
+            Diagnostic::io_error(
+                "read artifact directory entry",
+                err,
+                dir.display().to_string(),
+            )
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("toml") {
+            continue;
+        }
+        if let Some(catalog_entry) = read_catalog_entry(config, &path)? {
+            catalog_entries.push(catalog_entry);
+        }
+    }
+
+    catalog_entries.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(catalog_entries)
+}
+
+fn scan_rfc_kind(config: &Config) -> DiagnosticResult<Vec<CatalogEntry>> {
+    let dir = config.rfc_dir();
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let mut catalog_entries = Vec::new();
+    let entries = fs::read_dir(&dir).map_err(|err| {
+        Diagnostic::io_error("read RFC directory", err, dir.display().to_string())
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|err| {
+            Diagnostic::io_error("read RFC directory entry", err, dir.display().to_string())
+        })?;
+        let path = entry.path().join("rfc.toml");
+        if path.exists()
+            && let Some(catalog_entry) = read_catalog_entry(config, &path)?
+        {
+            catalog_entries.push(catalog_entry);
+        }
+    }
+
+    catalog_entries.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(catalog_entries)
+}
+
+fn scan_clause_kind(config: &Config) -> DiagnosticResult<Vec<CatalogEntry>> {
+    let dir = config.rfc_dir();
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let mut catalog_entries = Vec::new();
+    let rfc_dirs = fs::read_dir(&dir).map_err(|err| {
+        Diagnostic::io_error("read RFC directory", err, dir.display().to_string())
+    })?;
+    for rfc_dir in rfc_dirs {
+        let rfc_dir = rfc_dir.map_err(|err| {
+            Diagnostic::io_error("read RFC directory entry", err, dir.display().to_string())
+        })?;
+        let rfc_path = rfc_dir.path();
+        if !rfc_path.is_dir() {
+            continue;
+        }
+        let Some(rfc_id) = rfc_path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let clauses_dir = rfc_path.join("clauses");
+        if !clauses_dir.exists() {
+            continue;
+        }
+
+        let clauses = fs::read_dir(&clauses_dir).map_err(|err| {
+            Diagnostic::io_error(
+                "read clause directory",
+                err,
+                clauses_dir.display().to_string(),
+            )
+        })?;
+        for clause in clauses {
+            let clause = clause.map_err(|err| {
+                Diagnostic::io_error(
+                    "read clause directory entry",
+                    err,
+                    clauses_dir.display().to_string(),
+                )
+            })?;
+            let path = clause.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("toml") {
+                continue;
+            }
+            if let Some(mut catalog_entry) = read_catalog_entry(config, &path)? {
+                catalog_entry.id = format!("{rfc_id}:{}", catalog_entry.id);
+                catalog_entries.push(catalog_entry);
+            }
+        }
+    }
+
+    catalog_entries.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(catalog_entries)
+}
+
+fn read_catalog_entry(config: &Config, path: &Path) -> DiagnosticResult<Option<CatalogEntry>> {
+    let content = fs::read_to_string(path).map_err(|err| {
+        Diagnostic::io_error("read artifact for catalog", err, path.display().to_string())
+    })?;
+    let raw: toml::Value = match toml::from_str(&content) {
+        Ok(value) => value,
+        Err(_) => return Ok(None),
+    };
+    let Some(id) = raw
+        .get("govctl")
+        .and_then(|govctl| govctl.get("id"))
+        .and_then(toml::Value::as_str)
+    else {
+        return Ok(None);
+    };
+
+    let metadata = fs::metadata(path).map_err(|err| {
+        Diagnostic::io_error("read artifact metadata", err, path.display().to_string())
+    })?;
+    Ok(Some(CatalogEntry {
+        id: id.to_string(),
+        path: config.display_path(path).display().to_string(),
+        mtime_ns: mtime_ns(&metadata),
+        size: i64::try_from(metadata.len()).unwrap_or(i64::MAX),
+        source_hash: sha256_hex(&content),
+    }))
+}
+
+fn mtime_ns(metadata: &fs::Metadata) -> i64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| i64::try_from(duration.as_nanos()).unwrap_or(i64::MAX))
+        .unwrap_or(0)
+}
+
+fn sha256_hex(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+pub(crate) fn index_db_path(config: &Config) -> PathBuf {
+    project_root(config).join(".govctl").join("index.db")
+}
+
+pub(crate) fn project_root(config: &Config) -> &Path {
+    config
+        .gov_root
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn sqlite_diagnostic(action: &'static str, err: rusqlite::Error, path: &Path) -> Diagnostic {
+    Diagnostic::new(
+        DiagnosticCode::E0903UnexpectedError,
+        format!("{action}: {err}"),
+        path.display().to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(root: &Path) -> Config {
+        Config {
+            gov_root: root.join("gov"),
+            ..Config::default()
+        }
+    }
+
+    fn write_work_file(path: &Path, id: &str) -> std::io::Result<()> {
+        fs::write(
+            path,
+            format!(
+                r#"[govctl]
+id = "{id}"
+title = "Test"
+status = "queue"
+created = "2026-06-04"
+
+[content]
+description = "Test"
+"#
+            ),
+        )
+    }
+
+    fn write_adr_file(path: &Path, id: &str) -> std::io::Result<()> {
+        fs::write(
+            path,
+            format!(
+                r#"[govctl]
+id = "{id}"
+title = "Catalog ADR"
+status = "accepted"
+date = "2026-06-04"
+
+[content]
+context = "Catalog context"
+decision = "Catalog decision"
+consequences = "Catalog consequences"
+"#
+            ),
+        )
+    }
+
+    fn write_guard_file(path: &Path, id: &str) -> std::io::Result<()> {
+        fs::write(
+            path,
+            format!(
+                r#"[govctl]
+id = "{id}"
+title = "Catalog Guard"
+
+[check]
+command = "echo catalog"
+"#
+            ),
+        )
+    }
+
+    fn write_rfc_file(path: &Path, id: &str) -> std::io::Result<()> {
+        fs::write(
+            path,
+            format!(
+                r#"[govctl]
+id = "{id}"
+title = "Catalog RFC"
+version = "0.1.0"
+status = "draft"
+phase = "spec"
+owners = ["@test"]
+created = "2026-06-04"
+
+[[sections]]
+title = "Specification"
+clauses = ["clauses/C-CATALOG.toml"]
+"#
+            ),
+        )
+    }
+
+    fn write_clause_file(path: &Path, id: &str) -> std::io::Result<()> {
+        fs::write(
+            path,
+            format!(
+                r#"[govctl]
+id = "{id}"
+title = "Catalog Clause"
+kind = "normative"
+status = "active"
+
+[content]
+text = "Catalog clause"
+"#
+            ),
+        )
+    }
+
+    #[test]
+    fn catalog_kind_helpers_handle_unknown_values_and_rfc_dirs()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let config = test_config(temp.path());
+
+        assert!(CatalogKind::from_str("unknown").is_none());
+        assert_eq!(CatalogKind::Rfc.dir(&config), config.rfc_dir());
+        assert_eq!(CatalogKind::Clause.dir(&config), config.rfc_dir());
+
+        let record = CatalogRecord {
+            kind: CatalogKind::Work,
+            id: "WI-2026-06-04-994".to_string(),
+            path: "gov/work/item.toml".to_string(),
+            mtime_ns: 0,
+            size: 0,
+            source_hash: String::new(),
+        };
+        assert_eq!(
+            record.absolute_path(&config),
+            temp.path().join("gov/work/item.toml")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn scans_return_empty_when_artifact_dirs_are_missing() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp = tempfile::tempdir()?;
+        let config = test_config(temp.path());
+
+        assert!(scan_kind(&config, CatalogKind::Work)?.is_empty());
+        assert!(scan_kind(&config, CatalogKind::Rfc)?.is_empty());
+        assert!(scan_kind(&config, CatalogKind::Clause)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn schema_version_reset_clears_stale_catalog_rows() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let config = test_config(temp.path());
+        let path = index_db_path(&config);
+        let connection = open_catalog(&config)?;
+        connection.execute(
+            "UPDATE catalog_meta SET value = '0' WHERE key = 'catalog_schema_version'",
+            [],
+        )?;
+        connection.execute(
+            "
+            INSERT INTO artifact_catalog(kind, id, path, mtime_ns, size, source_hash)
+            VALUES('work', 'WI-2026-06-04-993', 'gov/work/stale.toml', 0, 0, '')
+            ",
+            [],
+        )?;
+
+        initialize_schema(&connection, &path)?;
+
+        let count: i64 =
+            connection.query_row("SELECT COUNT(*) FROM artifact_catalog", [], |row| {
+                row.get(0)
+            })?;
+        assert_eq!(count, 0);
+
+        connection.execute(
+            "UPDATE catalog_meta SET value = 'not-a-number' WHERE key = 'catalog_schema_version'",
+            [],
+        )?;
+        connection.execute(
+            "
+            INSERT INTO artifact_catalog(kind, id, path, mtime_ns, size, source_hash)
+            VALUES('work', 'WI-2026-06-04-992', 'gov/work/malformed.toml', 0, 0, '')
+            ",
+            [],
+        )?;
+
+        initialize_schema(&connection, &path)?;
+
+        let count: i64 =
+            connection.query_row("SELECT COUNT(*) FROM artifact_catalog", [], |row| {
+                row.get(0)
+            })?;
+        assert_eq!(count, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn read_catalog_entry_reports_missing_file() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let config = test_config(temp.path());
+        let err = match read_catalog_entry(&config, &temp.path().join("missing.toml")) {
+            Ok(_) => return Err(std::io::Error::other("missing file returned Ok").into()),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.code, DiagnosticCode::E0901IoError);
+        Ok(())
+    }
+
+    #[test]
+    fn cached_path_repairs_missing_entry_path() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let config = test_config(temp.path());
+        let work_dir = config.work_dir();
+        fs::create_dir_all(&work_dir)?;
+        let first_path = work_dir.join("first.toml");
+        let second_path = work_dir.join("second.toml");
+        write_work_file(&first_path, "WI-2026-06-04-999")?;
+
+        refresh_kind(&config, CatalogKind::Work)?;
+        assert_eq!(
+            cached_path(&config, CatalogKind::Work, "WI-2026-06-04-999"),
+            Some(first_path.clone())
+        );
+
+        fs::remove_file(first_path)?;
+        write_work_file(&second_path, "WI-2026-06-04-999")?;
+
+        assert_eq!(
+            cached_path(&config, CatalogKind::Work, "WI-2026-06-04-999"),
+            Some(second_path)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn loaders_repair_cached_path_with_mismatched_id() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let config = test_config(temp.path());
+        let work_dir = config.work_dir();
+        fs::create_dir_all(&work_dir)?;
+        let stale_path = work_dir.join("stale.toml");
+        let repaired_path = work_dir.join("repaired.toml");
+        write_work_file(&stale_path, "WI-2026-06-04-997")?;
+
+        refresh_kind(&config, CatalogKind::Work)?;
+        write_work_file(&stale_path, "WI-2026-06-04-996")?;
+        write_work_file(&repaired_path, "WI-2026-06-04-997")?;
+
+        let item = load_work_item_by_id(&config, "WI-2026-06-04-997")?;
+        assert_eq!(item.path, repaired_path);
+        Ok(())
+    }
+
+    #[test]
+    fn loader_reports_missing_artifact() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let config = test_config(temp.path());
+        fs::create_dir_all(config.work_dir())?;
+
+        let err = match load_work_item_by_id(&config, "WI-2026-06-04-000") {
+            Ok(_) => return Err(std::io::Error::other("missing work item returned Ok").into()),
+            Err(err) => err,
+        };
+        assert_eq!(err.code, DiagnosticCode::E0402WorkNotFound);
+        assert!(err.message.contains("Work item not found"));
+        Ok(())
+    }
+
+    #[test]
+    fn refresh_indexes_all_artifact_kinds_and_skips_noise() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp = tempfile::tempdir()?;
+        let config = test_config(temp.path());
+        fs::create_dir_all(config.work_dir())?;
+        fs::create_dir_all(config.adr_dir())?;
+        fs::create_dir_all(config.guard_dir())?;
+        fs::create_dir_all(config.rfc_dir().join("RFC-0009/clauses"))?;
+
+        write_work_file(
+            &config.work_dir().join("catalog-work.toml"),
+            "WI-2026-06-04-995",
+        )?;
+        write_adr_file(&config.adr_dir().join("ADR-0099-catalog.toml"), "ADR-0099")?;
+        write_guard_file(
+            &config.guard_dir().join("guard-catalog.toml"),
+            "GUARD-CATALOG",
+        )?;
+        write_rfc_file(&config.rfc_dir().join("RFC-0009/rfc.toml"), "RFC-0009")?;
+        write_clause_file(
+            &config.rfc_dir().join("RFC-0009/clauses/C-CATALOG.toml"),
+            "C-CATALOG",
+        )?;
+        fs::write(config.work_dir().join("README.md"), "not an artifact")?;
+        fs::write(config.work_dir().join("invalid.toml"), "not = [")?;
+        fs::write(config.work_dir().join("missing-id.toml"), "[content]\n")?;
+
+        for kind in [
+            CatalogKind::Rfc,
+            CatalogKind::Clause,
+            CatalogKind::Adr,
+            CatalogKind::Work,
+            CatalogKind::Guard,
+        ] {
+            refresh_kind(&config, kind)?;
+        }
+
+        let records = list_records(
+            &config,
+            &[
+                CatalogKind::Rfc,
+                CatalogKind::Clause,
+                CatalogKind::Adr,
+                CatalogKind::Work,
+                CatalogKind::Guard,
+            ],
+        )?;
+        let ids = records
+            .iter()
+            .map(|record| record.id.as_str())
+            .collect::<Vec<_>>();
+        assert!(ids.contains(&"RFC-0009"));
+        assert!(ids.contains(&"RFC-0009:C-CATALOG"));
+        assert!(ids.contains(&"ADR-0099"));
+        assert!(ids.contains(&"WI-2026-06-04-995"));
+        assert!(ids.contains(&"GUARD-CATALOG"));
+
+        assert_eq!(
+            load_adr_by_id(&config, "ADR-0099")?.spec.govctl.title,
+            "Catalog ADR"
+        );
+        assert_eq!(
+            load_guard_by_id(&config, "GUARD-CATALOG")?
+                .spec
+                .check
+                .command,
+            "echo catalog"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn refresh_removes_deleted_catalog_entries() -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let config = test_config(temp.path());
+        let work_dir = config.work_dir();
+        fs::create_dir_all(&work_dir)?;
+        let path = work_dir.join("work.toml");
+        write_work_file(&path, "WI-2026-06-04-998")?;
+
+        refresh_kind(&config, CatalogKind::Work)?;
+        assert!(cached_path(&config, CatalogKind::Work, "WI-2026-06-04-998").is_some());
+
+        fs::remove_file(path)?;
+        refresh_kind(&config, CatalogKind::Work)?;
+
+        assert!(cached_path(&config, CatalogKind::Work, "WI-2026-06-04-998").is_none());
+        Ok(())
+    }
+}

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,7 +1,7 @@
 use super::help;
 use super::{
-    AdrCommand, ClauseCommand, GuardCommand, LoopCommand, RenderTarget, RfcCommand, SkillFormat,
-    TagCommand, WorkCommand,
+    AdrCommand, ClauseCommand, GuardCommand, ListTarget, LoopCommand, OutputFormat, RenderTarget,
+    RfcCommand, SkillFormat, TagCommand, WorkCommand,
 };
 use clap::Subcommand;
 use std::path::PathBuf;
@@ -81,6 +81,51 @@ pub(crate) enum Commands {
         /// Run the effective guard set for a specific work item
         #[arg(long, conflicts_with = "guard_ids")]
         work: Option<String>,
+    },
+
+    /// Search governed artifacts.
+    ///
+    /// Traceability: global search is an explicit namespace exception in
+    /// [[RFC-0002:C-GLOBAL-COMMANDS]] and is specified by
+    /// [[RFC-0002:C-SEARCH-COMMAND]].
+    #[command(after_help = help::SEARCH)]
+    Search {
+        /// Query terms to search for.
+        ///
+        /// [[RFC-0002:C-SEARCH-COMMAND]]: `<query>...` is required and is
+        /// interpreted as user search terms, not backend raw query syntax.
+        #[arg(value_name = "QUERY", required = true)]
+        query: Vec<String>,
+        /// Restrict results to artifact kind (repeatable).
+        ///
+        /// [[RFC-0002:C-SEARCH-COMMAND]]: searches all supported artifact
+        /// kinds unless one or more `--type` filters are provided.
+        #[arg(long = "type", value_enum)]
+        types: Vec<ListTarget>,
+        /// Filter by tag (repeatable; artifact must have ALL specified tags).
+        ///
+        /// [[RFC-0002:C-SEARCH-COMMAND]]: multiple `--tag` values use ALL-tag
+        /// semantics; results must contain every requested tag.
+        #[arg(long)]
+        tag: Vec<String>,
+        /// Limit number of results.
+        ///
+        /// [[RFC-0002:C-SEARCH-COMMAND]]: `--limit` is supported and omission
+        /// applies a finite default limit.
+        #[arg(short = 'n', long)]
+        limit: Option<usize>,
+        /// Output format.
+        ///
+        /// [[RFC-0002:C-SEARCH-COMMAND]]: supports table, JSON, and plain
+        /// result contracts, with table as the CLI default.
+        #[arg(short = 'o', long, value_enum, default_value = "table")]
+        output: OutputFormat,
+        /// Force a full rebuild of the local search index before querying.
+        ///
+        /// [[RFC-0002:C-SEARCH-COMMAND]]: `--reindex` rebuilds the local
+        /// derived search index before returning results.
+        #[arg(long)]
+        reindex: bool,
     },
 
     /// Loop execution-state commands

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -66,6 +66,19 @@ NOTES:
     - `--work` conflicts with explicit guard IDs.
 "#;
 
+pub(super) const SEARCH: &str = r#"EXAMPLES:
+    govctl search caching
+    govctl search "work item" --type work
+    govctl search RFC-0002 -o json
+    govctl search migration --tag cli -n 5
+    govctl search cache --reindex
+
+NOTES:
+    - Searches RFCs, clauses, ADRs, work items, and guards by default.
+    - Use `--type` to limit results to one or more artifact kinds.
+    - Search indexes are derived local state under `.govctl/`.
+"#;
+
 pub(super) const LOOP: &str = r#"COMMON WORKFLOW:
     1. `govctl loop list open` to discover existing non-terminal loops
     2. `govctl loop start WI-2026-04-06-001` to create local loop state

--- a/src/cmd/describe/catalog.rs
+++ b/src/cmd/describe/catalog.rs
@@ -76,6 +76,13 @@ pub(super) fn command_catalog() -> Vec<CommandInfo> {
             INIT_REQUIRED,
         ),
         command(
+            "search",
+            "Search governed artifacts across the project",
+            "To find RFCs, clauses, ADRs, work items, and guards by content or ID.",
+            "govctl search caching --type adr",
+            INIT_REQUIRED,
+        ),
+        command(
             "loop list",
             "List persisted local loop states",
             "To discover interrupted or resumable loops before selecting one by loop ID.",

--- a/src/cmd/edit/toml_adapter.rs
+++ b/src/cmd/edit/toml_adapter.rs
@@ -2,9 +2,7 @@ use super::adapter::{TomlAdapter, display_scope_for_dir};
 use crate::config::Config;
 use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticResult};
 use crate::model::{AdrEntry, GuardEntry, WorkItemEntry};
-use crate::parse::{
-    load_adrs, load_guards, load_work_items, write_adr, write_guard, write_work_item,
-};
+use crate::parse::{load_work_items, write_adr, write_guard, write_work_item};
 use crate::write::WriteOp;
 use std::path::PathBuf;
 
@@ -43,15 +41,7 @@ impl TomlAdapter for AdrTomlAdapter {
     type Entry = AdrEntry;
 
     fn load(config: &Config, id: &str) -> DiagnosticResult<Self::Entry> {
-        load_toml_entry(
-            config,
-            id,
-            config.adr_dir(),
-            load_adrs,
-            |entry, id| entry.spec.govctl.id == id,
-            DiagnosticCode::E0302AdrNotFound,
-            "ADR",
-        )
+        crate::artifact_catalog::load_adr_by_id(config, id)
     }
 
     fn write(config: &Config, entry: &Self::Entry, op: WriteOp) -> DiagnosticResult<()> {
@@ -71,6 +61,14 @@ impl TomlAdapter for WorkTomlAdapter {
     type Entry = WorkItemEntry;
 
     fn load(config: &Config, id: &str) -> DiagnosticResult<Self::Entry> {
+        if id.starts_with("WI-") {
+            match crate::artifact_catalog::load_work_item_by_id(config, id) {
+                Ok(entry) => return Ok(entry),
+                Err(err) if err.code == DiagnosticCode::E0402WorkNotFound => {}
+                Err(err) => return Err(err),
+            }
+        }
+
         load_toml_entry(
             config,
             id,
@@ -99,15 +97,7 @@ impl TomlAdapter for GuardTomlAdapter {
     type Entry = GuardEntry;
 
     fn load(config: &Config, id: &str) -> DiagnosticResult<Self::Entry> {
-        load_toml_entry(
-            config,
-            id,
-            config.guard_dir(),
-            load_guards,
-            |entry, id| entry.spec.govctl.id == id,
-            DiagnosticCode::E1002GuardNotFound,
-            "Guard",
-        )
+        crate::artifact_catalog::load_guard_by_id(config, id)
     }
 
     fn write(config: &Config, entry: &Self::Entry, op: WriteOp) -> DiagnosticResult<()> {

--- a/src/cmd/guard_refs.rs
+++ b/src/cmd/guard_refs.rs
@@ -1,19 +1,10 @@
 use crate::config::Config;
-use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticResult};
+use crate::diagnostic::DiagnosticResult;
 use crate::model::GuardEntry;
-use crate::parse::{load_guards, load_work_items};
+use crate::parse::load_work_items;
 
 pub(crate) fn load_guard_by_id(config: &Config, id: &str) -> DiagnosticResult<GuardEntry> {
-    load_guards(config)?
-        .into_iter()
-        .find(|guard| guard.spec.govctl.id == id)
-        .ok_or_else(|| {
-            Diagnostic::new(
-                DiagnosticCode::E1002GuardNotFound,
-                format!("Guard not found: {id}"),
-                id,
-            )
-        })
+    crate::artifact_catalog::load_guard_by_id(config, id)
 }
 
 pub(crate) fn guard_reference_blockers(

--- a/src/cmd/lifecycle/adr.rs
+++ b/src/cmd/lifecycle/adr.rs
@@ -29,25 +29,21 @@ fn adr_matches_lifecycle_lookup(entry: &AdrEntry, adr_id: &str) -> bool {
 }
 
 fn load_lifecycle_adr(config: &Config, adr_id: &str) -> DiagnosticResult<AdrEntry> {
+    if adr_id.starts_with("ADR-") {
+        // [[RFC-0002:C-LIFECYCLE-VERBS]]: ADR lifecycle verbs operate on
+        // existing ADR IDs; normalize catalog misses to the ADR not-found path.
+        return crate::artifact_catalog::load_adr_by_id(config, adr_id).map_err(|err| {
+            if err.code == DiagnosticCode::E0302AdrNotFound {
+                adr_not_found(adr_id)
+            } else {
+                err
+            }
+        });
+    }
+
     load_adrs(config)?
         .into_iter()
         .find(|entry| adr_matches_lifecycle_lookup(entry, adr_id))
-        .ok_or_else(|| adr_not_found(adr_id))
-}
-
-fn exact_adr<'a>(adrs: &'a [AdrEntry], adr_id: &str) -> Option<&'a AdrEntry> {
-    adrs.iter().find(|entry| entry.spec.govctl.id == adr_id)
-}
-
-fn require_replacement_adr(adrs: &[AdrEntry], by: &str) -> DiagnosticResult<()> {
-    exact_adr(adrs, by)
-        .map(|_| ())
-        .ok_or_else(|| replacement_adr_not_found(by))
-}
-
-fn take_exact_adr(adrs: Vec<AdrEntry>, adr_id: &str) -> DiagnosticResult<AdrEntry> {
-    adrs.into_iter()
-        .find(|entry| entry.spec.govctl.id == adr_id)
         .ok_or_else(|| adr_not_found(adr_id))
 }
 
@@ -151,11 +147,16 @@ pub(super) fn supersede_adr(
     by: &str,
     op: WriteOp,
 ) -> DiagnosticResult<Diagnostics> {
-    let adrs = load_adrs(config)?;
-
-    require_replacement_adr(&adrs, by)?;
-
-    let mut entry = take_exact_adr(adrs, adr_id)?;
+    // [[RFC-0002:C-LIFECYCLE-VERBS]] and [[RFC-0001:C-ADR-STATUS]]: ADR
+    // supersede requires `--by` to identify an existing replacement ADR.
+    match crate::artifact_catalog::load_adr_by_id(config, by) {
+        Ok(_) => {}
+        Err(err) if err.code == DiagnosticCode::E0302AdrNotFound => {
+            return Err(replacement_adr_not_found(by));
+        }
+        Err(err) => return Err(err),
+    }
+    let mut entry = load_lifecycle_adr(config, adr_id)?;
 
     if !is_valid_adr_transition(entry.spec.govctl.status, AdrStatus::Superseded) {
         return Err(Diagnostic::new(

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -16,6 +16,7 @@ pub mod new;
 pub(crate) mod output;
 pub(crate) mod project_support;
 pub mod render;
+pub mod search;
 pub mod self_update;
 pub mod status;
 pub mod tag;

--- a/src/cmd/move_.rs
+++ b/src/cmd/move_.rs
@@ -126,17 +126,14 @@ pub fn move_item(
 
 /// Find work item by partial name or ID
 fn find_work_item_by_name(config: &Config, name: &str) -> DiagnosticResult<std::path::PathBuf> {
-    use crate::parse::load_work_items;
-
-    // First try: load all work items and match by ID
     if name.starts_with("WI-") {
-        let items = load_work_items(config)?;
-        if let Some(item) = items.iter().find(|w| w.spec.govctl.id == name) {
-            return Ok(item.path.clone());
+        match crate::artifact_catalog::load_work_item_by_id(config, name) {
+            Ok(item) => return Ok(item.path),
+            Err(err) if err.code == DiagnosticCode::E0402WorkNotFound => {}
+            Err(err) => return Err(err),
         }
     }
 
-    // Second try: match by filename
     let work_dir = &config.work_dir();
 
     if !work_dir.exists() {

--- a/src/cmd/render/show.rs
+++ b/src/cmd/render/show.rs
@@ -3,8 +3,7 @@ use crate::OutputFormat;
 use crate::cmd::output::print_json;
 use crate::config::Config;
 use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticResult, Diagnostics};
-use crate::load::{load_rfcs, split_clause_id};
-use crate::parse::{load_adrs, load_work_items};
+use crate::load::{find_clause_toml, find_rfc_toml, load_clause, load_rfc, split_clause_id};
 use crate::render::{expand_inline_refs, render_adr, render_clause, render_rfc, render_work_item};
 use crate::terminal_md::render_terminal_md;
 use serde::Serialize;
@@ -34,42 +33,33 @@ where
     Ok(())
 }
 
-fn find_show_item<T, Id, NotFound>(
-    items: Vec<T>,
-    id: &str,
-    item_id: Id,
-    not_found: NotFound,
-) -> DiagnosticResult<T>
-where
-    Id: for<'a> Fn(&'a T) -> &'a str,
-    NotFound: FnOnce() -> Diagnostic,
-{
-    items
-        .into_iter()
-        .find(|item| item_id(item) == id)
-        .ok_or_else(not_found)
-}
-
 /// Show RFC content to stdout (no file written).
 ///
 /// Per [[ADR-0022]], outputs markdown by default or JSON with --output json.
 pub fn show_rfc(config: &Config, id: &str, output: OutputFormat) -> DiagnosticResult<Diagnostics> {
-    let rfcs = load_rfcs(config).map_err(Diagnostic::from)?;
-
-    let rfc = find_show_item(
-        rfcs,
-        id,
-        |rfc| rfc.rfc.rfc_id.as_str(),
-        || {
-            artifact_not_found(
-                config,
-                DiagnosticCode::E0102RfcNotFound,
-                "RFC",
-                id,
-                config.rfc_dir(),
-            )
-        },
-    )?;
+    // [[RFC-0002:C-CRUD-VERBS]]: read-by-ID must error when no RFC exists for
+    // the requested stable resource ID from [[RFC-0002:C-RESOURCES]].
+    let path = find_rfc_toml(config, id).ok_or_else(|| {
+        artifact_not_found(
+            config,
+            DiagnosticCode::E0102RfcNotFound,
+            "RFC",
+            id,
+            config.rfc_dir(),
+        )
+    })?;
+    let rfc = load_rfc(config, &path).map_err(Diagnostic::from)?;
+    // [[RFC-0000:C-RFC-DEF]] makes the TOML `[govctl].id` authoritative; the
+    // resolved path must not satisfy a different requested RFC ID.
+    if rfc.rfc.rfc_id != id {
+        return Err(artifact_not_found(
+            config,
+            DiagnosticCode::E0102RfcNotFound,
+            "RFC",
+            id,
+            config.rfc_dir(),
+        ));
+    }
 
     print_show_output(
         config,
@@ -88,22 +78,7 @@ pub fn show_rfc(config: &Config, id: &str, output: OutputFormat) -> DiagnosticRe
 ///
 /// Per [[ADR-0022]], outputs markdown by default or JSON with --output json.
 pub fn show_adr(config: &Config, id: &str, output: OutputFormat) -> DiagnosticResult<Diagnostics> {
-    let adrs = load_adrs(config)?;
-
-    let adr = find_show_item(
-        adrs,
-        id,
-        |adr| adr.spec.govctl.id.as_str(),
-        || {
-            artifact_not_found(
-                config,
-                DiagnosticCode::E0302AdrNotFound,
-                "ADR",
-                id,
-                config.adr_dir(),
-            )
-        },
-    )?;
+    let adr = crate::artifact_catalog::load_adr_by_id(config, id)?;
 
     print_show_output(
         config,
@@ -122,22 +97,7 @@ pub fn show_adr(config: &Config, id: &str, output: OutputFormat) -> DiagnosticRe
 ///
 /// Per [[ADR-0022]], outputs markdown by default or JSON with --output json.
 pub fn show_work(config: &Config, id: &str, output: OutputFormat) -> DiagnosticResult<Diagnostics> {
-    let items = load_work_items(config)?;
-
-    let item = find_show_item(
-        items,
-        id,
-        |item| item.spec.govctl.id.as_str(),
-        || {
-            artifact_not_found(
-                config,
-                DiagnosticCode::E0402WorkNotFound,
-                "Work item",
-                id,
-                config.work_dir(),
-            )
-        },
-    )?;
+    let item = crate::artifact_catalog::load_work_item_by_id(config, id)?;
 
     print_show_output(
         config,
@@ -168,37 +128,27 @@ pub fn show_clause(
         )
     })?;
 
-    let rfcs = load_rfcs(config).map_err(Diagnostic::from)?;
-
-    let rfc = find_show_item(
-        rfcs,
-        rfc_id,
-        |rfc| rfc.rfc.rfc_id.as_str(),
-        || {
-            artifact_not_found(
-                config,
-                DiagnosticCode::E0102RfcNotFound,
-                "RFC",
-                rfc_id,
-                config.rfc_dir(),
-            )
-        },
-    )?;
-
-    let clause = find_show_item(
-        rfc.clauses,
-        clause_name,
-        |clause| clause.spec.clause_id.as_str(),
-        || {
-            artifact_not_found(
-                config,
-                DiagnosticCode::E0202ClauseNotFound,
-                "Clause",
-                id,
-                config.clause_dir(rfc_id),
-            )
-        },
-    )?;
+    let path = find_clause_toml(config, id).ok_or_else(|| {
+        artifact_not_found(
+            config,
+            DiagnosticCode::E0202ClauseNotFound,
+            "Clause",
+            id,
+            config.clause_dir(rfc_id),
+        )
+    })?;
+    let clause = load_clause(config, &path).map_err(Diagnostic::from)?;
+    // [[RFC-0002:C-RESOURCES]] defines `RFC-NNNN:C-NAME` as self-scoping, and
+    // [[RFC-0000:C-CLAUSE-DEF]] makes the clause TOML ID authoritative.
+    if clause.spec.clause_id != clause_name {
+        return Err(artifact_not_found(
+            config,
+            DiagnosticCode::E0202ClauseNotFound,
+            "Clause",
+            id,
+            config.clause_dir(rfc_id),
+        ));
+    }
 
     print_show_output(
         config,

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -1,0 +1,982 @@
+use crate::artifact_catalog::{self, CatalogKind, CatalogRecord};
+use crate::cmd::output::{command_table, print_json_array};
+use crate::config::Config;
+use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticResult, Diagnostics};
+use crate::load::{load_clause, load_rfc};
+use crate::model::{AdrEntry, ClauseEntry, GuardEntry, RfcIndex, WorkItemEntry};
+use crate::parse::{load_adr, load_guard, load_work_item};
+use crate::{ListTarget, OutputFormat};
+use comfy_table::{Attribute, Cell};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::Serialize;
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::Path;
+
+const SEARCH_SCHEMA_VERSION: i64 = 2;
+const DEFAULT_LIMIT: usize = 20;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SearchResult {
+    pub kind: String,
+    pub id: String,
+    pub title: String,
+    pub path: String,
+    pub snippet: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SearchDocument {
+    kind: CatalogKind,
+    id: String,
+    title: String,
+    path: String,
+    tags: Vec<String>,
+    status: Option<String>,
+    body: String,
+}
+
+#[derive(Debug, Clone)]
+struct SearchRow {
+    result: SearchResult,
+    tags: Vec<String>,
+    score: f64,
+}
+
+pub fn search(
+    config: &Config,
+    query: &[String],
+    type_filters: &[ListTarget],
+    tag_filters: &[String],
+    limit: Option<usize>,
+    output: OutputFormat,
+    reindex: bool,
+) -> DiagnosticResult<Diagnostics> {
+    let terms = query_terms(query)?;
+    let kinds = kinds_for_filters(type_filters);
+    let connection = open_search_index(config)?;
+    sync_search_index(config, &connection, &kinds, reindex)?;
+
+    let results = query_index(
+        config,
+        &connection,
+        &terms,
+        &kinds,
+        tag_filters,
+        limit.unwrap_or(DEFAULT_LIMIT),
+    )?;
+    print_results(&results, output);
+    Ok(vec![])
+}
+
+fn query_terms(query: &[String]) -> DiagnosticResult<Vec<String>> {
+    let terms = query
+        .iter()
+        .flat_map(|arg| arg.split_whitespace())
+        .map(str::trim)
+        .filter(|term| !term.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if terms.is_empty() {
+        return Err(Diagnostic::new(
+            DiagnosticCode::E0801MissingRequiredArg,
+            "search requires at least one query term",
+            "search",
+        ));
+    }
+    Ok(terms)
+}
+
+fn kinds_for_filters(type_filters: &[ListTarget]) -> Vec<CatalogKind> {
+    if type_filters.is_empty() {
+        return vec![
+            CatalogKind::Rfc,
+            CatalogKind::Clause,
+            CatalogKind::Adr,
+            CatalogKind::Work,
+            CatalogKind::Guard,
+        ];
+    }
+
+    let mut kinds = Vec::new();
+    for filter in type_filters {
+        let kind = match filter {
+            ListTarget::Rfc => CatalogKind::Rfc,
+            ListTarget::Clause => CatalogKind::Clause,
+            ListTarget::Adr => CatalogKind::Adr,
+            ListTarget::Work => CatalogKind::Work,
+            ListTarget::Guard => CatalogKind::Guard,
+        };
+        if !kinds.contains(&kind) {
+            kinds.push(kind);
+        }
+    }
+    kinds
+}
+
+fn open_search_index(config: &Config) -> DiagnosticResult<Connection> {
+    let path = artifact_catalog::index_db_path(config);
+    let parent = path.parent().ok_or_else(|| {
+        Diagnostic::new(
+            DiagnosticCode::E0901IoError,
+            "Local index database path has no parent directory",
+            path.display().to_string(),
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(|err| {
+        Diagnostic::io_error(
+            "create local index directory",
+            err,
+            parent.display().to_string(),
+        )
+    })?;
+    let connection = Connection::open(&path)
+        .map_err(|err| sqlite_diagnostic("open search index", err, &path))?;
+    initialize_search_schema(&connection, &path)?;
+    Ok(connection)
+}
+
+fn initialize_search_schema(connection: &Connection, path: &Path) -> DiagnosticResult<()> {
+    connection
+        .execute_batch(
+            "
+            PRAGMA journal_mode = WAL;
+            CREATE TABLE IF NOT EXISTS search_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            ",
+        )
+        .map_err(|err| sqlite_diagnostic("initialize search metadata", err, path))?;
+
+    let version: Option<i64> = connection
+        .query_row(
+            "SELECT value FROM search_meta WHERE key = 'search_schema_version'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|err| sqlite_diagnostic("read search schema version", err, path))?
+        .and_then(|value| value.parse::<i64>().ok());
+
+    if version != Some(SEARCH_SCHEMA_VERSION) {
+        connection
+            .execute_batch(
+                "
+                DROP TABLE IF EXISTS search_fts;
+                DROP TABLE IF EXISTS search_manifest;
+                DELETE FROM search_meta WHERE key = 'search_schema_version';
+                ",
+            )
+            .map_err(|err| sqlite_diagnostic("reset search index", err, path))?;
+    }
+
+    connection
+        .execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS search_manifest (
+                kind TEXT NOT NULL,
+                id TEXT NOT NULL,
+                path TEXT NOT NULL,
+                mtime_ns INTEGER NOT NULL,
+                size INTEGER NOT NULL,
+                source_hash TEXT NOT NULL,
+                PRIMARY KEY (kind, id)
+            );
+            CREATE VIRTUAL TABLE IF NOT EXISTS search_fts USING fts5(
+                kind UNINDEXED,
+                id UNINDEXED,
+                title,
+                path UNINDEXED,
+                tags UNINDEXED,
+                status UNINDEXED,
+                body,
+                tokenize = 'porter unicode61'
+            );
+            ",
+        )
+        .map_err(|err| sqlite_diagnostic("initialize search index", err, path))?;
+
+    connection
+        .execute(
+            "INSERT OR REPLACE INTO search_meta(key, value) VALUES('search_schema_version', ?1)",
+            params![SEARCH_SCHEMA_VERSION.to_string()],
+        )
+        .map_err(|err| sqlite_diagnostic("write search schema version", err, path))?;
+    Ok(())
+}
+
+fn sync_search_index(
+    config: &Config,
+    connection: &Connection,
+    requested_kinds: &[CatalogKind],
+    reindex: bool,
+) -> DiagnosticResult<()> {
+    let sync_kinds = if reindex {
+        vec![
+            CatalogKind::Rfc,
+            CatalogKind::Clause,
+            CatalogKind::Adr,
+            CatalogKind::Work,
+            CatalogKind::Guard,
+        ]
+    } else {
+        requested_kinds.to_vec()
+    };
+
+    if reindex {
+        // [[RFC-0002:C-SEARCH-COMMAND]]: sync_search_index honors
+        // `--reindex` by clearing derived local state with clear_search_index.
+        clear_search_index(config, connection)?;
+    }
+
+    for kind in &sync_kinds {
+        artifact_catalog::refresh_kind(config, *kind)?;
+    }
+    let records = artifact_catalog::list_records(config, &sync_kinds)?;
+    let current = records
+        .iter()
+        .map(|record| {
+            (
+                (record.kind.as_str().to_string(), record.id.clone()),
+                record,
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    let manifest = manifest_for_kinds(config, connection, &sync_kinds)?;
+    let fts_keys = fts_keys_for_kinds(config, connection, &sync_kinds)?;
+
+    let transaction = connection.unchecked_transaction().map_err(|err| {
+        sqlite_diagnostic(
+            "begin search index sync",
+            err,
+            &artifact_catalog::index_db_path(config),
+        )
+    })?;
+
+    // [[RFC-0002:C-SEARCH-COMMAND]]: sync_search_index treats fts_keys as
+    // derived local state; delete_indexed_document removes FTS rows no longer
+    // backed by authoritative TOML artifacts.
+    for key in fts_keys.iter().filter(|key| !current.contains_key(*key)) {
+        delete_indexed_document(config, &transaction, &key.0, &key.1)?;
+    }
+
+    // [[RFC-0002:C-SEARCH-COMMAND]]: sync_search_index keeps the manifest in
+    // step with authoritative records; delete_indexed_document removes stale
+    // manifest rows when their source artifact disappeared.
+    for (key, _) in manifest
+        .iter()
+        .filter(|(key, _)| !current.contains_key(*key))
+    {
+        delete_indexed_document(config, &transaction, &key.0, &key.1)?;
+    }
+
+    for record in records {
+        let key = (record.kind.as_str().to_string(), record.id.clone());
+        // [[RFC-0002:C-SEARCH-COMMAND]]: freshness is established only when
+        // manifest metadata matches and fts_keys still contains the document;
+        // otherwise upsert_indexed_document rebuilds the derived index entry.
+        if manifest
+            .get(&key)
+            .is_some_and(|freshness| freshness.matches(&record))
+            && fts_keys.contains(&key)
+        {
+            continue;
+        }
+        let document = build_search_document(config, &record)?;
+        upsert_indexed_document(config, &transaction, &record, &document)?;
+    }
+
+    transaction.commit().map_err(|err| {
+        sqlite_diagnostic(
+            "commit search index sync",
+            err,
+            &artifact_catalog::index_db_path(config),
+        )
+    })?;
+    Ok(())
+}
+
+fn clear_search_index(config: &Config, connection: &Connection) -> DiagnosticResult<()> {
+    connection
+        .execute_batch(
+            "
+            DELETE FROM search_fts;
+            DELETE FROM search_manifest;
+            ",
+        )
+        .map_err(|err| {
+            sqlite_diagnostic(
+                "clear search index",
+                err,
+                &artifact_catalog::index_db_path(config),
+            )
+        })?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Freshness {
+    path: String,
+    mtime_ns: i64,
+    size: i64,
+    source_hash: String,
+}
+
+impl Freshness {
+    fn matches(&self, record: &CatalogRecord) -> bool {
+        self.path == record.path
+            && self.mtime_ns == record.mtime_ns
+            && self.size == record.size
+            && self.source_hash == record.source_hash
+    }
+}
+
+fn manifest_for_kinds(
+    config: &Config,
+    connection: &Connection,
+    kinds: &[CatalogKind],
+) -> DiagnosticResult<HashMap<(String, String), Freshness>> {
+    let mut manifest = HashMap::new();
+    for kind in kinds {
+        let mut statement = connection
+            .prepare(
+                "
+                SELECT kind, id, path, mtime_ns, size, source_hash
+                FROM search_manifest
+                WHERE kind = ?1
+                ",
+            )
+            .map_err(|err| {
+                sqlite_diagnostic(
+                    "prepare search manifest listing",
+                    err,
+                    &artifact_catalog::index_db_path(config),
+                )
+            })?;
+        let rows = statement
+            .query_map(params![kind.as_str()], |row| {
+                let kind: String = row.get(0)?;
+                let id: String = row.get(1)?;
+                Ok((
+                    (kind, id),
+                    Freshness {
+                        path: row.get(2)?,
+                        mtime_ns: row.get(3)?,
+                        size: row.get(4)?,
+                        source_hash: row.get(5)?,
+                    },
+                ))
+            })
+            .map_err(|err| {
+                sqlite_diagnostic(
+                    "read search manifest listing",
+                    err,
+                    &artifact_catalog::index_db_path(config),
+                )
+            })?;
+        for row in rows {
+            let (key, freshness) = row.map_err(|err| {
+                sqlite_diagnostic(
+                    "decode search manifest listing",
+                    err,
+                    &artifact_catalog::index_db_path(config),
+                )
+            })?;
+            manifest.insert(key, freshness);
+        }
+    }
+    Ok(manifest)
+}
+
+fn fts_keys_for_kinds(
+    config: &Config,
+    connection: &Connection,
+    kinds: &[CatalogKind],
+) -> DiagnosticResult<HashSet<(String, String)>> {
+    let mut keys = HashSet::new();
+    for kind in kinds {
+        let mut statement = connection
+            .prepare(
+                "
+                SELECT kind, id
+                FROM search_fts
+                WHERE kind = ?1
+                ",
+            )
+            .map_err(|err| {
+                sqlite_diagnostic(
+                    "prepare search FTS listing",
+                    err,
+                    &artifact_catalog::index_db_path(config),
+                )
+            })?;
+        let rows = statement
+            .query_map(params![kind.as_str()], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|err| {
+                sqlite_diagnostic(
+                    "read search FTS listing",
+                    err,
+                    &artifact_catalog::index_db_path(config),
+                )
+            })?;
+        for row in rows {
+            keys.insert(row.map_err(|err| {
+                sqlite_diagnostic(
+                    "decode search FTS listing",
+                    err,
+                    &artifact_catalog::index_db_path(config),
+                )
+            })?);
+        }
+    }
+    Ok(keys)
+}
+
+fn delete_indexed_document(
+    config: &Config,
+    connection: &Connection,
+    kind: &str,
+    id: &str,
+) -> DiagnosticResult<()> {
+    connection
+        .execute(
+            "DELETE FROM search_fts WHERE kind = ?1 AND id = ?2",
+            params![kind, id],
+        )
+        .map_err(|err| {
+            sqlite_diagnostic(
+                "delete stale search document",
+                err,
+                &artifact_catalog::index_db_path(config),
+            )
+        })?;
+    connection
+        .execute(
+            "DELETE FROM search_manifest WHERE kind = ?1 AND id = ?2",
+            params![kind, id],
+        )
+        .map_err(|err| {
+            sqlite_diagnostic(
+                "delete stale search manifest entry",
+                err,
+                &artifact_catalog::index_db_path(config),
+            )
+        })?;
+    Ok(())
+}
+
+fn upsert_indexed_document(
+    config: &Config,
+    connection: &Connection,
+    record: &CatalogRecord,
+    document: &SearchDocument,
+) -> DiagnosticResult<()> {
+    delete_indexed_document(config, connection, record.kind.as_str(), &record.id)?;
+    connection
+        .execute(
+            "
+            INSERT INTO search_fts(kind, id, title, path, tags, status, body)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            ",
+            params![
+                document.kind.as_str(),
+                document.id,
+                document.title,
+                document.path,
+                encode_tags(&document.tags),
+                document.status.clone().unwrap_or_default(),
+                document.body
+            ],
+        )
+        .map_err(|err| {
+            sqlite_diagnostic(
+                "write search document",
+                err,
+                &artifact_catalog::index_db_path(config),
+            )
+        })?;
+    connection
+        .execute(
+            "
+            INSERT INTO search_manifest(kind, id, path, mtime_ns, size, source_hash)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            ON CONFLICT(kind, id) DO UPDATE SET
+                path = excluded.path,
+                mtime_ns = excluded.mtime_ns,
+                size = excluded.size,
+                source_hash = excluded.source_hash
+            ",
+            params![
+                record.kind.as_str(),
+                record.id,
+                record.path,
+                record.mtime_ns,
+                record.size,
+                record.source_hash
+            ],
+        )
+        .map_err(|err| {
+            sqlite_diagnostic(
+                "write search manifest entry",
+                err,
+                &artifact_catalog::index_db_path(config),
+            )
+        })?;
+    Ok(())
+}
+
+fn build_search_document(
+    config: &Config,
+    record: &CatalogRecord,
+) -> DiagnosticResult<SearchDocument> {
+    let path = record.absolute_path(config);
+    match record.kind {
+        CatalogKind::Rfc => {
+            let entry = load_rfc(config, &path).map_err(Diagnostic::from)?;
+            Ok(rfc_document(config, &entry))
+        }
+        CatalogKind::Clause => {
+            let entry = load_clause(config, &path).map_err(Diagnostic::from)?;
+            Ok(clause_document(config, record, &entry))
+        }
+        CatalogKind::Adr => {
+            let entry = load_adr(config, &path)?;
+            Ok(adr_document(config, &entry))
+        }
+        CatalogKind::Work => {
+            let entry = load_work_item(config, &path)?;
+            Ok(work_document(config, &entry))
+        }
+        CatalogKind::Guard => {
+            let entry = load_guard(config, &path)?;
+            Ok(guard_document(config, &entry))
+        }
+    }
+}
+
+fn rfc_document(config: &Config, entry: &RfcIndex) -> SearchDocument {
+    let rfc = &entry.rfc;
+    let mut parts = vec![
+        rfc.rfc_id.clone(),
+        rfc.title.clone(),
+        rfc.version.clone(),
+        rfc.status.as_ref().to_string(),
+        rfc.phase.as_ref().to_string(),
+    ];
+    parts.extend(rfc.owners.iter().cloned());
+    parts.extend(rfc.refs.iter().cloned());
+    parts.extend(rfc.tags.iter().cloned());
+    for section in &rfc.sections {
+        parts.push(section.title.clone());
+        parts.extend(section.clauses.iter().cloned());
+    }
+    for changelog in &rfc.changelog {
+        parts.push(changelog.version.clone());
+        parts.push(changelog.date.clone());
+        if let Some(notes) = &changelog.notes {
+            parts.push(notes.clone());
+        }
+        parts.extend(changelog.added.iter().cloned());
+        parts.extend(changelog.changed.iter().cloned());
+        parts.extend(changelog.deprecated.iter().cloned());
+        parts.extend(changelog.removed.iter().cloned());
+        parts.extend(changelog.fixed.iter().cloned());
+        parts.extend(changelog.security.iter().cloned());
+    }
+    SearchDocument {
+        kind: CatalogKind::Rfc,
+        id: rfc.rfc_id.clone(),
+        title: rfc.title.clone(),
+        path: config.display_path(&entry.path).display().to_string(),
+        tags: rfc.tags.clone(),
+        status: Some(format!("{}/{}", rfc.status.as_ref(), rfc.phase.as_ref())),
+        body: join_parts(parts),
+    }
+}
+
+fn clause_document(config: &Config, record: &CatalogRecord, entry: &ClauseEntry) -> SearchDocument {
+    let clause = &entry.spec;
+    let mut parts = vec![
+        record.id.clone(),
+        clause.clause_id.clone(),
+        clause.title.clone(),
+        clause.kind.as_ref().to_string(),
+        clause.status.as_ref().to_string(),
+        clause.text.clone(),
+    ];
+    parts.extend(clause.anchors.iter().cloned());
+    parts.extend(clause.tags.iter().cloned());
+    if let Some(since) = &clause.since {
+        parts.push(since.clone());
+    }
+    if let Some(superseded_by) = &clause.superseded_by {
+        parts.push(superseded_by.clone());
+    }
+    SearchDocument {
+        kind: CatalogKind::Clause,
+        id: record.id.clone(),
+        title: clause.title.clone(),
+        path: config.display_path(&entry.path).display().to_string(),
+        tags: clause.tags.clone(),
+        status: Some(clause.status.as_ref().to_string()),
+        body: join_parts(parts),
+    }
+}
+
+fn adr_document(config: &Config, entry: &AdrEntry) -> SearchDocument {
+    let meta = &entry.spec.govctl;
+    let content = &entry.spec.content;
+    let mut parts = vec![
+        meta.id.clone(),
+        meta.title.clone(),
+        meta.status.as_ref().to_string(),
+        meta.date.clone(),
+        content.context.clone(),
+        content.decision.clone(),
+        content.consequences.clone(),
+    ];
+    parts.extend(meta.refs.iter().cloned());
+    parts.extend(meta.tags.iter().cloned());
+    if let Some(superseded_by) = &meta.superseded_by {
+        parts.push(superseded_by.clone());
+    }
+    for alternative in &content.alternatives {
+        parts.push(alternative.text.clone());
+        parts.push(alternative.status.as_ref().to_string());
+        parts.extend(alternative.pros.iter().cloned());
+        parts.extend(alternative.cons.iter().cloned());
+        if let Some(reason) = &alternative.rejection_reason {
+            parts.push(reason.clone());
+        }
+    }
+    SearchDocument {
+        kind: CatalogKind::Adr,
+        id: meta.id.clone(),
+        title: meta.title.clone(),
+        path: config.display_path(&entry.path).display().to_string(),
+        tags: meta.tags.clone(),
+        status: Some(meta.status.as_ref().to_string()),
+        body: join_parts(parts),
+    }
+}
+
+fn work_document(config: &Config, entry: &WorkItemEntry) -> SearchDocument {
+    let meta = &entry.spec.govctl;
+    let content = &entry.spec.content;
+    let mut parts = vec![
+        meta.id.clone(),
+        meta.title.clone(),
+        meta.status.as_ref().to_string(),
+        content.description.clone(),
+    ];
+    parts.extend(meta.refs.iter().cloned());
+    parts.extend(meta.depends_on.iter().cloned());
+    parts.extend(meta.tags.iter().cloned());
+    for item in &content.acceptance_criteria {
+        parts.push(item.text.clone());
+        parts.push(item.status.as_ref().to_string());
+        parts.push(item.category.as_ref().to_string());
+    }
+    parts.extend(content.notes.iter().cloned());
+    SearchDocument {
+        kind: CatalogKind::Work,
+        id: meta.id.clone(),
+        title: meta.title.clone(),
+        path: config.display_path(&entry.path).display().to_string(),
+        tags: meta.tags.clone(),
+        status: Some(meta.status.as_ref().to_string()),
+        body: join_parts(parts),
+    }
+}
+
+fn guard_document(config: &Config, entry: &GuardEntry) -> SearchDocument {
+    let meta = &entry.spec.govctl;
+    let mut parts = vec![
+        meta.id.clone(),
+        meta.title.clone(),
+        entry.spec.check.command.clone(),
+    ];
+    parts.extend(meta.refs.iter().cloned());
+    parts.extend(meta.tags.iter().cloned());
+    if let Some(pattern) = &entry.spec.check.pattern {
+        parts.push(pattern.clone());
+    }
+    SearchDocument {
+        kind: CatalogKind::Guard,
+        id: meta.id.clone(),
+        title: meta.title.clone(),
+        path: config.display_path(&entry.path).display().to_string(),
+        tags: meta.tags.clone(),
+        status: None,
+        body: join_parts(parts),
+    }
+}
+
+fn join_parts(parts: Vec<String>) -> String {
+    parts
+        .into_iter()
+        .filter(|part| !part.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn query_index(
+    config: &Config,
+    connection: &Connection,
+    terms: &[String],
+    kinds: &[CatalogKind],
+    tag_filters: &[String],
+    limit: usize,
+) -> DiagnosticResult<Vec<SearchResult>> {
+    let fts_query = fts_query(terms);
+    let exact_terms = exact_terms(terms);
+    let kind_filter = kinds
+        .iter()
+        .map(|kind| kind.as_str())
+        .collect::<HashSet<_>>();
+    let tag_filters = tag_filters
+        .iter()
+        .map(|tag| tag.as_str())
+        .collect::<Vec<_>>();
+
+    let mut statement = connection
+        .prepare(
+            "
+            SELECT kind, id, title, path, tags, status,
+                   snippet(search_fts, 6, '', '', '...', 18),
+                   bm25(search_fts)
+            FROM search_fts
+            WHERE search_fts MATCH ?1
+            ",
+        )
+        .map_err(|err| {
+            sqlite_diagnostic(
+                "prepare search query",
+                err,
+                &artifact_catalog::index_db_path(config),
+            )
+        })?;
+
+    let rows = statement
+        .query_map(params![fts_query], |row| {
+            let tags_blob: String = row.get(4)?;
+            let status: String = row.get(5)?;
+            let snippet: String = row.get(6)?;
+            Ok(SearchRow {
+                result: SearchResult {
+                    kind: row.get(0)?,
+                    id: row.get(1)?,
+                    title: row.get(2)?,
+                    path: row.get(3)?,
+                    snippet: clean_snippet(&snippet),
+                    score: Some(row.get(7)?),
+                    status: (!status.is_empty()).then_some(status),
+                },
+                tags: decode_tags(&tags_blob),
+                score: row.get(7)?,
+            })
+        })
+        .map_err(|err| {
+            Diagnostic::new(
+                DiagnosticCode::E0806InvalidPattern,
+                format!("Invalid search query: {err}"),
+                "search",
+            )
+        })?;
+
+    let mut matches = Vec::new();
+    for row in rows {
+        let row = row.map_err(|err| {
+            sqlite_diagnostic(
+                "read search result",
+                err,
+                &artifact_catalog::index_db_path(config),
+            )
+        })?;
+        if !kind_filter.contains(row.result.kind.as_str()) {
+            continue;
+        }
+        if !has_all_tags(&row.tags, &tag_filters) {
+            continue;
+        }
+        matches.push(row);
+    }
+
+    matches.sort_by(|a, b| {
+        let a_exact = exact_terms.contains(&a.result.id.to_lowercase());
+        let b_exact = exact_terms.contains(&b.result.id.to_lowercase());
+        match (a_exact, b_exact) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            _ => a
+                .score
+                .partial_cmp(&b.score)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| a.result.id.cmp(&b.result.id)),
+        }
+    });
+
+    Ok(matches
+        .into_iter()
+        .take(limit)
+        .map(|row| row.result)
+        .collect())
+}
+
+fn fts_query(terms: &[String]) -> String {
+    terms
+        .iter()
+        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn exact_terms(terms: &[String]) -> HashSet<String> {
+    let mut exact = terms
+        .iter()
+        .map(|term| term.to_lowercase())
+        .collect::<HashSet<_>>();
+    exact.insert(terms.join(" ").to_lowercase());
+    exact
+}
+
+fn encode_tags(tags: &[String]) -> String {
+    tags.join("\n")
+}
+
+fn decode_tags(value: &str) -> Vec<String> {
+    value
+        .lines()
+        .map(str::trim)
+        .filter(|tag| !tag.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn has_all_tags(tags: &[String], filters: &[&str]) -> bool {
+    filters
+        .iter()
+        .all(|filter| tags.iter().any(|tag| tag == filter))
+}
+
+fn clean_snippet(snippet: &str) -> String {
+    snippet.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn print_results(results: &[SearchResult], output: OutputFormat) {
+    match output {
+        OutputFormat::Json => print_json_array(results),
+        OutputFormat::Plain => {
+            for result in results {
+                println!("{}", result.id);
+            }
+        }
+        OutputFormat::Table => {
+            let mut table = command_table();
+            table.set_header(
+                ["Kind", "ID", "Title", "Path", "Snippet"]
+                    .iter()
+                    .map(|header| Cell::new(*header).add_attribute(Attribute::Bold))
+                    .collect::<Vec<_>>(),
+            );
+            for result in results {
+                table.add_row(vec![
+                    Cell::new(&result.kind),
+                    Cell::new(&result.id),
+                    Cell::new(&result.title),
+                    Cell::new(&result.path),
+                    Cell::new(&result.snippet),
+                ]);
+            }
+            println!("{table}");
+        }
+    }
+}
+
+fn sqlite_diagnostic(action: &'static str, err: rusqlite::Error, path: &Path) -> Diagnostic {
+    Diagnostic::new(
+        DiagnosticCode::E0903UnexpectedError,
+        format!("{action}: {err}"),
+        path.display().to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_terms_rejects_empty_input_and_splits_whitespace()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let empty = match query_terms(&[]) {
+            Ok(_) => return Err(std::io::Error::other("empty search returned Ok").into()),
+            Err(err) => err,
+        };
+        assert_eq!(empty.code, DiagnosticCode::E0801MissingRequiredArg);
+
+        let terms = match query_terms(&["  cache  index ".to_string(), "ADR-0001".to_string()]) {
+            Ok(terms) => terms,
+            Err(err) => {
+                return Err(
+                    std::io::Error::other(format!("non-empty search failed: {err:?}")).into(),
+                );
+            }
+        };
+        assert_eq!(terms, vec!["cache", "index", "ADR-0001"]);
+        Ok(())
+    }
+
+    #[test]
+    fn kind_filters_map_all_targets_and_deduplicate() {
+        let kinds = kinds_for_filters(&[
+            ListTarget::Rfc,
+            ListTarget::Clause,
+            ListTarget::Adr,
+            ListTarget::Work,
+            ListTarget::Guard,
+            ListTarget::Adr,
+        ]);
+        assert_eq!(
+            kinds,
+            vec![
+                CatalogKind::Rfc,
+                CatalogKind::Clause,
+                CatalogKind::Adr,
+                CatalogKind::Work,
+                CatalogKind::Guard
+            ]
+        );
+    }
+
+    #[test]
+    fn fts_query_quotes_user_terms_and_exact_terms_include_phrase() {
+        let terms = vec!["cache".to_string(), "quote\"term".to_string()];
+        assert_eq!(fts_query(&terms), "\"cache\" \"quote\"\"term\"");
+
+        let exact = exact_terms(&terms);
+        assert!(exact.contains("cache"));
+        assert!(exact.contains("quote\"term"));
+        assert!(exact.contains("cache quote\"term"));
+    }
+
+    #[test]
+    fn tag_and_snippet_helpers_normalize_values() {
+        let tags = vec!["search".to_string(), "cache".to_string()];
+        let encoded = encode_tags(&tags);
+        assert_eq!(decode_tags(&format!("\n{encoded}\n\n")), tags);
+        assert!(has_all_tags(&tags, &["search", "cache"]));
+        assert!(!has_all_tags(&tags, &["search", "missing"]));
+        assert_eq!(
+            clean_snippet(" cache\n\nresult\tbody "),
+            "cache result body"
+        );
+    }
+}

--- a/src/cmd/work_lookup.rs
+++ b/src/cmd/work_lookup.rs
@@ -1,20 +1,10 @@
 use crate::config::Config;
-use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticResult};
+use crate::diagnostic::DiagnosticResult;
 use crate::model::WorkItemEntry;
-use crate::parse::load_work_items;
 
 pub(crate) fn load_work_item_by_id(
     config: &Config,
     work_id: &str,
 ) -> DiagnosticResult<WorkItemEntry> {
-    load_work_items(config)?
-        .into_iter()
-        .find(|item| item.spec.govctl.id == work_id)
-        .ok_or_else(|| {
-            Diagnostic::new(
-                DiagnosticCode::E0402WorkNotFound,
-                format!("Work item not found: {work_id}"),
-                work_id,
-            )
-        })
+    crate::artifact_catalog::load_work_item_by_id(config, work_id)
 }

--- a/src/command_router/execute/builtin.rs
+++ b/src/command_router/execute/builtin.rs
@@ -23,6 +23,14 @@ pub(super) fn execute_builtin(config: &Config, builtin: &BuiltinOp, op: WriteOp)
         BuiltinOp::Verify { guard_ids, work } => {
             cmd::verify::verify(config, guard_ids, work.as_deref())
         }
+        BuiltinOp::Search {
+            query,
+            types,
+            tags,
+            limit,
+            output,
+            reindex,
+        } => cmd::search::search(config, query, types, tags, *limit, *output, *reindex),
         BuiltinOp::Describe { context } => cmd::describe::describe(config, *context),
         BuiltinOp::SelfUpdate { check } => cmd::self_update::self_update(*check),
         BuiltinOp::Completions { shell } => {

--- a/src/command_router/parsed.rs
+++ b/src/command_router/parsed.rs
@@ -33,6 +33,21 @@ impl CommandPlan {
                 guard_ids: guard_ids.clone(),
                 work: work.clone(),
             }))),
+            Commands::Search {
+                query,
+                types,
+                tag,
+                limit,
+                output,
+                reindex,
+            } => Ok(global(Op::Builtin(BuiltinOp::Search {
+                query: query.clone(),
+                types: types.clone(),
+                tags: tag.clone(),
+                limit: *limit,
+                output: *output,
+                reindex: *reindex,
+            }))),
             Commands::Describe { context, .. } => Ok(global(Op::Builtin(BuiltinOp::Describe {
                 context: *context,
             }))),

--- a/src/command_router/plan.rs
+++ b/src/command_router/plan.rs
@@ -57,6 +57,14 @@ pub enum BuiltinOp {
         guard_ids: Vec<String>,
         work: Option<String>,
     },
+    Search {
+        query: Vec<String>,
+        types: Vec<ListTarget>,
+        tags: Vec<String>,
+        limit: Option<usize>,
+        output: OutputFormat,
+        reindex: bool,
+    },
     Describe {
         context: bool,
     },
@@ -129,6 +137,11 @@ impl BuiltinOp {
             | Self::LoopList { .. }
             | Self::LoopShow { .. }
             | Self::LoopResume { .. } => true,
+            // [[RFC-0002:C-SEARCH-COMMAND]]: search may sync `.govctl/`
+            // derived local state but must not mutate governed artifacts or
+            // rendered docs; [[RFC-0004:C-DEFINITIONS]] keeps that outside the
+            // gov-root write-lock class.
+            Self::Search { .. } => true,
             #[cfg(feature = "tui")]
             Self::Tui => true,
             _ => false,

--- a/src/command_router/tests/lock_disposition.rs
+++ b/src/command_router/tests/lock_disposition.rs
@@ -93,6 +93,18 @@ fn test_lock_disposition_is_lock_free_for_inspect_commands()
         LockDisposition::None
     );
     assert_eq!(
+        global(Op::Builtin(BuiltinOp::Search {
+            query: vec!["cache".to_string()],
+            types: vec![],
+            tags: vec![],
+            limit: None,
+            output: OutputFormat::Table,
+            reindex: false,
+        }))
+        .lock_disposition(),
+        LockDisposition::None
+    );
+    assert_eq!(
         plan_get("RFC-0001", Some("title"))?.lock_disposition(),
         LockDisposition::None
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 use clap::Parser;
 use std::process::ExitCode;
 
+mod artifact_catalog;
 mod artifact_index;
 mod cli;
 mod cmd;

--- a/tests/display_path_tests/show.rs
+++ b/tests/display_path_tests/show.rs
@@ -16,6 +16,45 @@ fn test_show_rfc_missing_returns_scope_context() -> common::TestResult {
 }
 
 #[test]
+fn test_show_rfc_rejects_path_with_mismatched_id() -> common::TestResult {
+    let temp_dir = init_project()?;
+    let rfc_dir = temp_dir.path().join("gov/rfc/RFC-0001");
+    fs::create_dir_all(&rfc_dir)?;
+    fs::write(
+        rfc_dir.join("rfc.toml"),
+        r#"[govctl]
+id = "RFC-0002"
+title = "Wrong RFC"
+version = "0.1.0"
+status = "draft"
+phase = "spec"
+owners = ["test@example.com"]
+created = "2026-01-01"
+
+[[sections]]
+title = "Specification"
+clauses = []
+
+[[changelog]]
+version = "0.1.0"
+date = "2026-01-01"
+notes = "Initial draft"
+"#,
+    )?;
+
+    let output = run_commands(temp_dir.path(), &[&["rfc", "show", "RFC-0001"]])?;
+
+    assert_show_missing_scope(
+        &output,
+        temp_dir.path(),
+        "error[E0102]: RFC not found: RFC-0001",
+        "gov/rfc",
+    );
+    assert!(!output.contains("Wrong RFC"), "{output}");
+    Ok(())
+}
+
+#[test]
 fn test_show_adr_missing_returns_scope_context() -> common::TestResult {
     let temp_dir = init_project()?;
 
@@ -84,5 +123,36 @@ notes = "Initial draft"
         "error[E0202]: Clause not found: RFC-0001:C-MISSING",
         "gov/rfc/RFC-0001/clauses",
     );
+    Ok(())
+}
+
+#[test]
+fn test_show_clause_rejects_path_with_mismatched_id() -> common::TestResult {
+    let temp_dir = init_project()?;
+    let clauses_dir = temp_dir.path().join("gov/rfc/RFC-0001/clauses");
+    fs::create_dir_all(&clauses_dir)?;
+    fs::write(
+        clauses_dir.join("C-TARGET.toml"),
+        r#"[govctl]
+schema = 1
+id = "C-ACTUAL"
+title = "Wrong Clause"
+kind = "normative"
+status = "active"
+
+[content]
+text = "Wrong clause body"
+"#,
+    )?;
+
+    let output = run_commands(temp_dir.path(), &[&["clause", "show", "RFC-0001:C-TARGET"]])?;
+
+    assert_show_missing_scope(
+        &output,
+        temp_dir.path(),
+        "error[E0202]: Clause not found: RFC-0001:C-TARGET",
+        "gov/rfc/RFC-0001/clauses",
+    );
+    assert!(!output.contains("Wrong Clause"), "{output}");
     Ok(())
 }

--- a/tests/edit_tests/work_tests/fields.rs
+++ b/tests/edit_tests/work_tests/fields.rs
@@ -39,6 +39,44 @@ fn test_work_set_title() -> common::TestResult {
 }
 
 #[test]
+fn test_work_get_falls_back_to_partial_filename_starting_with_wi() -> common::TestResult {
+    let temp_dir = init_project()?;
+    std::fs::write(
+        temp_dir.path().join("gov/work/WI-partial-edit.toml"),
+        r#"[govctl]
+schema = 1
+id = "WI-2026-01-01-778"
+title = "Partial Edit Lookup"
+status = "queue"
+created = "2026-01-01"
+
+[content]
+description = "Partial edit lookup"
+"#,
+    )?;
+
+    let output = common::run_commands(temp_dir.path(), &[&["work", "get", "WI-partial", "title"]])?;
+    assert!(output.contains("Partial Edit Lookup"), "{output}");
+    Ok(())
+}
+
+#[test]
+fn test_work_get_by_id_propagates_lookup_errors() -> common::TestResult {
+    let temp_dir = init_project()?;
+    let work_dir = temp_dir.path().join("gov/work");
+    std::fs::remove_dir_all(&work_dir)?;
+    std::fs::write(&work_dir, "not a directory")?;
+
+    let output = common::run_commands(
+        temp_dir.path(),
+        &[&["work", "get", "WI-2026-01-01-001", "title"]],
+    )?;
+    assert!(output.contains("error[E0901]"), "{output}");
+    assert!(!output.contains("Work item not found"), "{output}");
+    Ok(())
+}
+
+#[test]
 fn test_work_set_status_rejected() -> common::TestResult {
     let (temp_dir, date) = init_project_with_date()?;
     let id = first_work_id(&date);

--- a/tests/lifecycle_tests/adr.rs
+++ b/tests/lifecycle_tests/adr.rs
@@ -155,6 +155,67 @@ fn test_supersede_adr() -> common::TestResult {
 }
 
 #[test]
+fn test_supersede_adr_propagates_replacement_lookup_errors() -> common::TestResult {
+    let temp_dir = init_project()?;
+    let adr_dir = temp_dir.path().join("gov/adr");
+    std::fs::remove_dir_all(&adr_dir)?;
+    std::fs::write(&adr_dir, "not a directory")?;
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[&[
+            "adr",
+            "supersede",
+            "ADR-0001",
+            "--by",
+            "ADR-0002",
+            "--force",
+        ]],
+    )?;
+    assert!(output.contains("error[E0901]"), "{output}");
+    assert!(!output.contains("Replacement ADR not found"), "{output}");
+    Ok(())
+}
+
+#[test]
+fn test_accept_adr_propagates_lookup_errors() -> common::TestResult {
+    let temp_dir = init_project()?;
+    let adr_dir = temp_dir.path().join("gov/adr");
+    std::fs::remove_dir_all(&adr_dir)?;
+    std::fs::write(&adr_dir, "not a directory")?;
+
+    let output = run_commands(temp_dir.path(), &[&["adr", "accept", "ADR-0001"]])?;
+    assert!(output.contains("error[E0901]"), "{output}");
+    assert!(!output.contains("ADR not found"), "{output}");
+    Ok(())
+}
+
+#[test]
+fn test_supersede_adr_rejects_missing_replacement() -> common::TestResult {
+    let temp_dir = init_project()?;
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[
+            &["adr", "new", "Old Decision"],
+            &[
+                "adr",
+                "supersede",
+                "ADR-0001",
+                "--by",
+                "ADR-9999",
+                "--force",
+            ],
+        ],
+    )?;
+    assert!(
+        output.contains("Replacement ADR not found: ADR-9999"),
+        "{output}"
+    );
+    Ok(())
+}
+
+#[test]
 fn test_accept_rejected_adr_fails() -> common::TestResult {
     let (temp_dir, date) = init_project_with_date()?;
 

--- a/tests/snapshots/test_describe__describe_basic.snap
+++ b/tests/snapshots/test_describe__describe_basic.snap
@@ -55,6 +55,15 @@ $ govctl describe
       ]
     },
     {
+      "name": "search",
+      "purpose": "Search governed artifacts across the project",
+      "when_to_use": "To find RFCs, clauses, ADRs, work items, and guards by content or ID.",
+      "example": "govctl search caching --type adr",
+      "prerequisites": [
+        "govctl init"
+      ]
+    },
+    {
       "name": "loop list",
       "purpose": "List persisted local loop states",
       "when_to_use": "To discover interrupted or resumable loops before selecting one by loop ID.",

--- a/tests/snapshots/test_describe__describe_in_initialized_project.snap
+++ b/tests/snapshots/test_describe__describe_in_initialized_project.snap
@@ -55,6 +55,15 @@ $ govctl describe
       ]
     },
     {
+      "name": "search",
+      "purpose": "Search governed artifacts across the project",
+      "when_to_use": "To find RFCs, clauses, ADRs, work items, and guards by content or ID.",
+      "example": "govctl search caching --type adr",
+      "prerequisites": [
+        "govctl init"
+      ]
+    },
+    {
       "name": "loop list",
       "purpose": "List persisted local loop states",
       "when_to_use": "To discover interrupted or resumable loops before selecting one by loop ID.",

--- a/tests/snapshots/test_describe__describe_with_context_active_work_item.snap
+++ b/tests/snapshots/test_describe__describe_with_context_active_work_item.snap
@@ -60,6 +60,15 @@ $ govctl describe --context
       ]
     },
     {
+      "name": "search",
+      "purpose": "Search governed artifacts across the project",
+      "when_to_use": "To find RFCs, clauses, ADRs, work items, and guards by content or ID.",
+      "example": "govctl search caching --type adr",
+      "prerequisites": [
+        "govctl init"
+      ]
+    },
+    {
       "name": "loop list",
       "purpose": "List persisted local loop states",
       "when_to_use": "To discover interrupted or resumable loops before selecting one by loop ID.",

--- a/tests/snapshots/test_describe__describe_with_context_draft_rfc.snap
+++ b/tests/snapshots/test_describe__describe_with_context_draft_rfc.snap
@@ -60,6 +60,15 @@ $ govctl describe --context
       ]
     },
     {
+      "name": "search",
+      "purpose": "Search governed artifacts across the project",
+      "when_to_use": "To find RFCs, clauses, ADRs, work items, and guards by content or ID.",
+      "example": "govctl search caching --type adr",
+      "prerequisites": [
+        "govctl init"
+      ]
+    },
+    {
       "name": "loop list",
       "purpose": "List persisted local loop states",
       "when_to_use": "To discover interrupted or resumable loops before selecting one by loop ID.",

--- a/tests/snapshots/test_describe__describe_with_context_empty_project.snap
+++ b/tests/snapshots/test_describe__describe_with_context_empty_project.snap
@@ -55,6 +55,15 @@ $ govctl describe --context
       ]
     },
     {
+      "name": "search",
+      "purpose": "Search governed artifacts across the project",
+      "when_to_use": "To find RFCs, clauses, ADRs, work items, and guards by content or ID.",
+      "example": "govctl search caching --type adr",
+      "prerequisites": [
+        "govctl init"
+      ]
+    },
+    {
       "name": "loop list",
       "purpose": "List persisted local loop states",
       "when_to_use": "To discover interrupted or resumable loops before selecting one by loop ID.",

--- a/tests/snapshots/test_describe__describe_with_context_normative_impl_phase_rfc.snap
+++ b/tests/snapshots/test_describe__describe_with_context_normative_impl_phase_rfc.snap
@@ -68,6 +68,15 @@ $ govctl describe --context
       ]
     },
     {
+      "name": "search",
+      "purpose": "Search governed artifacts across the project",
+      "when_to_use": "To find RFCs, clauses, ADRs, work items, and guards by content or ID.",
+      "example": "govctl search caching --type adr",
+      "prerequisites": [
+        "govctl init"
+      ]
+    },
+    {
       "name": "loop list",
       "purpose": "List persisted local loop states",
       "when_to_use": "To discover interrupted or resumable loops before selecting one by loop ID.",

--- a/tests/snapshots/test_describe__describe_with_context_normative_spec_phase_rfc.snap
+++ b/tests/snapshots/test_describe__describe_with_context_normative_spec_phase_rfc.snap
@@ -64,6 +64,15 @@ $ govctl describe --context
       ]
     },
     {
+      "name": "search",
+      "purpose": "Search governed artifacts across the project",
+      "when_to_use": "To find RFCs, clauses, ADRs, work items, and guards by content or ID.",
+      "example": "govctl search caching --type adr",
+      "prerequisites": [
+        "govctl init"
+      ]
+    },
+    {
       "name": "loop list",
       "purpose": "List persisted local loop states",
       "when_to_use": "To discover interrupted or resumable loops before selecting one by loop ID.",

--- a/tests/snapshots/test_describe__describe_with_context_normative_test_phase_rfc.snap
+++ b/tests/snapshots/test_describe__describe_with_context_normative_test_phase_rfc.snap
@@ -72,6 +72,15 @@ $ govctl describe --context
       ]
     },
     {
+      "name": "search",
+      "purpose": "Search governed artifacts across the project",
+      "when_to_use": "To find RFCs, clauses, ADRs, work items, and guards by content or ID.",
+      "example": "govctl search caching --type adr",
+      "prerequisites": [
+        "govctl init"
+      ]
+    },
+    {
       "name": "loop list",
       "purpose": "List persisted local loop states",
       "when_to_use": "To discover interrupted or resumable loops before selecting one by loop ID.",

--- a/tests/snapshots/test_describe__describe_with_context_proposed_adr.snap
+++ b/tests/snapshots/test_describe__describe_with_context_proposed_adr.snap
@@ -59,6 +59,15 @@ $ govctl describe --context
       ]
     },
     {
+      "name": "search",
+      "purpose": "Search governed artifacts across the project",
+      "when_to_use": "To find RFCs, clauses, ADRs, work items, and guards by content or ID.",
+      "example": "govctl search caching --type adr",
+      "prerequisites": [
+        "govctl init"
+      ]
+    },
+    {
       "name": "loop list",
       "purpose": "List persisted local loop states",
       "when_to_use": "To discover interrupted or resumable loops before selecting one by loop ID.",

--- a/tests/snapshots/test_describe__describe_with_context_queued_work_items.snap
+++ b/tests/snapshots/test_describe__describe_with_context_queued_work_items.snap
@@ -65,6 +65,15 @@ $ govctl describe --context
       ]
     },
     {
+      "name": "search",
+      "purpose": "Search governed artifacts across the project",
+      "when_to_use": "To find RFCs, clauses, ADRs, work items, and guards by content or ID.",
+      "example": "govctl search caching --type adr",
+      "prerequisites": [
+        "govctl init"
+      ]
+    },
+    {
       "name": "loop list",
       "purpose": "List persisted local loop states",
       "when_to_use": "To discover interrupted or resumable loops before selecting one by loop ID.",

--- a/tests/test_move.rs
+++ b/tests/test_move.rs
@@ -3,10 +3,10 @@
 mod common;
 
 use common::{
-    first_work_id, init_project_with_date, normalize_output, run_commands, run_dynamic_commands,
-    work_add_acceptance, work_new_active,
+    first_work_id, init_project, init_project_with_date, normalize_output, run_commands,
+    run_dynamic_commands, work_add_acceptance, work_new_active,
 };
-use std::path::Path;
+use std::{fs, path::Path};
 
 fn setup_active_work_item_with_criteria(
     dir: &Path,
@@ -155,6 +155,53 @@ fn test_move_by_work_item_id() -> common::TestResult {
         ],
     )?;
     assert_move_snapshot!(temp_dir, &date, &output)
+}
+
+#[test]
+fn test_move_falls_back_to_partial_filename_starting_with_wi() -> common::TestResult {
+    let temp_dir = init_project()?;
+    let work_path = temp_dir.path().join("gov/work/WI-partial-custom.toml");
+    fs::write(
+        work_path,
+        r#"[govctl]
+schema = 1
+id = "WI-2026-01-01-777"
+title = "Partial Filename"
+status = "active"
+created = "2026-01-01"
+started = "2026-01-01"
+
+[content]
+description = "Partial filename lookup"
+"#,
+    )?;
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[
+            &["work", "move", "WI-partial", "cancelled"],
+            &["work", "get", "WI-2026-01-01-777", "status"],
+        ],
+    )?;
+    assert!(output.contains("Moved WI-partial-custom.toml to cancelled"));
+    assert!(output.contains("$ govctl work get WI-2026-01-01-777 status\ncancelled"));
+    Ok(())
+}
+
+#[test]
+fn test_move_by_work_item_id_propagates_lookup_errors() -> common::TestResult {
+    let temp_dir = init_project()?;
+    let work_dir = temp_dir.path().join("gov/work");
+    fs::remove_dir_all(&work_dir)?;
+    fs::write(&work_dir, "not a directory")?;
+
+    let output = run_commands(
+        temp_dir.path(),
+        &[&["work", "move", "WI-2026-01-01-001", "active"]],
+    )?;
+    assert!(output.contains("error[E0901]"), "{output}");
+    assert!(!output.contains("Work item not found"), "{output}");
+    Ok(())
 }
 
 #[test]

--- a/tests/test_search.rs
+++ b/tests/test_search.rs
@@ -1,0 +1,378 @@
+mod common;
+
+use common::{init_project, run_commands, write_guard_with_timeout};
+use rusqlite::Connection;
+use std::fs;
+use std::path::Path;
+
+fn write_clause(
+    dir: &Path,
+    rfc_id: &str,
+    clause_id: &str,
+    tag: Option<&str>,
+) -> common::TestResult {
+    let tags = tag
+        .map(|tag| format!("tags = [\"{tag}\"]\n"))
+        .unwrap_or_default();
+    let path = dir
+        .join("gov/rfc")
+        .join(rfc_id)
+        .join("clauses")
+        .join(format!("{clause_id}.toml"));
+    fs::write(
+        path,
+        format!(
+            r#"[govctl]
+schema = 1
+id = "{clause_id}"
+title = "Cache Clause"
+kind = "normative"
+status = "active"
+anchors = ["cache-anchor"]
+since = "0.1.0"
+superseded_by = "C-NEXT"
+{tags}
+[content]
+text = "cache clause body"
+"#
+        ),
+    )?;
+    Ok(())
+}
+
+fn write_search_rfc(dir: &Path) -> common::TestResult {
+    let rfc_dir = dir.join("gov/rfc/RFC-0001");
+    fs::create_dir_all(rfc_dir.join("clauses"))?;
+    fs::write(
+        rfc_dir.join("rfc.toml"),
+        r#"[govctl]
+schema = 1
+id = "RFC-0001"
+title = "Cache Policy"
+version = "0.1.0"
+status = "draft"
+phase = "spec"
+owners = ["@test-user"]
+created = "2026-01-01"
+refs = ["ADR-0001"]
+tags = ["rfctag"]
+
+[[sections]]
+title = "Cache Specification"
+clauses = ["clauses/C-CACHE.toml"]
+
+[[changelog]]
+version = "0.1.0"
+date = "2026-01-01"
+notes = "cache changelog note"
+added = ["cache added"]
+changed = ["cache changed"]
+deprecated = ["cache deprecated"]
+removed = ["cache removed"]
+fixed = ["cache fixed"]
+security = ["cache security"]
+"#,
+    )?;
+    Ok(())
+}
+
+fn write_adr(dir: &Path) -> common::TestResult {
+    fs::write(
+        dir.join("gov/adr/ADR-0001-cache-decision.toml"),
+        r#"[govctl]
+schema = 1
+id = "ADR-0001"
+title = "Cache Decision"
+status = "superseded"
+date = "2026-01-01"
+superseded_by = "ADR-0002"
+refs = ["RFC-0001"]
+tags = ["adrtag"]
+
+[content]
+context = "cache context"
+decision = "Use cache search"
+consequences = "Searchable ADR"
+
+[[content.alternatives]]
+text = "cache alternative"
+status = "rejected"
+pros = ["cache pro"]
+cons = ["cache con"]
+rejection_reason = "cache reason"
+"#,
+    )?;
+    Ok(())
+}
+
+fn write_work(dir: &Path, id: &str, title: &str, description: &str) -> common::TestResult {
+    fs::write(
+        dir.join("gov/work/2026-01-01-search-work.toml"),
+        format!(
+            r#"[govctl]
+schema = 1
+id = "{id}"
+title = "{title}"
+status = "active"
+created = "2026-01-01"
+started = "2026-01-01"
+refs = ["RFC-0001"]
+depends_on = ["WI-2026-01-01-999"]
+tags = ["worktag"]
+
+[content]
+description = "{description}"
+notes = ["cache durable note"]
+
+[[content.acceptance_criteria]]
+text = "cache criterion"
+status = "pending"
+category = "chore"
+"#
+        ),
+    )?;
+    Ok(())
+}
+
+fn write_work_with_journal(dir: &Path) -> common::TestResult {
+    fs::write(
+        dir.join("gov/work/2026-01-01-journal-work.toml"),
+        r#"[govctl]
+schema = 1
+id = "WI-2026-01-01-002"
+title = "Journal Work"
+status = "active"
+created = "2026-01-01"
+started = "2026-01-01"
+
+[content]
+description = "stable searchable body"
+
+[[content.journal]]
+date = "2026-01-01"
+content = "journalonlytoken"
+"#,
+    )?;
+    Ok(())
+}
+
+#[test]
+fn test_search_finds_all_artifact_types_and_output_formats() -> common::TestResult {
+    let temp_dir = init_project()?;
+    write_search_rfc(temp_dir.path())?;
+    write_clause(temp_dir.path(), "RFC-0001", "C-CACHE", Some("searchtag"))?;
+    write_adr(temp_dir.path())?;
+    write_work(
+        temp_dir.path(),
+        "WI-2026-01-01-001",
+        "Cache Work",
+        "cache work body",
+    )?;
+    write_guard_with_timeout(
+        temp_dir.path(),
+        "GUARD-CACHE",
+        "echo cache",
+        Some("cache"),
+        5,
+    )?;
+
+    let json = run_commands(
+        temp_dir.path(),
+        &[&["search", "cache", "-o", "json", "-n", "10"]],
+    )?;
+    assert!(json.contains("\"kind\": \"rfc\""), "{json}");
+    assert!(json.contains("\"kind\": \"clause\""), "{json}");
+    assert!(json.contains("\"kind\": \"adr\""), "{json}");
+    assert!(json.contains("\"kind\": \"work\""), "{json}");
+    assert!(json.contains("\"kind\": \"guard\""), "{json}");
+    assert!(json.contains("\"path\""), "{json}");
+    assert!(json.contains("\"snippet\""), "{json}");
+
+    let plain = run_commands(
+        temp_dir.path(),
+        &[&["search", "cache", "--type", "guard", "-o", "plain"]],
+    )?;
+    assert!(plain.contains("GUARD-CACHE"), "{plain}");
+    assert!(!plain.contains("ADR-0001"), "{plain}");
+
+    let tagged = run_commands(
+        temp_dir.path(),
+        &[&["search", "cache", "--tag", "searchtag", "-o", "plain"]],
+    )?;
+    assert!(tagged.contains("RFC-0001:C-CACHE"), "{tagged}");
+    assert!(!tagged.contains("ADR-0001"), "{tagged}");
+
+    let table = run_commands(temp_dir.path(), &[&["search", "cache", "--type", "rfc"]])?;
+    assert!(table.contains("Kind"), "{table}");
+    assert!(table.contains("ID"), "{table}");
+    assert!(table.contains("Title"), "{table}");
+    assert!(table.contains("Path"), "{table}");
+    assert!(table.contains("Snippet"), "{table}");
+
+    let stemmed = run_commands(
+        temp_dir.path(),
+        &[&["search", "caching", "--type", "work", "-o", "plain"]],
+    )?;
+    assert!(stemmed.contains("WI-2026-01-01-001"), "{stemmed}");
+
+    let clause = run_commands(
+        temp_dir.path(),
+        &[&["search", "cache", "--type", "clause", "-o", "plain"]],
+    )?;
+    assert!(clause.contains("RFC-0001:C-CACHE"), "{clause}");
+
+    let adr = run_commands(
+        temp_dir.path(),
+        &[&[
+            "search",
+            "cache",
+            "--type",
+            "adr",
+            "--reindex",
+            "-o",
+            "plain",
+        ]],
+    )?;
+    assert!(adr.contains("ADR-0001"), "{adr}");
+    Ok(())
+}
+
+#[test]
+fn test_search_sync_updates_changed_and_deleted_artifacts() -> common::TestResult {
+    let temp_dir = init_project()?;
+    let work_id = "WI-2026-01-01-001";
+    write_work(temp_dir.path(), work_id, "Needle Work", "needle body")?;
+
+    let initial = run_commands(
+        temp_dir.path(),
+        &[&["search", "needle", "--type", "work", "-o", "plain"]],
+    )?;
+    assert!(initial.contains(work_id), "{initial}");
+
+    write_work(temp_dir.path(), work_id, "Haystack Work", "haystack body")?;
+    let stale_query = run_commands(
+        temp_dir.path(),
+        &[&["search", "needle", "--type", "work", "-o", "plain"]],
+    )?;
+    assert!(!stale_query.contains(work_id), "{stale_query}");
+
+    let changed_query = run_commands(
+        temp_dir.path(),
+        &[&["search", "haystack", "--type", "work", "-o", "plain"]],
+    )?;
+    assert!(changed_query.contains(work_id), "{changed_query}");
+
+    fs::remove_file(temp_dir.path().join("gov/work/2026-01-01-search-work.toml"))?;
+    let deleted_query = run_commands(
+        temp_dir.path(),
+        &[&["search", "haystack", "--type", "work", "-o", "plain"]],
+    )?;
+    assert!(!deleted_query.contains(work_id), "{deleted_query}");
+    Ok(())
+}
+
+#[test]
+fn test_search_repairs_manifest_fts_divergence() -> common::TestResult {
+    let temp_dir = init_project()?;
+    let work_id = "WI-2026-01-01-001";
+    let work_path = temp_dir.path().join("gov/work/2026-01-01-search-work.toml");
+    let db_path = temp_dir.path().join(".govctl/index.db");
+    write_work(temp_dir.path(), work_id, "Needle Work", "needle body")?;
+
+    let initial = run_commands(
+        temp_dir.path(),
+        &[&["search", "needle", "--type", "work", "-o", "plain"]],
+    )?;
+    assert!(initial.contains(work_id), "{initial}");
+
+    {
+        let connection = Connection::open(&db_path)?;
+        connection.execute(
+            "DELETE FROM search_fts WHERE kind = 'work' AND id = ?1",
+            [work_id],
+        )?;
+    }
+    let repaired = run_commands(
+        temp_dir.path(),
+        &[&["search", "needle", "--type", "work", "-o", "plain"]],
+    )?;
+    assert!(repaired.contains(work_id), "{repaired}");
+
+    {
+        let connection = Connection::open(&db_path)?;
+        connection.execute(
+            "DELETE FROM search_manifest WHERE kind = 'work' AND id = ?1",
+            [work_id],
+        )?;
+    }
+    fs::remove_file(work_path)?;
+    let orphan_removed = run_commands(
+        temp_dir.path(),
+        &[&["search", "needle", "--type", "work", "-o", "plain"]],
+    )?;
+    assert!(!orphan_removed.contains(work_id), "{orphan_removed}");
+    Ok(())
+}
+
+#[test]
+fn test_search_does_not_index_legacy_work_journal() -> common::TestResult {
+    let temp_dir = init_project()?;
+    write_work_with_journal(temp_dir.path())?;
+
+    let rendered = run_commands(temp_dir.path(), &[&["work", "show", "WI-2026-01-01-002"]])?;
+    assert!(rendered.contains("journalonlytoken"), "{rendered}");
+
+    let search = run_commands(
+        temp_dir.path(),
+        &[&[
+            "search",
+            "journalonlytoken",
+            "--type",
+            "work",
+            "-o",
+            "plain",
+        ]],
+    )?;
+    assert!(!search.contains("WI-2026-01-01-002"), "{search}");
+    Ok(())
+}
+
+#[test]
+fn test_search_rebuilds_unversioned_existing_fts_table() -> common::TestResult {
+    let temp_dir = init_project()?;
+    let db_dir = temp_dir.path().join(".govctl");
+    fs::create_dir_all(&db_dir)?;
+    {
+        let connection = Connection::open(db_dir.join("index.db"))?;
+        connection.execute_batch(
+            "
+            CREATE TABLE search_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE VIRTUAL TABLE search_fts USING fts5(
+                kind UNINDEXED,
+                id UNINDEXED,
+                title,
+                path UNINDEXED,
+                tags UNINDEXED,
+                status UNINDEXED,
+                body
+            );
+            ",
+        )?;
+    }
+    write_work(
+        temp_dir.path(),
+        "WI-2026-01-01-003",
+        "Cache Work",
+        "cache body",
+    )?;
+
+    let search = run_commands(
+        temp_dir.path(),
+        &[&["search", "caching", "--type", "work", "-o", "plain"]],
+    )?;
+    assert!(search.contains("WI-2026-01-01-003"), "{search}");
+    Ok(())
+}


### PR DESCRIPTION
Add a derived .govctl SQLite catalog for direct artifact lookup and a top-level govctl search command backed by FTS5.

Update RFC/ADR governance docs, MSRV/dependencies, rendered docs, changelog, and regression coverage for search freshness, index repair, lookup fallback, and ID/path authority checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ranked govctl search across RFCs/clauses/ADRs/work items/guards with type/tag filters, limits, outputs (table/JSON/plain) and --reindex.
  * Project-local derived search index under .govctl/ with stable output fields (kind,id,title,path,snippet).

* **Behavior Changes**
  * Single-artifact lookups prefer a local artifact catalog and repair/bypass stale entries; search refuses to return results when index freshness is unknown.

* **Documentation**
  * Minimum Rust version raised to 1.96.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->