### PR TITLE
feat(tui): add read-only cockpit views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Release entries are curated summaries for readers. Work item traceability remain
 
 - govctl check no longer prints a checked-count summary before schema/load diagnostics (WI-2026-06-07-001)
 - TUI cockpit keeps list ordering, search cache, loop diagnostics, DAG fallback, and ops summaries consistent (WI-2026-06-07-002)
+- TUI no longer enables mouse capture without handling mouse events (WI-2026-06-07-004)
 
 ## [0.9.2] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ Release entries are curated summaries for readers. Work item traceability remain
 
 ## [Unreleased]
 
+### Added
+
+- RFC-0007 specifies TUI v2 read-only cockpit, loop DAG, search, diagnostics, and human-first UX obligations (WI-2026-06-06-001)
+- Accepted ADR records the TUI v2 read-only cockpit architecture and rejects full CRUD editing for the first phase (WI-2026-06-06-001)
+- TUI dashboard provides human navigation to overview, artifact browsing, search, loops, and diagnostics (WI-2026-06-06-001)
+- TUI loop views list persisted loops and render selected loop dependency DAGs from loop state (WI-2026-06-06-001)
+- TUI search view lets humans query governance artifacts and jump from results to detail views (WI-2026-06-06-001)
+- TUI diagnostics view presents govctl check diagnostics grouped for human review without mutating project state (WI-2026-06-06-001)
+
+### Fixed
+
+- govctl check no longer prints a checked-count summary before schema/load diagnostics (WI-2026-06-07-001)
+- TUI cockpit keeps list ordering, search cache, loop diagnostics, DAG fallback, and ops summaries consistent (WI-2026-06-07-002)
+
 ## [0.9.2] - 2026-06-05
 
 0.9.2 focuses on discovery and lookup performance. It adds a project-wide

--- a/docs/rfc/RFC-0007.md
+++ b/docs/rfc/RFC-0007.md
@@ -1,9 +1,9 @@
 <!-- GENERATED: do not edit. Source: RFC-0007 -->
-<!-- SIGNATURE: sha256:91177e1f7103f1972c47d7e569b8e052f642e507e2ef6874c70aad9727c76881 -->
+<!-- SIGNATURE: sha256:303da9a81b07039277740dbbb6e4012f89153de338c4a25998f0105ba52027db -->
 
 # RFC-0007: TUI v2 read-only cockpit
 
-> **Version:** 0.1.0 | **Status:** normative | **Phase:** test
+> **Version:** 0.2.0 | **Status:** normative | **Phase:** test
 
 **References:** [RFC-0003](../rfc/RFC-0003.md), [RFC-0006](../rfc/RFC-0006.md), [RFC-0002](../rfc/RFC-0002.md)
 
@@ -42,6 +42,28 @@ When TUI v2 presents an operation that would mutate state, it MUST present it as
 **Rationale:** The CLI already owns mutation semantics, dry-run behavior, diagnostics, lock handling, and lifecycle gates. Keeping the first TUI v2 phase read-only gives humans a richer project cockpit without creating a second, weaker edit model.
 
 *Since: v0.1.0*
+
+### [RFC-0007:C-RESPONSIBILITY-BOUNDARIES] TUI responsibility boundaries (Normative) <a id="rfc-0007c-responsibility-boundaries"></a>
+
+TUI v2 MUST keep terminal I/O, input dispatch, data loading, and rendering as separate responsibilities.
+
+The terminal adapter MUST be limited to terminal lifecycle, event polling, event reading, frame drawing, and shutdown handling.
+
+Input dispatch MUST translate keyboard input into in-memory TUI state transitions.
+
+Input dispatch MUST NOT perform filesystem I/O, database access, command execution, terminal drawing, or governed artifact mutation.
+
+Renderers MUST read already-loaded TUI state and draw frames.
+
+Renderers MUST NOT load project artifacts, refresh indexes, execute commands, mutate governed state, or mutate persisted loop state.
+
+Data-loading code MUST convert filesystem, schema, search-index, and loop-state failures into visible diagnostic state rather than hiding them from the cockpit.
+
+New primary views or key-routing behavior SHOULD be covered by focused state-transition tests, renderer tests using a terminal test backend, or both.
+
+**Rationale:** These boundaries keep TUI v2 human-facing, read-only, and testable without creating a second hidden execution model beside the CLI.
+
+*Since: v0.2.0*
 
 ### [RFC-0007:C-COCKPIT-VIEWS] Cockpit view model (Normative) <a id="rfc-0007c-cockpit-views"></a>
 
@@ -150,6 +172,14 @@ When a terminal is too small for the preferred layout, TUI v2 MUST fall back to 
 ---
 
 ## Changelog
+
+### v0.2.0 (2026-06-07)
+
+Specify TUI responsibility boundaries
+
+#### Added
+
+- Require terminal I/O, input dispatch, data loading, and rendering to remain separate testable responsibilities
 
 ### v0.1.0 (2026-06-06)
 

--- a/docs/rfc/RFC-0007.md
+++ b/docs/rfc/RFC-0007.md
@@ -1,0 +1,156 @@
+<!-- GENERATED: do not edit. Source: RFC-0007 -->
+<!-- SIGNATURE: sha256:91177e1f7103f1972c47d7e569b8e052f642e507e2ef6874c70aad9727c76881 -->
+
+# RFC-0007: TUI v2 read-only cockpit
+
+> **Version:** 0.1.0 | **Status:** normative | **Phase:** test
+
+**References:** [RFC-0003](../rfc/RFC-0003.md), [RFC-0006](../rfc/RFC-0006.md), [RFC-0002](../rfc/RFC-0002.md)
+
+---
+
+## 1. Summary
+
+### [RFC-0007:C-SUMMARY] Summary (Informative) <a id="rfc-0007c-summary"></a>
+
+This RFC defines TUI v2 as a human-first, read-only cockpit for understanding a governed project.
+
+TUI v2 builds on the baseline browsing behavior in [RFC-0003](../rfc/RFC-0003.md), the global search contract in [RFC-0002:C-SEARCH-COMMAND](../rfc/RFC-0002.md#rfc-0002c-search-command), and the loop state model in [RFC-0006](../rfc/RFC-0006.md). It focuses on project overview, artifact discovery, loop state visualization, diagnostics, and readable navigation.
+
+**Scope:** This RFC covers externally visible TUI behavior and interaction constraints. It does not specify private Rust module layout, ratatui widget internals, or a full interactive artifact editor.
+
+**Rationale:** The existing TUI is useful for browsing RFCs, ADRs, and work items, but it does not expose newer governance concepts such as search, loop local state, dependency DAGs, guards, releases, or check diagnostics. TUI v2 should help a human understand project state quickly without creating a second mutation surface parallel to the CLI.
+
+*Since: v0.1.0*
+
+---
+
+## 2. Specification
+
+### [RFC-0007:C-READ-ONLY] Read-only cockpit boundary (Normative) <a id="rfc-0007c-read-only"></a>
+
+TUI v2 MUST be read-only for governed project state in its first implementation phase.
+
+TUI v2 MUST NOT create, edit, delete, move, finalize, accept, reject, supersede, deprecate, render, or otherwise mutate governed artifacts.
+
+TUI v2 MUST NOT mutate persisted loop state or round artifacts under `.govctl/loops/`.
+
+TUI v2 MAY refresh disposable derived local indexes under `.govctl/` only when doing so follows the freshness and local-state rules defined by [RFC-0002:C-SEARCH-COMMAND](../rfc/RFC-0002.md#rfc-0002c-search-command).
+
+When TUI v2 presents an operation that would mutate state, it MUST present it as a suggested CLI command or help text rather than executing it.
+
+**Rationale:** The CLI already owns mutation semantics, dry-run behavior, diagnostics, lock handling, and lifecycle gates. Keeping the first TUI v2 phase read-only gives humans a richer project cockpit without creating a second, weaker edit model.
+
+*Since: v0.1.0*
+
+### [RFC-0007:C-COCKPIT-VIEWS] Cockpit view model (Normative) <a id="rfc-0007c-cockpit-views"></a>
+
+TUI v2 MUST provide a top-level human navigation model with visible entry points for overview, artifact browsing, search, loops, and diagnostics.
+
+The overview view MUST summarize at least RFCs, ADRs, work items, and verification guards when those artifacts are available.
+
+The artifact browsing views MUST preserve the existing RFC, ADR, and Work Item browsing capabilities required by [RFC-0003](../rfc/RFC-0003.md).
+
+The artifact browsing views SHOULD include verification guards, clauses, releases, and tags when those data sources can be loaded without violating [RFC-0007:C-READ-ONLY](../rfc/RFC-0007.md#rfc-0007c-read-only).
+
+The current view, selection context, active filter or query, and primary key bindings MUST remain visible or discoverable without leaving the TUI.
+
+**Rationale:** A cockpit should orient a human before asking them to drill into details. The top-level model makes newer governance concepts discoverable while preserving the older RFC/ADR/Work browsing workflows.
+
+*Since: v0.1.0*
+
+### [RFC-0007:C-LOOP-VIEWS] Loop state views (Normative) <a id="rfc-0007c-loop-views"></a>
+
+TUI v2 MUST provide a loop list view that discovers persisted loop states according to [RFC-0006:C-LOOP-LISTING](../rfc/RFC-0006.md#rfc-0006c-loop-listing).
+
+Each listed loop MUST show the loop ID, lifecycle state, editable `work` roots, resolved work item count, aggregate round count, and next action when those values are present in valid loop state.
+
+TUI v2 MUST provide a loop inspector for a selected loop.
+
+The loop inspector MUST show the selected loop's lifecycle state, current round, next action, editable `work` roots, resolved work set, loop-level item statuses, round counts, and dependency information.
+
+If a loop state file is invalid, TUI v2 MUST present a readable diagnostic for that loop and MUST NOT treat invalid loop state as authoritative.
+
+TUI v2 MUST NOT repair, replan, resume, run, or otherwise mutate loop state while rendering loop views.
+
+**Rationale:** Loop state is local but highly useful to humans resuming or auditing work. The TUI should expose this state directly while preserving [RFC-0006](../rfc/RFC-0006.md) ownership of loop execution semantics.
+
+*Since: v0.1.0*
+
+### [RFC-0007:C-LOOP-DAG] Loop dependency DAG visualization (Normative) <a id="rfc-0007c-loop-dag"></a>
+
+TUI v2 MUST render a selected loop's dependency graph as a visual DAG derived from the loop state's `dependencies` table.
+
+The DAG view MUST represent every work item in the loop state's resolved work set unless viewport constraints require an explicit neighborhood or layer-limited fallback.
+
+The DAG view MUST distinguish loop-level item statuses such as `pending`, `active`, `done`, `failed`, `blocked`, and `cancelled` using readable text and semantic styling.
+
+The DAG view MUST make the selected work item visually distinct and MUST show its direct dependencies and direct dependents when that information is available.
+
+The DAG layout MUST be deterministic for the same loop state.
+
+When the graph is too large or the terminal viewport is too small for a full DAG, TUI v2 MUST degrade to a readable representation that still exposes ordering, dependencies, selected item context, and hidden item counts.
+
+**Rationale:** A plain topological list is not enough for humans to understand batch execution. A visual DAG exposes why work is ready, blocked, or downstream of another item while still allowing terminal-size fallbacks.
+
+*Since: v0.1.0*
+
+### [RFC-0007:C-SEARCH] TUI search (Normative) <a id="rfc-0007c-search"></a>
+
+TUI v2 MUST provide a search view for governed artifacts.
+
+The search view MUST interpret query text according to [RFC-0002:C-SEARCH-COMMAND](../rfc/RFC-0002.md#rfc-0002c-search-command) rather than exposing backend-specific raw query syntax.
+
+The search view SHOULD support artifact type filtering and tag filtering when the terminal interaction model can expose those filters clearly.
+
+Search results MUST show at least artifact kind, ID, title, and enough snippet or metadata context for a human to choose a result.
+
+Selecting a search result MUST navigate to the corresponding TUI detail view when that artifact kind is supported by TUI v2.
+
+Search result loading MUST follow the read-only boundary in [RFC-0007:C-READ-ONLY](../rfc/RFC-0007.md#rfc-0007c-read-only).
+
+**Rationale:** Search is the fastest way for humans to recover context in a large governed repository. Reusing the CLI search contract prevents TUI search from drifting into a separate discovery model.
+
+*Since: v0.1.0*
+
+### [RFC-0007:C-DIAGNOSTICS] Diagnostics view (Normative) <a id="rfc-0007c-diagnostics"></a>
+
+TUI v2 MUST provide a diagnostics view that presents project check diagnostics to a human.
+
+The diagnostics view MUST show diagnostic severity, code, message, and target context when those fields are available.
+
+The diagnostics view SHOULD group or filter diagnostics by severity and artifact target.
+
+When a diagnostic target corresponds to an artifact that TUI v2 can display, selecting the diagnostic SHOULD navigate to that artifact's detail view or an equivalent contextual view.
+
+The diagnostics view MUST NOT automatically apply migrations, edit artifacts, render documents, or run mutation commands to resolve diagnostics.
+
+**Rationale:** `govctl check` is the central safety signal for governed work. TUI v2 should make those diagnostics easier for a human to triage without turning validation into an implicit repair workflow.
+
+*Since: v0.1.0*
+
+### [RFC-0007:C-HUMAN-UX] Human-first terminal UX (Normative) <a id="rfc-0007c-human-ux"></a>
+
+TUI v2 MUST optimize rendered screens for human comprehension rather than machine parsing.
+
+TUI v2 MUST use consistent semantic styling for artifact kind, lifecycle status, phase, diagnostic severity, loop item status, selection, and muted secondary information.
+
+TUI v2 MUST preserve keyboard-only navigation across all primary views.
+
+TUI v2 MUST expose view-specific key bindings through persistent footer text, help overlay, or an equivalent discoverable mechanism.
+
+TUI v2 MUST avoid layouts where essential text overlaps, truncates without context, or becomes unreadable on common narrow terminal widths.
+
+When a terminal is too small for the preferred layout, TUI v2 MUST fall back to a simpler readable layout rather than preserving a broken multi-pane layout.
+
+**Rationale:** A human-facing terminal UI succeeds when state, hierarchy, and next steps are quickly legible. Visual polish should come from semantic consistency and resilient layout, not from decorative complexity.
+
+*Since: v0.1.0*
+
+---
+
+## Changelog
+
+### v0.1.0 (2026-06-06)
+
+Initial draft

--- a/gov/adr/ADR-0049-adopt-read-only-cockpit-model-for-tui-v2.toml
+++ b/gov/adr/ADR-0049-adopt-read-only-cockpit-model-for-tui-v2.toml
@@ -1,0 +1,105 @@
+#:schema ../schema/adr.schema.json
+
+[govctl]
+id = "ADR-0049"
+title = "Adopt read-only cockpit model for TUI v2"
+status = "accepted"
+date = "2026-06-06"
+refs = [
+    "RFC-0007",
+    "RFC-0003",
+    "RFC-0006",
+    "RFC-0002",
+]
+tags = ["tui"]
+
+[content]
+context = """
+TUI v2 needs to become more useful and more readable for humans working in a governed repository.
+
+### Problem Statement
+
+The current TUI is primarily a dashboard plus RFC/ADR/work item browser. It does not expose newer governance concepts such as project-wide search, persisted loop state, dependency DAGs, or check diagnostics. At the same time, govctl already has a mature CLI mutation model for edits, lifecycle transitions, dry-run behavior, diagnostics, and write locking.
+
+### Constraints
+
+- [[RFC-0003]] defines the existing TUI browsing baseline.
+- [[RFC-0007]] defines TUI v2 behavior for a read-only cockpit.
+- [[RFC-0002]] owns CLI resource and search semantics.
+- [[RFC-0006]] owns loop state and loop execution semantics.
+- First-phase TUI v2 must serve humans, not agents or machine parsing.
+
+### Options Considered
+
+We considered keeping the current TUI and adding isolated views, building a full CRUD TUI editor, and building a read-only human cockpit with loop DAG visualization."""
+decision = """
+We will **build TUI v2 as a read-only human cockpit with loop DAG visualization**.
+
+The first phase of TUI v2 will focus on human understanding: project overview, artifact browsing, search, persisted loop state, dependency DAGs, and diagnostics. It will not implement artifact editing, lifecycle transitions, loop execution, migration, rendering, or other mutations.
+
+### Implementation Notes
+
+- TUI v2 may show suggested CLI commands for mutating workflows, but it must not execute those mutations.
+- Loop DAG rendering should use persisted loop state from [[RFC-0006]] rather than recomputing a separate execution model.
+- Search behavior should reuse [[RFC-0002:C-SEARCH-COMMAND]] semantics instead of introducing TUI-only query behavior.
+- Responsive terminal layouts should degrade to readable simpler views rather than preserving broken multi-pane layouts."""
+consequences = """
+### Positive
+
+- TUI v2 gets a coherent product shape instead of another set of isolated list/detail additions.
+- Humans can inspect project state, search context, loop progress, DAG dependencies, and diagnostics from one terminal surface.
+- The existing CLI remains the single mutation authority for artifact edits, lifecycle transitions, loop execution, rendering, dry-run, and locking.
+- The loop DAG view makes dependency readiness and blocked downstream work understandable without reading raw state files.
+
+### Negative
+
+- Users who want a full terminal editor must still switch to CLI commands for mutations. Mitigation: TUI v2 can display suggested commands without executing them.
+- Visual DAG layout adds complexity that simple lists do not have. Mitigation: keep the layout deterministic, test the data model separately from widget rendering, and provide readable fallbacks for large graphs or narrow terminals.
+- Search and diagnostics views may expose more information than fits comfortably on small terminals. Mitigation: prioritize stable summaries, selected-item inspectors, and responsive single-column fallbacks.
+
+### Neutral
+
+- This decision does not prevent future write-capable TUI workflows. It requires those workflows to be designed later against the existing edit model, dry-run behavior, diagnostics, and write-lock rules.
+- Disposable `.govctl` search/catalog index refresh remains acceptable when governed by the existing search freshness contract; persisted loop state remains read-only in the TUI."""
+
+[[content.alternatives]]
+text = "Keep current TUI and add isolated feature views"
+status = "rejected"
+pros = [
+    "Smallest incremental change",
+    "Low initial implementation risk",
+]
+cons = [
+    "Leaves dashboard/list/detail as the organizing model",
+    "Makes search, loops, and diagnostics feel bolted on",
+    "Does not establish a coherent human cockpit information architecture",
+]
+rejection_reason = "This would continue the existing pattern of isolated TUI additions rather than solving the product shape problem."
+
+[[content.alternatives]]
+text = "Build a full interactive CRUD TUI editor"
+status = "rejected"
+pros = [
+    "Provides one integrated terminal surface for browsing and editing",
+    "Could be attractive for humans who prefer TUI workflows",
+]
+cons = [
+    "Duplicates CLI edit, lifecycle, dry-run, diagnostics, and lock semantics",
+    "Raises risk of a weaker parallel mutation model",
+    "Greatly expands first-phase scope before the cockpit model is proven",
+]
+rejection_reason = "First-phase TUI v2 should not create a second mutation surface parallel to the governed CLI."
+
+[[content.alternatives]]
+text = "Build a read-only human cockpit with loop DAG visualization"
+status = "accepted"
+pros = [
+    "Creates one coherent product shape for overview, browsing, search, loops, and diagnostics",
+    "Preserves CLI ownership of mutations and lifecycle gates",
+    "Makes loop dependency state understandable to humans through a visual DAG",
+    "Can be implemented and tested incrementally without weakening artifact authority",
+]
+cons = [
+    "Users still need to run CLI commands for edits and lifecycle transitions",
+    "DAG layout and responsive terminal rendering add UI complexity",
+]

--- a/gov/rfc/RFC-0007/clauses/C-COCKPIT-VIEWS.toml
+++ b/gov/rfc/RFC-0007/clauses/C-COCKPIT-VIEWS.toml
@@ -1,0 +1,22 @@
+#:schema ../../../schema/clause.schema.json
+
+[govctl]
+id = "C-COCKPIT-VIEWS"
+title = "Cockpit view model"
+kind = "normative"
+status = "active"
+since = "0.1.0"
+
+[content]
+text = """
+TUI v2 MUST provide a top-level human navigation model with visible entry points for overview, artifact browsing, search, loops, and diagnostics.
+
+The overview view MUST summarize at least RFCs, ADRs, work items, and verification guards when those artifacts are available.
+
+The artifact browsing views MUST preserve the existing RFC, ADR, and Work Item browsing capabilities required by [[RFC-0003]].
+
+The artifact browsing views SHOULD include verification guards, clauses, releases, and tags when those data sources can be loaded without violating [[RFC-0007:C-READ-ONLY]].
+
+The current view, selection context, active filter or query, and primary key bindings MUST remain visible or discoverable without leaving the TUI.
+
+**Rationale:** A cockpit should orient a human before asking them to drill into details. The top-level model makes newer governance concepts discoverable while preserving the older RFC/ADR/Work browsing workflows."""

--- a/gov/rfc/RFC-0007/clauses/C-DIAGNOSTICS.toml
+++ b/gov/rfc/RFC-0007/clauses/C-DIAGNOSTICS.toml
@@ -1,0 +1,22 @@
+#:schema ../../../schema/clause.schema.json
+
+[govctl]
+id = "C-DIAGNOSTICS"
+title = "Diagnostics view"
+kind = "normative"
+status = "active"
+since = "0.1.0"
+
+[content]
+text = """
+TUI v2 MUST provide a diagnostics view that presents project check diagnostics to a human.
+
+The diagnostics view MUST show diagnostic severity, code, message, and target context when those fields are available.
+
+The diagnostics view SHOULD group or filter diagnostics by severity and artifact target.
+
+When a diagnostic target corresponds to an artifact that TUI v2 can display, selecting the diagnostic SHOULD navigate to that artifact's detail view or an equivalent contextual view.
+
+The diagnostics view MUST NOT automatically apply migrations, edit artifacts, render documents, or run mutation commands to resolve diagnostics.
+
+**Rationale:** `govctl check` is the central safety signal for governed work. TUI v2 should make those diagnostics easier for a human to triage without turning validation into an implicit repair workflow."""

--- a/gov/rfc/RFC-0007/clauses/C-HUMAN-UX.toml
+++ b/gov/rfc/RFC-0007/clauses/C-HUMAN-UX.toml
@@ -1,0 +1,24 @@
+#:schema ../../../schema/clause.schema.json
+
+[govctl]
+id = "C-HUMAN-UX"
+title = "Human-first terminal UX"
+kind = "normative"
+status = "active"
+since = "0.1.0"
+
+[content]
+text = """
+TUI v2 MUST optimize rendered screens for human comprehension rather than machine parsing.
+
+TUI v2 MUST use consistent semantic styling for artifact kind, lifecycle status, phase, diagnostic severity, loop item status, selection, and muted secondary information.
+
+TUI v2 MUST preserve keyboard-only navigation across all primary views.
+
+TUI v2 MUST expose view-specific key bindings through persistent footer text, help overlay, or an equivalent discoverable mechanism.
+
+TUI v2 MUST avoid layouts where essential text overlaps, truncates without context, or becomes unreadable on common narrow terminal widths.
+
+When a terminal is too small for the preferred layout, TUI v2 MUST fall back to a simpler readable layout rather than preserving a broken multi-pane layout.
+
+**Rationale:** A human-facing terminal UI succeeds when state, hierarchy, and next steps are quickly legible. Visual polish should come from semantic consistency and resilient layout, not from decorative complexity."""

--- a/gov/rfc/RFC-0007/clauses/C-LOOP-DAG.toml
+++ b/gov/rfc/RFC-0007/clauses/C-LOOP-DAG.toml
@@ -1,0 +1,24 @@
+#:schema ../../../schema/clause.schema.json
+
+[govctl]
+id = "C-LOOP-DAG"
+title = "Loop dependency DAG visualization"
+kind = "normative"
+status = "active"
+since = "0.1.0"
+
+[content]
+text = """
+TUI v2 MUST render a selected loop's dependency graph as a visual DAG derived from the loop state's `dependencies` table.
+
+The DAG view MUST represent every work item in the loop state's resolved work set unless viewport constraints require an explicit neighborhood or layer-limited fallback.
+
+The DAG view MUST distinguish loop-level item statuses such as `pending`, `active`, `done`, `failed`, `blocked`, and `cancelled` using readable text and semantic styling.
+
+The DAG view MUST make the selected work item visually distinct and MUST show its direct dependencies and direct dependents when that information is available.
+
+The DAG layout MUST be deterministic for the same loop state.
+
+When the graph is too large or the terminal viewport is too small for a full DAG, TUI v2 MUST degrade to a readable representation that still exposes ordering, dependencies, selected item context, and hidden item counts.
+
+**Rationale:** A plain topological list is not enough for humans to understand batch execution. A visual DAG exposes why work is ready, blocked, or downstream of another item while still allowing terminal-size fallbacks."""

--- a/gov/rfc/RFC-0007/clauses/C-LOOP-VIEWS.toml
+++ b/gov/rfc/RFC-0007/clauses/C-LOOP-VIEWS.toml
@@ -1,0 +1,24 @@
+#:schema ../../../schema/clause.schema.json
+
+[govctl]
+id = "C-LOOP-VIEWS"
+title = "Loop state views"
+kind = "normative"
+status = "active"
+since = "0.1.0"
+
+[content]
+text = """
+TUI v2 MUST provide a loop list view that discovers persisted loop states according to [[RFC-0006:C-LOOP-LISTING]].
+
+Each listed loop MUST show the loop ID, lifecycle state, editable `work` roots, resolved work item count, aggregate round count, and next action when those values are present in valid loop state.
+
+TUI v2 MUST provide a loop inspector for a selected loop.
+
+The loop inspector MUST show the selected loop's lifecycle state, current round, next action, editable `work` roots, resolved work set, loop-level item statuses, round counts, and dependency information.
+
+If a loop state file is invalid, TUI v2 MUST present a readable diagnostic for that loop and MUST NOT treat invalid loop state as authoritative.
+
+TUI v2 MUST NOT repair, replan, resume, run, or otherwise mutate loop state while rendering loop views.
+
+**Rationale:** Loop state is local but highly useful to humans resuming or auditing work. The TUI should expose this state directly while preserving [[RFC-0006]] ownership of loop execution semantics."""

--- a/gov/rfc/RFC-0007/clauses/C-READ-ONLY.toml
+++ b/gov/rfc/RFC-0007/clauses/C-READ-ONLY.toml
@@ -1,0 +1,22 @@
+#:schema ../../../schema/clause.schema.json
+
+[govctl]
+id = "C-READ-ONLY"
+title = "Read-only cockpit boundary"
+kind = "normative"
+status = "active"
+since = "0.1.0"
+
+[content]
+text = """
+TUI v2 MUST be read-only for governed project state in its first implementation phase.
+
+TUI v2 MUST NOT create, edit, delete, move, finalize, accept, reject, supersede, deprecate, render, or otherwise mutate governed artifacts.
+
+TUI v2 MUST NOT mutate persisted loop state or round artifacts under `.govctl/loops/`.
+
+TUI v2 MAY refresh disposable derived local indexes under `.govctl/` only when doing so follows the freshness and local-state rules defined by [[RFC-0002:C-SEARCH-COMMAND]].
+
+When TUI v2 presents an operation that would mutate state, it MUST present it as a suggested CLI command or help text rather than executing it.
+
+**Rationale:** The CLI already owns mutation semantics, dry-run behavior, diagnostics, lock handling, and lifecycle gates. Keeping the first TUI v2 phase read-only gives humans a richer project cockpit without creating a second, weaker edit model."""

--- a/gov/rfc/RFC-0007/clauses/C-RESPONSIBILITY-BOUNDARIES.toml
+++ b/gov/rfc/RFC-0007/clauses/C-RESPONSIBILITY-BOUNDARIES.toml
@@ -1,0 +1,28 @@
+#:schema ../../../schema/clause.schema.json
+
+[govctl]
+id = "C-RESPONSIBILITY-BOUNDARIES"
+title = "TUI responsibility boundaries"
+kind = "normative"
+status = "active"
+since = "0.2.0"
+
+[content]
+text = """
+TUI v2 MUST keep terminal I/O, input dispatch, data loading, and rendering as separate responsibilities.
+
+The terminal adapter MUST be limited to terminal lifecycle, event polling, event reading, frame drawing, and shutdown handling.
+
+Input dispatch MUST translate keyboard input into in-memory TUI state transitions.
+
+Input dispatch MUST NOT perform filesystem I/O, database access, command execution, terminal drawing, or governed artifact mutation.
+
+Renderers MUST read already-loaded TUI state and draw frames.
+
+Renderers MUST NOT load project artifacts, refresh indexes, execute commands, mutate governed state, or mutate persisted loop state.
+
+Data-loading code MUST convert filesystem, schema, search-index, and loop-state failures into visible diagnostic state rather than hiding them from the cockpit.
+
+New primary views or key-routing behavior SHOULD be covered by focused state-transition tests, renderer tests using a terminal test backend, or both.
+
+**Rationale:** These boundaries keep TUI v2 human-facing, read-only, and testable without creating a second hidden execution model beside the CLI."""

--- a/gov/rfc/RFC-0007/clauses/C-SEARCH.toml
+++ b/gov/rfc/RFC-0007/clauses/C-SEARCH.toml
@@ -1,0 +1,24 @@
+#:schema ../../../schema/clause.schema.json
+
+[govctl]
+id = "C-SEARCH"
+title = "TUI search"
+kind = "normative"
+status = "active"
+since = "0.1.0"
+
+[content]
+text = """
+TUI v2 MUST provide a search view for governed artifacts.
+
+The search view MUST interpret query text according to [[RFC-0002:C-SEARCH-COMMAND]] rather than exposing backend-specific raw query syntax.
+
+The search view SHOULD support artifact type filtering and tag filtering when the terminal interaction model can expose those filters clearly.
+
+Search results MUST show at least artifact kind, ID, title, and enough snippet or metadata context for a human to choose a result.
+
+Selecting a search result MUST navigate to the corresponding TUI detail view when that artifact kind is supported by TUI v2.
+
+Search result loading MUST follow the read-only boundary in [[RFC-0007:C-READ-ONLY]].
+
+**Rationale:** Search is the fastest way for humans to recover context in a large governed repository. Reusing the CLI search contract prevents TUI search from drifting into a separate discovery model."""

--- a/gov/rfc/RFC-0007/clauses/C-SUMMARY.toml
+++ b/gov/rfc/RFC-0007/clauses/C-SUMMARY.toml
@@ -1,0 +1,18 @@
+#:schema ../../../schema/clause.schema.json
+
+[govctl]
+id = "C-SUMMARY"
+title = "Summary"
+kind = "informative"
+status = "active"
+since = "0.1.0"
+
+[content]
+text = """
+This RFC defines TUI v2 as a human-first, read-only cockpit for understanding a governed project.
+
+TUI v2 builds on the baseline browsing behavior in [[RFC-0003]], the global search contract in [[RFC-0002:C-SEARCH-COMMAND]], and the loop state model in [[RFC-0006]]. It focuses on project overview, artifact discovery, loop state visualization, diagnostics, and readable navigation.
+
+**Scope:** This RFC covers externally visible TUI behavior and interaction constraints. It does not specify private Rust module layout, ratatui widget internals, or a full interactive artifact editor.
+
+**Rationale:** The existing TUI is useful for browsing RFCs, ADRs, and work items, but it does not expose newer governance concepts such as search, loop local state, dependency DAGs, guards, releases, or check diagnostics. TUI v2 should help a human understand project state quickly without creating a second mutation surface parallel to the CLI."""

--- a/gov/rfc/RFC-0007/rfc.toml
+++ b/gov/rfc/RFC-0007/rfc.toml
@@ -3,18 +3,19 @@
 [govctl]
 id = "RFC-0007"
 title = "TUI v2 read-only cockpit"
-version = "0.1.0"
+version = "0.2.0"
 status = "normative"
 phase = "test"
 owners = ["@govctl-org"]
 created = "2026-06-06"
-updated = "2026-06-06"
+updated = "2026-06-07"
 refs = [
     "RFC-0003",
     "RFC-0006",
     "RFC-0002",
 ]
 tags = ["tui"]
+signature = "e281def7edbba823ed931af760b3830cef9aa2b77049ebc4f6d0faebb24f9491"
 
 [[sections]]
 title = "Summary"
@@ -24,6 +25,7 @@ clauses = ["clauses/C-SUMMARY.toml"]
 title = "Specification"
 clauses = [
     "clauses/C-READ-ONLY.toml",
+    "clauses/C-RESPONSIBILITY-BOUNDARIES.toml",
     "clauses/C-COCKPIT-VIEWS.toml",
     "clauses/C-LOOP-VIEWS.toml",
     "clauses/C-LOOP-DAG.toml",
@@ -31,6 +33,12 @@ clauses = [
     "clauses/C-DIAGNOSTICS.toml",
     "clauses/C-HUMAN-UX.toml",
 ]
+
+[[changelog]]
+version = "0.2.0"
+date = "2026-06-07"
+notes = "Specify TUI responsibility boundaries"
+added = ["Require terminal I/O, input dispatch, data loading, and rendering to remain separate testable responsibilities"]
 
 [[changelog]]
 version = "0.1.0"

--- a/gov/rfc/RFC-0007/rfc.toml
+++ b/gov/rfc/RFC-0007/rfc.toml
@@ -1,0 +1,38 @@
+#:schema ../../schema/rfc.schema.json
+
+[govctl]
+id = "RFC-0007"
+title = "TUI v2 read-only cockpit"
+version = "0.1.0"
+status = "normative"
+phase = "test"
+owners = ["@govctl-org"]
+created = "2026-06-06"
+updated = "2026-06-06"
+refs = [
+    "RFC-0003",
+    "RFC-0006",
+    "RFC-0002",
+]
+tags = ["tui"]
+
+[[sections]]
+title = "Summary"
+clauses = ["clauses/C-SUMMARY.toml"]
+
+[[sections]]
+title = "Specification"
+clauses = [
+    "clauses/C-READ-ONLY.toml",
+    "clauses/C-COCKPIT-VIEWS.toml",
+    "clauses/C-LOOP-VIEWS.toml",
+    "clauses/C-LOOP-DAG.toml",
+    "clauses/C-SEARCH.toml",
+    "clauses/C-DIAGNOSTICS.toml",
+    "clauses/C-HUMAN-UX.toml",
+]
+
+[[changelog]]
+version = "0.1.0"
+date = "2026-06-06"
+notes = "Initial draft"

--- a/gov/work/2026-06-06-implement-tui-v2-read-only-cockpit.toml
+++ b/gov/work/2026-06-06-implement-tui-v2-read-only-cockpit.toml
@@ -1,0 +1,59 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-06-06-001"
+title = "Implement TUI v2 read-only cockpit"
+status = "done"
+created = "2026-06-06"
+started = "2026-06-06"
+completed = "2026-06-06"
+refs = [
+    "RFC-0003",
+    "RFC-0006",
+    "RFC-0002",
+    "RFC-0007",
+    "ADR-0049",
+]
+
+[content]
+description = "Implement TUI v2 as a human-first, read-only project cockpit. The work updates the TUI specification, records the architectural decision to avoid first-phase write operations, and implements richer navigation for project overview, artifact discovery, loop state with dependency DAG visualization, diagnostics, and searchable governance context."
+
+[[content.acceptance_criteria]]
+text = "RFC-0007 specifies TUI v2 read-only cockpit, loop DAG, search, diagnostics, and human-first UX obligations"
+status = "done"
+category = "added"
+
+[[content.acceptance_criteria]]
+text = "Accepted ADR records the TUI v2 read-only cockpit architecture and rejects full CRUD editing for the first phase"
+status = "done"
+category = "added"
+
+[[content.acceptance_criteria]]
+text = "TUI dashboard provides human navigation to overview, artifact browsing, search, loops, and diagnostics"
+status = "done"
+category = "added"
+
+[[content.acceptance_criteria]]
+text = "TUI loop views list persisted loops and render selected loop dependency DAGs from loop state"
+status = "done"
+category = "added"
+
+[[content.acceptance_criteria]]
+text = "TUI search view lets humans query governance artifacts and jump from results to detail views"
+status = "done"
+category = "added"
+
+[[content.acceptance_criteria]]
+text = "TUI diagnostics view presents govctl check diagnostics grouped for human review without mutating project state"
+status = "done"
+category = "added"
+
+[[content.acceptance_criteria]]
+text = "Focused TUI tests cover loop DAG layout/rendering, loop list loading, search navigation, diagnostics presentation, and responsive rendering"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "govctl check and cargo test pass"
+status = "done"
+category = "chore"

--- a/gov/work/2026-06-07-fix-check-summary-on-schema-load-errors.toml
+++ b/gov/work/2026-06-07-fix-check-summary-on-schema-load-errors.toml
@@ -1,0 +1,27 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-06-07-001"
+title = "Fix check summary on schema load errors"
+status = "done"
+created = "2026-06-07"
+started = "2026-06-07"
+completed = "2026-06-07"
+
+[content]
+description = "Fix the check command regression where schema/load failures print a successful-looking checked summary before diagnostics, causing CI snapshot failures and confusing output."
+
+[[content.acceptance_criteria]]
+text = "govctl check passes"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "govctl check no longer prints a checked-count summary before schema/load diagnostics"
+status = "done"
+category = "fixed"
+
+[[content.acceptance_criteria]]
+text = "failing RFC/clause wire-format snapshot tests pass"
+status = "done"
+category = "chore"

--- a/gov/work/2026-06-07-fix-tui-cockpit-review-findings.toml
+++ b/gov/work/2026-06-07-fix-tui-cockpit-review-findings.toml
@@ -1,0 +1,23 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-06-07-002"
+title = "Fix TUI cockpit review findings"
+status = "done"
+created = "2026-06-07"
+started = "2026-06-07"
+completed = "2026-06-07"
+refs = ["RFC-0007"]
+
+[content]
+description = "Fix verified TUI cockpit review findings: sorted supplement loading, stale search cache invalidation, loop-state IO diagnostics, DAG fallback/error visibility, ops totals, and RFC-0007 traceability comments."
+
+[[content.acceptance_criteria]]
+text = "TUI tests and govctl check pass"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "TUI cockpit keeps list ordering, search cache, loop diagnostics, DAG fallback, and ops summaries consistent"
+status = "done"
+category = "fixed"

--- a/gov/work/2026-06-07-improve-tui-testability-and-coverage.toml
+++ b/gov/work/2026-06-07-improve-tui-testability-and-coverage.toml
@@ -1,0 +1,28 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-06-07-003"
+title = "Improve TUI testability and coverage"
+status = "done"
+created = "2026-06-07"
+started = "2026-06-07"
+completed = "2026-06-07"
+refs = ["RFC-0007"]
+
+[content]
+description = "Improve TUI testability and coverage by extracting key dispatch from terminal IO and adding focused render/dispatch tests for TUI chrome, help, lists, and navigation paths."
+
+[[content.acceptance_criteria]]
+text = "TUI key dispatch is testable without terminal IO"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "TUI chrome, help, and list renderers have focused coverage"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "govctl check and TUI tests pass"
+status = "done"
+category = "chore"

--- a/gov/work/2026-06-07-remove-unused-tui-mouse-capture.toml
+++ b/gov/work/2026-06-07-remove-unused-tui-mouse-capture.toml
@@ -1,0 +1,23 @@
+#:schema ../schema/work.schema.json
+
+[govctl]
+id = "WI-2026-06-07-004"
+title = "Remove unused TUI mouse capture"
+status = "done"
+created = "2026-06-07"
+started = "2026-06-07"
+completed = "2026-06-07"
+refs = ["RFC-0007"]
+
+[content]
+description = "Remove unused mouse capture from the read-only TUI so terminal selection and copy behavior are not intercepted when no mouse events are handled."
+
+[[content.acceptance_criteria]]
+text = "govctl check and TUI tests pass"
+status = "done"
+category = "chore"
+
+[[content.acceptance_criteria]]
+text = "TUI no longer enables mouse capture without handling mouse events"
+status = "done"
+category = "fixed"

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -15,7 +15,59 @@ use crate::verification;
 
 /// Validate all governed documents
 pub fn check_all(config: &Config) -> DiagnosticResult<Diagnostics> {
+    let (all_diagnostics, summary) = collect_diagnostics(config)?;
+
+    if summary.project_loaded {
+        // Print summary (colorized)
+        ui::check_header();
+        ui::check_count(summary.rfc_count, "RFCs");
+        ui::check_count(summary.clause_count, "clauses");
+        ui::check_count(summary.adr_count, "ADRs");
+        ui::check_count(summary.work_count, "work items");
+        ui::check_count(summary.guard_count, "verification guards");
+
+        // Show source scan summary if enabled
+        if config.source_scan.enabled {
+            ui::check_count(summary.files_scanned, "source files scanned");
+            ui::check_count(summary.refs_found, "references found");
+        }
+
+        eprintln!();
+    }
+
+    let has_blocking_diagnostics = all_diagnostics.iter().any(|diag| {
+        matches!(
+            diag.level,
+            DiagnosticLevel::Error | DiagnosticLevel::Warning
+        )
+    });
+    if !has_blocking_diagnostics {
+        ui::success("All checks passed");
+    }
+
+    Ok(all_diagnostics)
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct CheckSummary {
+    pub project_loaded: bool,
+    pub rfc_count: usize,
+    pub clause_count: usize,
+    pub adr_count: usize,
+    pub work_count: usize,
+    pub guard_count: usize,
+    pub files_scanned: usize,
+    pub refs_found: usize,
+}
+
+/// Collect check diagnostics without printing. Used by read-only views such as
+/// the TUI so diagnostics can be rendered inside the terminal frame. Implements
+/// [[RFC-0007:C-DIAGNOSTICS]] for the read-only cockpit diagnostics model.
+pub(crate) fn collect_diagnostics(
+    config: &Config,
+) -> DiagnosticResult<(Diagnostics, CheckSummary)> {
     let mut all_diagnostics = Vec::new();
+    let mut summary = CheckSummary::default();
 
     // Pre-load support checks implement [[RFC-0002:C-GLOBAL-COMMANDS]].
     // They run before artifact loading because stale local schemas can reject
@@ -40,21 +92,25 @@ pub fn check_all(config: &Config) -> DiagnosticResult<Diagnostics> {
         Ok(result) => result,
         Err(diags) => {
             all_diagnostics.extend(diags);
-            return Ok(all_diagnostics);
+            return Ok((all_diagnostics, summary));
         }
     };
 
     let index = load_result.index;
+    summary.project_loaded = true;
     all_diagnostics.extend(load_result.warnings);
 
     // Validate governance artifacts
     let result = validate_project(&index, config);
+    summary.rfc_count = result.rfc_count;
+    summary.clause_count = result.clause_count;
+    summary.adr_count = result.adr_count;
+    summary.work_count = result.work_count;
     all_diagnostics.extend(result.diagnostics);
 
-    let mut guard_count = 0usize;
     match load_guards_with_warnings(config) {
         Ok(result) => {
-            guard_count = result.items.len();
+            summary.guard_count = result.items.len();
             all_diagnostics.extend(result.warnings);
             let (guards_by_id, guard_diags) = verification::build_guard_index(result.items);
             all_diagnostics.extend(guard_diags);
@@ -77,35 +133,11 @@ pub fn check_all(config: &Config) -> DiagnosticResult<Diagnostics> {
 
     // Scan source code for references (if enabled)
     let scan_result = scan_source_refs(config, &index);
+    summary.files_scanned = scan_result.files_scanned;
+    summary.refs_found = scan_result.refs_found;
     all_diagnostics.extend(scan_result.diagnostics);
 
-    // Print summary (colorized)
-    ui::check_header();
-    ui::check_count(result.rfc_count, "RFCs");
-    ui::check_count(result.clause_count, "clauses");
-    ui::check_count(result.adr_count, "ADRs");
-    ui::check_count(result.work_count, "work items");
-    ui::check_count(guard_count, "verification guards");
-
-    // Show source scan summary if enabled
-    if config.source_scan.enabled {
-        ui::check_count(scan_result.files_scanned, "source files scanned");
-        ui::check_count(scan_result.refs_found, "references found");
-    }
-
-    eprintln!();
-
-    let has_blocking_diagnostics = all_diagnostics.iter().any(|diag| {
-        matches!(
-            diag.level,
-            DiagnosticLevel::Error | DiagnosticLevel::Warning
-        )
-    });
-    if !has_blocking_diagnostics {
-        ui::success("All checks passed");
-    }
-
-    Ok(all_diagnostics)
+    Ok((all_diagnostics, summary))
 }
 
 /// Fast-path: assert that at least one active work item exists.

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -57,21 +57,37 @@ pub fn search(
     output: OutputFormat,
     reindex: bool,
 ) -> DiagnosticResult<Diagnostics> {
+    let results = search_results(config, query, type_filters, tag_filters, limit, reindex)?;
+    print_results(&results, output);
+    Ok(vec![])
+}
+
+/// Return search results for read-only callers such as the TUI. Implements
+/// [[RFC-0007:C-SEARCH]], [[RFC-0007:C-READ-ONLY]], and
+/// [[RFC-0002:C-SEARCH-COMMAND]].
+pub(crate) fn search_results(
+    config: &Config,
+    query: &[String],
+    type_filters: &[ListTarget],
+    tag_filters: &[String],
+    limit: Option<usize>,
+    reindex: bool,
+) -> DiagnosticResult<Vec<SearchResult>> {
     let terms = query_terms(query)?;
     let kinds = kinds_for_filters(type_filters);
     let connection = open_search_index(config)?;
+    // Implements [[RFC-0007:C-READ-ONLY]] via disposable derived-index refresh.
     sync_search_index(config, &connection, &kinds, reindex)?;
 
-    let results = query_index(
+    // Implements [[RFC-0007:C-SEARCH]] using [[RFC-0002:C-SEARCH-COMMAND]] semantics.
+    query_index(
         config,
         &connection,
         &terms,
         &kinds,
         tag_filters,
         limit.unwrap_or(DEFAULT_LIMIT),
-    )?;
-    print_results(&results, output);
-    Ok(vec![])
+    )
 }
 
 fn query_terms(query: &[String]) -> DiagnosticResult<Vec<String>> {

--- a/src/tui/app/filter.rs
+++ b/src/tui/app/filter.rs
@@ -1,4 +1,5 @@
 use super::{App, View};
+use crate::diagnostic::DiagnosticLevel;
 
 fn fields_match_normalized_query(query: &str, fields: &[&str]) -> bool {
     fields
@@ -11,12 +12,20 @@ impl App {
     pub fn list_total_len(&self) -> usize {
         match self.view {
             View::RfcList => self.index.rfcs.len(),
+            View::ClauseList => self.supplement.clauses.len(),
             View::AdrList => self.index.adrs.len(),
             View::WorkList => self.index.work_items.len(),
+            View::GuardList => self.supplement.guards.len(),
+            View::ReleaseList => self.supplement.releases.len(),
+            View::TagList => self.supplement.tags.len(),
+            View::Search => self.search_results.len(),
+            View::LoopList => self.supplement.loops.len(),
+            View::DiagnosticList => self.supplement.diagnostics.len(),
             _ => 0,
         }
     }
 
+    // Implements [[RFC-0007:C-COCKPIT-VIEWS]]: cached list indices follow view data.
     pub(super) fn invalidate_indices(&mut self) {
         self.indices_dirty = true;
     }
@@ -44,6 +53,32 @@ impl App {
                             rfc.rfc.title.as_str(),
                             rfc.rfc.status.as_ref(),
                             rfc.rfc.phase.as_ref(),
+                        ],
+                    ) {
+                        Some(idx)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            View::ClauseList => self
+                .supplement
+                .clauses
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, entry)| {
+                    if !has_query {
+                        return Some(idx);
+                    }
+                    let clause = &entry.clause.spec;
+                    if fields_match_normalized_query(
+                        &query,
+                        &[
+                            entry.rfc_id.as_str(),
+                            clause.clause_id.as_str(),
+                            clause.title.as_str(),
+                            clause.status.as_ref(),
+                            clause.kind.as_ref(),
                         ],
                     ) {
                         Some(idx)
@@ -86,6 +121,135 @@ impl App {
                         &query,
                         &[meta.id.as_str(), meta.title.as_str(), meta.status.as_ref()],
                     ) {
+                        Some(idx)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            View::GuardList => self
+                .supplement
+                .guards
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, guard)| {
+                    if !has_query {
+                        return Some(idx);
+                    }
+                    let meta = guard.meta();
+                    if fields_match_normalized_query(
+                        &query,
+                        &[
+                            meta.id.as_str(),
+                            meta.title.as_str(),
+                            guard.spec.check.command.as_str(),
+                        ],
+                    ) {
+                        Some(idx)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            View::ReleaseList => self
+                .supplement
+                .releases
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, release)| {
+                    if !has_query
+                        || fields_match_normalized_query(
+                            &query,
+                            &[release.version.as_str(), release.date.as_str()],
+                        )
+                    {
+                        Some(idx)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            View::TagList => self
+                .supplement
+                .tags
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, tag)| {
+                    if !has_query || fields_match_normalized_query(&query, &[tag.name.as_str()]) {
+                        Some(idx)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            View::Search => self
+                .search_results
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, result)| {
+                    if !has_query
+                        || fields_match_normalized_query(
+                            &query,
+                            &[
+                                result.kind.as_str(),
+                                result.id.as_str(),
+                                result.title.as_str(),
+                                result.snippet.as_str(),
+                            ],
+                        )
+                    {
+                        Some(idx)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            View::LoopList => self
+                .supplement
+                .loops
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, entry)| {
+                    if !has_query {
+                        return Some(idx);
+                    }
+                    let state = entry
+                        .state
+                        .as_ref()
+                        .map(|state| state.loop_meta.state.as_str())
+                        .unwrap_or("invalid");
+                    let work = entry
+                        .state
+                        .as_ref()
+                        .map(|state| state.loop_meta.work.join(" "))
+                        .unwrap_or_default();
+                    if fields_match_normalized_query(
+                        &query,
+                        &[entry.id.as_str(), state, work.as_str()],
+                    ) {
+                        Some(idx)
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            View::DiagnosticList => self
+                .supplement
+                .diagnostics
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, diagnostic)| {
+                    if !has_query
+                        || fields_match_normalized_query(
+                            &query,
+                            &[
+                                diagnostic.code.code(),
+                                diagnostic_level_label(diagnostic.level),
+                                diagnostic.message.as_str(),
+                                diagnostic.file.as_str(),
+                            ],
+                        )
+                    {
                         Some(idx)
                     } else {
                         None
@@ -157,6 +321,14 @@ impl App {
             self.selected = len - 1;
         }
         self.table_state.select(Some(self.selected));
+    }
+}
+
+fn diagnostic_level_label(level: DiagnosticLevel) -> &'static str {
+    match level {
+        DiagnosticLevel::Error => "error",
+        DiagnosticLevel::Warning => "warning",
+        DiagnosticLevel::Info => "info",
     }
 }
 

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -1,5 +1,9 @@
 //! Application state for TUI.
 
+use super::data::{TuiLoopEntry, TuiSupplement, load_supplement};
+use crate::cmd::search::SearchResult;
+use crate::config::Config;
+use crate::diagnostic::Diagnostic;
 use crate::model::ProjectIndex;
 use ratatui::widgets::{ListState, TableState};
 
@@ -12,23 +16,38 @@ pub enum View {
     #[default]
     Dashboard,
     RfcList,
+    ClauseList,
     AdrList,
     WorkList,
+    GuardList,
+    ReleaseList,
+    TagList,
+    Search,
+    LoopList,
+    LoopDetail(usize),
+    DiagnosticList,
     RfcDetail(usize),
     AdrDetail(usize),
     WorkDetail(usize),
+    GuardDetail(usize),
     /// Clause detail view: (rfc_index, clause_index)
     ClauseDetail(usize, usize),
 }
 
 /// Application state
 pub struct App {
+    /// Project configuration
+    pub config: Config,
     /// Project data
     pub index: ProjectIndex,
+    /// Additional read-only cockpit data
+    pub supplement: TuiSupplement,
     /// Current view
     pub view: View,
     /// Selected index in list views
     pub selected: usize,
+    /// Selected work item index in loop detail views
+    pub loop_selected: usize,
     /// Table state for scrollable list views
     pub table_state: TableState,
     /// List state for clause selection in RFC detail view
@@ -42,6 +61,14 @@ pub struct App {
     /// Cached filtered indices (invalidated on filter/view change)
     cached_indices: Vec<usize>,
     indices_dirty: bool,
+    /// Search query for the TUI search view
+    pub search_query: String,
+    /// Whether search input mode is active
+    pub search_mode: bool,
+    /// Search results from the last submitted query
+    pub search_results: Vec<SearchResult>,
+    /// Search error from the last submitted query
+    pub search_error: Option<Diagnostic>,
     /// Whether filter input mode is active
     pub filter_mode: bool,
     /// Show help overlay
@@ -61,9 +88,12 @@ impl App {
             .sort_by(|a, b| a.meta().id.cmp(&b.meta().id));
 
         Self {
+            config: Config::default(),
             index,
+            supplement: TuiSupplement::default(),
             view: View::Dashboard,
             selected: 0,
+            loop_selected: 0,
             table_state: TableState::default().with_selected(Some(0)),
             clause_list_state: ListState::default().with_selected(Some(0)),
             scroll: 0,
@@ -71,9 +101,568 @@ impl App {
             filter_query: String::new(),
             cached_indices: Vec::new(),
             indices_dirty: true,
+            search_query: String::new(),
+            search_mode: false,
+            search_results: Vec::new(),
+            search_error: None,
             filter_mode: false,
             show_help: false,
             should_quit: false,
         }
+    }
+
+    pub fn with_project(config: Config, index: ProjectIndex) -> Self {
+        let mut app = Self::new(index);
+        let supplement = load_supplement(&config, &app.index);
+        app.config = config;
+        app.supplement = supplement;
+        app
+    }
+
+    pub fn loop_entries(&self) -> &[TuiLoopEntry] {
+        &self.supplement.loops
+    }
+
+    pub fn current_loop_state(&self, loop_idx: usize) -> Option<&crate::loop_state::LoopState> {
+        self.supplement
+            .loops
+            .get(loop_idx)
+            .and_then(|entry| entry.state.as_ref())
+    }
+
+    pub fn current_loop_order(&self, loop_idx: usize) -> Vec<String> {
+        self.current_loop_state(loop_idx)
+            .and_then(|state| crate::loop_planner::topological_order_for_state(state).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn selected_loop_work_id(&self, loop_idx: usize) -> Option<String> {
+        self.current_loop_order(loop_idx)
+            .get(self.loop_selected)
+            .cloned()
+    }
+
+    // Implements [[RFC-0007:C-SEARCH]] and [[RFC-0007:C-READ-ONLY]].
+    pub fn submit_search(&mut self) {
+        let query = self.search_query.trim();
+        if query.is_empty() {
+            self.search_results.clear();
+            self.search_error = None;
+            self.selected = 0;
+            self.table_state.select(None);
+            self.invalidate_indices();
+            return;
+        }
+
+        match crate::cmd::search::search_results(
+            &self.config,
+            &[query.to_string()],
+            &[],
+            &[],
+            Some(50),
+            false,
+        ) {
+            Ok(results) => {
+                self.search_results = results;
+                self.search_error = None;
+            }
+            Err(diagnostic) => {
+                self.search_results.clear();
+                self.search_error = Some(diagnostic);
+            }
+        }
+        self.selected = 0;
+        self.table_state = TableState::default()
+            .with_selected((!self.search_results.is_empty()).then_some(self.selected));
+        self.invalidate_indices();
+    }
+
+    pub fn push_search_char(&mut self, ch: char) {
+        self.search_query.push(ch);
+    }
+
+    pub fn pop_search_char(&mut self) {
+        self.search_query.pop();
+    }
+
+    pub fn enter_search_mode(&mut self) {
+        self.search_mode = true;
+    }
+
+    pub fn exit_search_mode(&mut self) {
+        self.search_mode = false;
+    }
+
+    pub fn enter_search_result_at(&mut self, result_idx: usize) {
+        let Some(result) = self.search_results.get(result_idx).cloned() else {
+            return;
+        };
+        self.view = match result.kind.as_str() {
+            "rfc" => self
+                .index
+                .rfcs
+                .iter()
+                .position(|rfc| rfc.rfc.rfc_id == result.id)
+                .map(View::RfcDetail)
+                .unwrap_or(View::Search),
+            "clause" => self
+                .index
+                .rfcs
+                .iter()
+                .enumerate()
+                .find_map(|(rfc_idx, rfc)| {
+                    rfc.clauses
+                        .iter()
+                        .position(|clause| {
+                            format!("{}:{}", rfc.rfc.rfc_id, clause.spec.clause_id) == result.id
+                        })
+                        .map(|clause_idx| View::ClauseDetail(rfc_idx, clause_idx))
+                })
+                .unwrap_or(View::Search),
+            "adr" => self
+                .index
+                .adrs
+                .iter()
+                .position(|adr| adr.meta().id == result.id)
+                .map(View::AdrDetail)
+                .unwrap_or(View::Search),
+            "work" => self
+                .index
+                .work_items
+                .iter()
+                .position(|item| item.meta().id == result.id)
+                .map(View::WorkDetail)
+                .unwrap_or(View::Search),
+            "guard" => self
+                .supplement
+                .guards
+                .iter()
+                .position(|guard| guard.meta().id == result.id)
+                .map(View::GuardDetail)
+                .unwrap_or(View::Search),
+            _ => View::Search,
+        };
+        self.scroll = 0;
+    }
+
+    pub fn enter_diagnostic_target_at(&mut self, diagnostic_idx: usize) {
+        let Some(diagnostic) = self.supplement.diagnostics.get(diagnostic_idx) else {
+            return;
+        };
+        let file = diagnostic.file.as_str();
+        if let Some((idx, _)) = self
+            .index
+            .rfcs
+            .iter()
+            .enumerate()
+            .find(|(_, rfc)| file == self.config.display_path(&rfc.path).display().to_string())
+        {
+            self.view = View::RfcDetail(idx);
+            return;
+        }
+        if let Some((rfc_idx, clause_idx)) =
+            self.index
+                .rfcs
+                .iter()
+                .enumerate()
+                .find_map(|(rfc_idx, rfc)| {
+                    rfc.clauses
+                        .iter()
+                        .enumerate()
+                        .find(|(_, clause)| {
+                            file == self.config.display_path(&clause.path).display().to_string()
+                        })
+                        .map(|(clause_idx, _)| (rfc_idx, clause_idx))
+                })
+        {
+            self.view = View::ClauseDetail(rfc_idx, clause_idx);
+            return;
+        }
+        if let Some((idx, _)) = self
+            .index
+            .adrs
+            .iter()
+            .enumerate()
+            .find(|(_, adr)| file == self.config.display_path(&adr.path).display().to_string())
+        {
+            self.view = View::AdrDetail(idx);
+            return;
+        }
+        if let Some((idx, _)) =
+            self.index.work_items.iter().enumerate().find(|(_, item)| {
+                file == self.config.display_path(&item.path).display().to_string()
+            })
+        {
+            self.view = View::WorkDetail(idx);
+            return;
+        }
+        if let Some((idx, _)) = self
+            .supplement
+            .guards
+            .iter()
+            .enumerate()
+            .find(|(_, guard)| file == self.config.display_path(&guard.path).display().to_string())
+        {
+            self.view = View::GuardDetail(idx);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::diagnostic::{Diagnostic, DiagnosticCode};
+    use crate::loop_state::LoopState;
+    use crate::model::{
+        ClauseEntry, ClauseKind, ClauseSpec, ClauseStatus, GuardCheck, GuardEntry, GuardMeta,
+        GuardSpec, ProjectIndex, RfcIndex, RfcPhase, RfcSpec, RfcStatus, WorkItemContent,
+        WorkItemEntry, WorkItemMeta, WorkItemSpec, WorkItemStatus, WorkItemVerification,
+    };
+    use crate::tui::data::TuiLoopEntry;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    #[test]
+    fn with_project_loads_supplement_from_sorted_index() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::TempDir::new()?;
+        let config = Config {
+            gov_root: temp_dir.path().join("gov"),
+            ..Default::default()
+        };
+        let index = ProjectIndex {
+            rfcs: vec![
+                rfc_entry("RFC-0002", "C-TWO"),
+                rfc_entry("RFC-0001", "C-ONE"),
+            ],
+            adrs: vec![],
+            work_items: vec![],
+        };
+
+        let app = App::with_project(config, index);
+
+        assert_eq!(app.index.rfcs[0].rfc.rfc_id, "RFC-0001");
+        assert_eq!(
+            app.supplement
+                .clauses
+                .iter()
+                .map(|entry| entry.rfc_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["RFC-0001", "RFC-0002"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn empty_search_submit_invalidates_cached_indices() {
+        let mut app = App::new(project_index());
+        app.view = View::Search;
+        app.search_results.push(SearchResult {
+            kind: "rfc".to_string(),
+            id: "RFC-0001".to_string(),
+            title: "TUI cockpit".to_string(),
+            path: "gov/rfc/RFC-0001/rfc.toml".to_string(),
+            snippet: "TUI cockpit".to_string(),
+            score: None,
+            status: Some("normative".to_string()),
+        });
+        app.search_results.push(SearchResult {
+            kind: "work".to_string(),
+            id: "WI-2026-06-06-001".to_string(),
+            title: "Implement TUI v2".to_string(),
+            path: "gov/work/WI-2026-06-06-001.toml".to_string(),
+            snippet: "work item".to_string(),
+            score: None,
+            status: Some("active".to_string()),
+        });
+        assert_eq!(app.list_indices(), vec![0, 1]);
+
+        app.search_query = "   ".to_string();
+        app.submit_search();
+
+        assert!(app.search_results.is_empty());
+        assert!(app.list_indices().is_empty());
+    }
+
+    #[test]
+    fn search_result_enters_matching_detail_view() {
+        let mut app = App::new(project_index());
+        app.view = View::Search;
+        app.search_results.push(SearchResult {
+            kind: "rfc".to_string(),
+            id: "RFC-0001".to_string(),
+            title: "TUI cockpit".to_string(),
+            path: "gov/rfc/RFC-0001/rfc.toml".to_string(),
+            snippet: "TUI cockpit".to_string(),
+            score: None,
+            status: Some("normative".to_string()),
+        });
+
+        app.enter_search_result_at(0);
+
+        assert_eq!(app.view, View::RfcDetail(0));
+    }
+
+    #[test]
+    fn diagnostic_target_enters_matching_work_detail() {
+        let mut app = App::new(project_index());
+        app.view = View::DiagnosticList;
+        app.supplement.diagnostics.push(Diagnostic::new(
+            DiagnosticCode::E0901IoError,
+            "work item diagnostic",
+            "gov/work/WI-2026-06-06-001.toml",
+        ));
+
+        app.enter_diagnostic_target_at(0);
+
+        assert_eq!(app.view, View::WorkDetail(0));
+    }
+
+    #[test]
+    fn diagnostic_target_enters_matching_clause_detail() {
+        let mut app = App::new(project_index());
+        app.view = View::DiagnosticList;
+        app.supplement.diagnostics.push(Diagnostic::new(
+            DiagnosticCode::E0901IoError,
+            "clause diagnostic",
+            "gov/rfc/RFC-0001/clauses/C-TEST.toml",
+        ));
+
+        app.enter_diagnostic_target_at(0);
+
+        assert_eq!(app.view, View::ClauseDetail(0, 0));
+    }
+
+    #[test]
+    fn diagnostic_target_enters_matching_guard_detail() {
+        let mut app = App::new(project_index());
+        app.view = View::DiagnosticList;
+        app.supplement.guards.push(guard_entry());
+        app.supplement.diagnostics.push(Diagnostic::new(
+            DiagnosticCode::E0901IoError,
+            "guard diagnostic",
+            "gov/guard/GUARD-TEST.toml",
+        ));
+
+        app.enter_diagnostic_target_at(0);
+
+        assert_eq!(app.view, View::GuardDetail(0));
+    }
+
+    #[test]
+    fn diagnostic_filter_matches_severity() {
+        let mut app = App::new(project_index());
+        app.view = View::DiagnosticList;
+        app.filter_query = "warning".to_string();
+        app.supplement.diagnostics.push(Diagnostic::new(
+            DiagnosticCode::E0901IoError,
+            "error diagnostic",
+            "gov/rfc/RFC-0001/rfc.toml",
+        ));
+        app.supplement.diagnostics.push(Diagnostic::new(
+            DiagnosticCode::W0110SchemaOutdated,
+            "warning diagnostic",
+            "gov/config.toml",
+        ));
+
+        assert_eq!(app.list_indices(), vec![1]);
+    }
+
+    #[test]
+    fn filtered_diagnostic_enters_visible_target() {
+        let mut app = App::new(project_index());
+        app.view = View::DiagnosticList;
+        app.filter_query = "target".to_string();
+        app.supplement.diagnostics.push(Diagnostic::new(
+            DiagnosticCode::E0901IoError,
+            "other diagnostic",
+            "gov/rfc/RFC-0001/rfc.toml",
+        ));
+        app.supplement.diagnostics.push(Diagnostic::new(
+            DiagnosticCode::E0901IoError,
+            "target diagnostic",
+            "gov/work/WI-2026-06-06-001.toml",
+        ));
+
+        app.enter_detail();
+
+        assert_eq!(app.view, View::WorkDetail(0));
+    }
+
+    #[test]
+    fn filtered_search_enters_visible_result() {
+        let mut app = App::new(project_index());
+        app.view = View::Search;
+        app.filter_query = "target".to_string();
+        app.search_results.push(SearchResult {
+            kind: "work".to_string(),
+            id: "WI-2026-06-06-001".to_string(),
+            title: "Other result".to_string(),
+            path: "gov/work/WI-2026-06-06-001.toml".to_string(),
+            snippet: "not the match".to_string(),
+            score: None,
+            status: Some("active".to_string()),
+        });
+        app.search_results.push(SearchResult {
+            kind: "rfc".to_string(),
+            id: "RFC-0001".to_string(),
+            title: "Target result".to_string(),
+            path: "gov/rfc/RFC-0001/rfc.toml".to_string(),
+            snippet: "target".to_string(),
+            score: None,
+            status: Some("normative".to_string()),
+        });
+
+        app.enter_detail();
+
+        assert_eq!(app.view, View::RfcDetail(0));
+    }
+
+    #[test]
+    fn loop_detail_uses_independent_work_selection() -> Result<(), Box<dyn std::error::Error>> {
+        let mut app = App::new(ProjectIndex::default());
+        app.supplement
+            .loops
+            .push(loop_entry("LOOP-2026-06-06-001", "WI-2026-06-06-001")?);
+        app.supplement
+            .loops
+            .push(loop_entry("LOOP-2026-06-06-002", "WI-2026-06-06-002")?);
+        app.view = View::LoopList;
+        app.selected = 1;
+
+        app.enter_detail();
+
+        assert_eq!(app.view, View::LoopDetail(1));
+        assert_eq!(app.selected, 1);
+        assert_eq!(app.loop_selected, 0);
+        assert_eq!(
+            app.selected_loop_work_id(1).as_deref(),
+            Some("WI-2026-06-06-002")
+        );
+
+        app.go_back();
+
+        assert_eq!(app.view, View::LoopList);
+        assert_eq!(app.selected, 1);
+        Ok(())
+    }
+
+    fn project_index() -> ProjectIndex {
+        ProjectIndex {
+            rfcs: vec![RfcIndex {
+                rfc: RfcSpec {
+                    rfc_id: "RFC-0001".to_string(),
+                    title: "TUI cockpit".to_string(),
+                    version: "0.1.0".to_string(),
+                    status: RfcStatus::Normative,
+                    phase: RfcPhase::Impl,
+                    owners: vec![],
+                    created: "2026-06-06".to_string(),
+                    updated: None,
+                    supersedes: None,
+                    refs: vec![],
+                    tags: vec![],
+                    sections: vec![],
+                    changelog: vec![],
+                    signature: None,
+                },
+                clauses: vec![ClauseEntry {
+                    spec: ClauseSpec {
+                        clause_id: "C-TEST".to_string(),
+                        title: "Clause test".to_string(),
+                        kind: ClauseKind::Normative,
+                        status: ClauseStatus::Active,
+                        text: "Clause body".to_string(),
+                        anchors: vec![],
+                        superseded_by: None,
+                        since: None,
+                        tags: vec![],
+                    },
+                    path: PathBuf::from("gov/rfc/RFC-0001/clauses/C-TEST.toml"),
+                }],
+                path: PathBuf::from("gov/rfc/RFC-0001/rfc.toml"),
+            }],
+            adrs: vec![],
+            work_items: vec![WorkItemEntry {
+                spec: WorkItemSpec {
+                    govctl: WorkItemMeta::new(
+                        "WI-2026-06-06-001",
+                        "Implement TUI v2",
+                        WorkItemStatus::Active,
+                    ),
+                    content: WorkItemContent::default(),
+                    verification: WorkItemVerification::default(),
+                },
+                path: PathBuf::from("gov/work/WI-2026-06-06-001.toml"),
+            }],
+        }
+    }
+
+    fn rfc_entry(rfc_id: &str, clause_id: &str) -> RfcIndex {
+        RfcIndex {
+            rfc: RfcSpec {
+                rfc_id: rfc_id.to_string(),
+                title: rfc_id.to_string(),
+                version: "0.1.0".to_string(),
+                status: RfcStatus::Normative,
+                phase: RfcPhase::Impl,
+                owners: vec![],
+                created: "2026-06-06".to_string(),
+                updated: None,
+                supersedes: None,
+                refs: vec![],
+                tags: vec![],
+                sections: vec![],
+                changelog: vec![],
+                signature: None,
+            },
+            clauses: vec![ClauseEntry {
+                spec: ClauseSpec {
+                    clause_id: clause_id.to_string(),
+                    title: clause_id.to_string(),
+                    kind: ClauseKind::Normative,
+                    status: ClauseStatus::Active,
+                    text: "Clause body".to_string(),
+                    anchors: vec![],
+                    superseded_by: None,
+                    since: None,
+                    tags: vec![],
+                },
+                path: PathBuf::from(format!("gov/rfc/{rfc_id}/clauses/{clause_id}.toml")),
+            }],
+            path: PathBuf::from(format!("gov/rfc/{rfc_id}/rfc.toml")),
+        }
+    }
+
+    fn guard_entry() -> GuardEntry {
+        GuardEntry {
+            spec: GuardSpec {
+                govctl: GuardMeta::new("GUARD-TEST", "Guard test"),
+                check: GuardCheck {
+                    command: "true".to_string(),
+                    timeout_secs: 1,
+                    pattern: None,
+                },
+            },
+            path: PathBuf::from("gov/guard/GUARD-TEST.toml"),
+        }
+    }
+
+    fn loop_entry(
+        loop_id: &str,
+        work_id: &str,
+    ) -> crate::diagnostic::DiagnosticResult<TuiLoopEntry> {
+        let mut dependencies = BTreeMap::new();
+        dependencies.insert(work_id.to_string(), Vec::new());
+        Ok(TuiLoopEntry {
+            id: loop_id.to_string(),
+            state: Some(LoopState::new(
+                loop_id,
+                vec![work_id.to_string()],
+                vec![work_id.to_string()],
+                dependencies,
+            )?),
+            diagnostic: None,
+        })
     }
 }

--- a/src/tui/app/navigation.rs
+++ b/src/tui/app/navigation.rs
@@ -56,8 +56,41 @@ impl App {
                 self.clause_list_state = ListState::default().with_selected(Some(0));
                 View::RfcDetail(real_idx)
             }
+            View::ClauseList => self
+                .supplement
+                .clauses
+                .get(real_idx)
+                .and_then(|entry| {
+                    self.index
+                        .rfcs
+                        .iter()
+                        .position(|rfc| rfc.rfc.rfc_id == entry.rfc_id)
+                        .and_then(|rfc_idx| {
+                            self.index.rfcs[rfc_idx]
+                                .clauses
+                                .iter()
+                                .position(|clause| {
+                                    clause.spec.clause_id == entry.clause.spec.clause_id
+                                })
+                                .map(|clause_idx| View::ClauseDetail(rfc_idx, clause_idx))
+                        })
+                })
+                .unwrap_or(View::ClauseList),
             View::AdrList => View::AdrDetail(real_idx),
             View::WorkList => View::WorkDetail(real_idx),
+            View::GuardList => View::GuardDetail(real_idx),
+            View::Search => {
+                self.enter_search_result_at(real_idx);
+                return;
+            }
+            View::LoopList => {
+                self.loop_selected = 0;
+                View::LoopDetail(real_idx)
+            }
+            View::DiagnosticList => {
+                self.enter_diagnostic_target_at(real_idx);
+                return;
+            }
             _ => return,
         };
         self.scroll = 0;
@@ -70,7 +103,18 @@ impl App {
             View::RfcDetail(_) => View::RfcList,
             View::AdrDetail(_) => View::AdrList,
             View::WorkDetail(_) => View::WorkList,
-            View::RfcList | View::AdrList | View::WorkList => View::Dashboard,
+            View::GuardDetail(_) => View::GuardList,
+            View::LoopDetail(_) => View::LoopList,
+            View::RfcList
+            | View::ClauseList
+            | View::AdrList
+            | View::WorkList
+            | View::GuardList
+            | View::ReleaseList
+            | View::TagList
+            | View::Search
+            | View::LoopList
+            | View::DiagnosticList => View::Dashboard,
             View::Dashboard => {
                 self.should_quit = true;
                 View::Dashboard
@@ -90,7 +134,19 @@ impl App {
         self.table_state = TableState::default().with_selected(Some(0));
         self.scroll = 0;
         self.invalidate_indices();
-        if matches!(self.view, View::RfcList | View::AdrList | View::WorkList) {
+        if matches!(
+            self.view,
+            View::RfcList
+                | View::ClauseList
+                | View::AdrList
+                | View::WorkList
+                | View::GuardList
+                | View::ReleaseList
+                | View::TagList
+                | View::Search
+                | View::LoopList
+                | View::DiagnosticList
+        ) {
             self.filter_mode = false;
             self.clear_filter();
         } else {
@@ -188,5 +244,23 @@ impl App {
                 self.scroll = 0;
             }
         }
+    }
+
+    pub fn loop_item_count(&self) -> usize {
+        match self.view {
+            View::LoopDetail(idx) => self.current_loop_order(idx).len(),
+            _ => 0,
+        }
+    }
+
+    pub fn loop_item_next(&mut self) {
+        let len = self.loop_item_count();
+        if len > 0 && self.loop_selected < len - 1 {
+            self.loop_selected += 1;
+        }
+    }
+
+    pub fn loop_item_prev(&mut self) {
+        self.loop_selected = self.loop_selected.saturating_sub(1);
     }
 }

--- a/src/tui/dag.rs
+++ b/src/tui/dag.rs
@@ -1,0 +1,241 @@
+use crate::diagnostic::DiagnosticResult;
+use crate::loop_planner::topological_order_for_state;
+use crate::loop_state::LoopState;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DagLine {
+    pub work_id: String,
+    pub depth: usize,
+    pub selected: bool,
+    pub hidden: bool,
+    pub text: String,
+}
+
+pub fn dag_lines(
+    state: &LoopState,
+    selected_work_id: Option<&str>,
+    max_lines: usize,
+) -> DiagnosticResult<Vec<DagLine>> {
+    // Implements [[RFC-0007:C-LOOP-DAG]]: deterministic loop ordering.
+    let order = topological_order_for_state(state)?;
+    if max_lines == 0 {
+        return Ok(Vec::new());
+    }
+
+    // Implements [[RFC-0007:C-LOOP-DAG]]: reserve space for hidden-count fallback.
+    let item_budget = if order.len() > max_lines {
+        max_lines.saturating_sub(1)
+    } else {
+        max_lines
+    };
+    // Implements [[RFC-0007:C-LOOP-DAG]]: selected-item neighborhood fallback.
+    let visible = visible_work_ids(state, &order, selected_work_id, item_budget);
+    // Implements [[RFC-0007:C-LOOP-DAG]]: hidden item counts remain visible.
+    let hidden_count = order.len().saturating_sub(visible.len());
+    // Implements [[RFC-0007:C-LOOP-DAG]]: stable visual depth for dependencies.
+    let depths = node_depths(state, &order);
+
+    let mut lines = Vec::new();
+    for work_id in visible {
+        let Some(item) = state.items.get(&work_id) else {
+            continue;
+        };
+        let depth = *depths.get(&work_id).unwrap_or(&0);
+        let selected = selected_work_id == Some(work_id.as_str());
+        let deps = state
+            .dependencies
+            .get(&work_id)
+            .filter(|deps| !deps.is_empty())
+            .map(|deps| format!(" <- {}", deps.join(", ")))
+            .unwrap_or_default();
+        let branch = if depth == 0 { "●" } else { "└─" };
+        let marker = if selected { ">" } else { " " };
+        let indent = "  ".repeat(depth);
+        lines.push(DagLine {
+            work_id: work_id.clone(),
+            depth,
+            selected,
+            hidden: false,
+            text: format!(
+                "{marker}{indent}{branch} {work_id} [{}]{}",
+                item.status.as_str(),
+                deps
+            ),
+        });
+    }
+
+    if hidden_count > 0 && lines.len() < max_lines {
+        lines.push(DagLine {
+            work_id: String::new(),
+            depth: 0,
+            selected: false,
+            hidden: true,
+            text: format!("... {hidden_count} hidden item(s); narrow DAG neighborhood shown"),
+        });
+    }
+
+    Ok(lines)
+}
+
+fn visible_work_ids(
+    state: &LoopState,
+    order: &[String],
+    selected_work_id: Option<&str>,
+    max_lines: usize,
+) -> Vec<String> {
+    if order.len() <= max_lines {
+        return order.to_vec();
+    }
+
+    let mut visible = BTreeSet::new();
+    if let Some(selected) =
+        selected_work_id.filter(|selected| order.iter().any(|id| id == selected))
+    {
+        visible.insert(selected.to_string());
+
+        if max_lines > 1
+            && let Some(deps) = state.dependencies.get(selected)
+        {
+            for dep in order.iter().filter(|work_id| deps.contains(*work_id)) {
+                if visible.len() >= max_lines {
+                    break;
+                }
+                visible.insert(dep.clone());
+            }
+        }
+
+        if visible.len() < max_lines {
+            for work_id in order {
+                if visible.len() >= max_lines {
+                    break;
+                }
+                if state
+                    .dependencies
+                    .get(work_id)
+                    .is_some_and(|deps| deps.iter().any(|dep| dep == selected))
+                {
+                    visible.insert(work_id.clone());
+                }
+            }
+        }
+    }
+
+    for work_id in order {
+        if visible.len() >= max_lines {
+            break;
+        }
+        visible.insert(work_id.clone());
+    }
+
+    order
+        .iter()
+        .filter(|work_id| visible.contains(*work_id))
+        .take(max_lines)
+        .cloned()
+        .collect()
+}
+
+fn node_depths(state: &LoopState, order: &[String]) -> BTreeMap<String, usize> {
+    let mut depths = BTreeMap::new();
+    for work_id in order {
+        let depth = state
+            .dependencies
+            .get(work_id)
+            .map(|deps| {
+                deps.iter()
+                    .filter_map(|dep| depths.get(dep))
+                    .map(|depth| depth + 1)
+                    .max()
+                    .unwrap_or(0)
+            })
+            .unwrap_or(0);
+        depths.insert(work_id.clone(), depth);
+    }
+    depths
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::loop_state::{LoopState, LoopWorkItemStatus};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn dag_lines_are_deterministic_and_status_aware() -> Result<(), Box<dyn std::error::Error>> {
+        let state = sample_loop_state()?;
+        let lines = dag_lines(&state, Some("WI-2026-01-01-002"), 10)?;
+
+        assert_eq!(lines[0].work_id, "WI-2026-01-01-001");
+        assert!(lines.iter().any(|line| line.selected));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.text.contains("[active]")
+                    && line.text.contains("WI-2026-01-01-002"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn dag_lines_show_neighborhood_fallback() -> Result<(), Box<dyn std::error::Error>> {
+        let state = sample_loop_state()?;
+        let lines = dag_lines(&state, Some("WI-2026-01-01-002"), 2)?;
+
+        assert!(lines.iter().any(|line| line.hidden));
+        assert!(lines.len() <= 2);
+        assert!(lines.iter().any(|line| line.selected));
+        Ok(())
+    }
+
+    #[test]
+    fn dag_lines_fallback_keeps_late_selected_item() -> Result<(), Box<dyn std::error::Error>> {
+        let state = sample_loop_state()?;
+        let lines = dag_lines(&state, Some("WI-2026-01-01-003"), 2)?;
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.selected && line.work_id == "WI-2026-01-01-003")
+        );
+        assert!(lines.iter().any(|line| line.hidden));
+        assert!(lines.len() <= 2);
+        Ok(())
+    }
+
+    #[test]
+    fn dag_lines_one_line_fallback_shows_hidden_count() -> Result<(), Box<dyn std::error::Error>> {
+        let state = sample_loop_state()?;
+        let lines = dag_lines(&state, Some("WI-2026-01-01-003"), 1)?;
+
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].hidden);
+        assert!(lines[0].text.contains("hidden item"));
+        Ok(())
+    }
+
+    fn sample_loop_state() -> DiagnosticResult<LoopState> {
+        let mut dependencies = BTreeMap::new();
+        dependencies.insert("WI-2026-01-01-001".to_string(), vec![]);
+        dependencies.insert(
+            "WI-2026-01-01-002".to_string(),
+            vec!["WI-2026-01-01-001".to_string()],
+        );
+        dependencies.insert(
+            "WI-2026-01-01-003".to_string(),
+            vec!["WI-2026-01-01-002".to_string()],
+        );
+        let mut state = LoopState::new(
+            "LOOP-2026-01-01-001",
+            vec!["WI-2026-01-01-003".to_string()],
+            vec![
+                "WI-2026-01-01-001".to_string(),
+                "WI-2026-01-01-002".to_string(),
+                "WI-2026-01-01-003".to_string(),
+            ],
+            dependencies,
+        )?;
+        state.set_item_status("WI-2026-01-01-002", LoopWorkItemStatus::Active)?;
+        Ok(state)
+    }
+}

--- a/src/tui/data.rs
+++ b/src/tui/data.rs
@@ -1,0 +1,255 @@
+use crate::cmd::check::{CheckSummary, collect_diagnostics};
+use crate::config::Config;
+use crate::diagnostic::{Diagnostic, DiagnosticCode, Diagnostics};
+use crate::loop_state::{LoopState, load_loop_state, loop_state_root, validate_loop_id};
+use crate::model::{ClauseEntry, GuardEntry, ProjectIndex, Release};
+use crate::parse::{load_guards_with_warnings, load_releases};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone)]
+pub struct TuiClauseEntry {
+    pub rfc_id: String,
+    pub clause: ClauseEntry,
+}
+
+#[derive(Debug, Clone)]
+pub struct TuiLoopEntry {
+    pub id: String,
+    pub state: Option<LoopState>,
+    pub diagnostic: Option<Diagnostic>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TuiTagSummary {
+    pub name: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TuiSupplement {
+    pub guards: Vec<GuardEntry>,
+    pub releases: Vec<Release>,
+    pub clauses: Vec<TuiClauseEntry>,
+    pub loops: Vec<TuiLoopEntry>,
+    pub tags: Vec<TuiTagSummary>,
+    pub diagnostics: Diagnostics,
+    pub check_summary: CheckSummary,
+}
+
+pub fn load_supplement(config: &Config, index: &ProjectIndex) -> TuiSupplement {
+    let mut supplement = TuiSupplement {
+        clauses: index
+            .iter_clauses()
+            .map(|(rfc, clause)| TuiClauseEntry {
+                rfc_id: rfc.rfc.rfc_id.clone(),
+                clause: clause.clone(),
+            })
+            .collect(),
+        tags: tag_summaries(config, index),
+        ..TuiSupplement::default()
+    };
+
+    if let Ok(result) = load_guards_with_warnings(config) {
+        supplement.guards = result.items;
+    }
+
+    if let Ok(releases) = load_releases(config) {
+        supplement.releases = releases.releases;
+    }
+
+    match collect_diagnostics(config) {
+        Ok((diagnostics, summary)) => {
+            supplement.diagnostics.extend(diagnostics);
+            supplement.check_summary = summary;
+        }
+        Err(diagnostic) => supplement.diagnostics.push(diagnostic),
+    }
+
+    supplement.loops = load_loop_entries(config);
+    supplement
+}
+
+fn tag_summaries(config: &Config, index: &ProjectIndex) -> Vec<TuiTagSummary> {
+    let mut counts = BTreeMap::<String, usize>::new();
+    for tag in &config.tags.allowed {
+        counts.entry(tag.clone()).or_default();
+    }
+    for rfc in &index.rfcs {
+        for tag in &rfc.rfc.tags {
+            *counts.entry(tag.clone()).or_default() += 1;
+        }
+        for clause in &rfc.clauses {
+            for tag in &clause.spec.tags {
+                *counts.entry(tag.clone()).or_default() += 1;
+            }
+        }
+    }
+    for adr in &index.adrs {
+        for tag in &adr.meta().tags {
+            *counts.entry(tag.clone()).or_default() += 1;
+        }
+    }
+    for item in &index.work_items {
+        for tag in &item.meta().tags {
+            *counts.entry(tag.clone()).or_default() += 1;
+        }
+    }
+
+    counts
+        .into_iter()
+        .map(|(name, count)| TuiTagSummary { name, count })
+        .collect()
+}
+
+fn load_loop_entries(config: &Config) -> Vec<TuiLoopEntry> {
+    let root = loop_state_root(config);
+    let entries = match std::fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(err) => {
+            return vec![TuiLoopEntry {
+                id: root.display().to_string(),
+                state: None,
+                diagnostic: Some(Diagnostic::new(
+                    DiagnosticCode::E0901IoError,
+                    format!("Failed to read loop state directory: {err}"),
+                    root.display().to_string(),
+                )),
+            }];
+        }
+    };
+    let mut loop_ids = Vec::new();
+    let mut diagnostics = Vec::new();
+    for entry in entries {
+        let Ok(entry) = entry else {
+            diagnostics.push(TuiLoopEntry {
+                id: root.display().to_string(),
+                state: None,
+                diagnostic: Some(Diagnostic::new(
+                    DiagnosticCode::E0901IoError,
+                    "Failed to read loop state directory entry",
+                    root.display().to_string(),
+                )),
+            });
+            continue;
+        };
+        let Some(loop_id) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        // Implements [[RFC-0007:C-LOOP-VIEWS]]: invalid loop IDs are not authoritative.
+        if validate_loop_id(&loop_id).is_ok() {
+            loop_ids.push(loop_id);
+        }
+    }
+    loop_ids.sort();
+
+    let mut loops = diagnostics;
+    loops.extend(
+        loop_ids
+            .into_iter()
+            // Implements [[RFC-0007:C-LOOP-VIEWS]]: load valid loop states read-only.
+            .map(|loop_id| match load_loop_state(config, &loop_id) {
+                Ok(state) => TuiLoopEntry {
+                    id: loop_id,
+                    state: Some(state),
+                    diagnostic: None,
+                },
+                // Implements [[RFC-0007:C-LOOP-VIEWS]]: invalid loop state remains visible.
+                Err(diagnostic) => TuiLoopEntry {
+                    id: loop_id,
+                    state: None,
+                    diagnostic: Some(diagnostic),
+                },
+            }),
+    );
+    loops
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PathsConfig;
+    use crate::loop_state::{LoopState, write_loop_state_with_op};
+    use crate::write::WriteOp;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn load_loop_entries_loads_sorted_persisted_loop_states()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::TempDir::new()?;
+        let config = Config {
+            gov_root: temp_dir.path().join("gov"),
+            paths: PathsConfig {
+                docs_output: temp_dir.path().join("docs"),
+                agent_dir: temp_dir.path().join(".claude"),
+            },
+            ..Default::default()
+        };
+
+        std::fs::create_dir_all(temp_dir.path().join(".govctl/loops/not-a-loop"))?;
+        write_loop_state_with_op(
+            &config,
+            &loop_state("LOOP-2026-06-06-002", "WI-2026-06-06-002")?,
+            WriteOp::Execute,
+        )?;
+        write_loop_state_with_op(
+            &config,
+            &loop_state("LOOP-2026-06-06-001", "WI-2026-06-06-001")?,
+            WriteOp::Execute,
+        )?;
+
+        let loops = load_loop_entries(&config);
+
+        assert_eq!(
+            loops
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["LOOP-2026-06-06-001", "LOOP-2026-06-06-002"]
+        );
+        assert!(loops.iter().all(|entry| entry.state.is_some()));
+        Ok(())
+    }
+
+    #[test]
+    fn load_loop_entries_reports_directory_read_errors() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::TempDir::new()?;
+        let config = Config {
+            gov_root: temp_dir.path().join("gov"),
+            paths: PathsConfig {
+                docs_output: temp_dir.path().join("docs"),
+                agent_dir: temp_dir.path().join(".claude"),
+            },
+            ..Default::default()
+        };
+        std::fs::create_dir_all(temp_dir.path().join(".govctl"))?;
+        std::fs::write(temp_dir.path().join(".govctl/loops"), "not a directory")?;
+
+        let loops = load_loop_entries(&config);
+
+        assert_eq!(loops.len(), 1);
+        assert!(loops[0].state.is_none());
+        let diagnostic = loops[0]
+            .diagnostic
+            .as_ref()
+            .ok_or_else(|| std::io::Error::other("missing diagnostic"))?;
+        assert_eq!(diagnostic.code, DiagnosticCode::E0901IoError);
+        assert!(
+            diagnostic
+                .message
+                .contains("Failed to read loop state directory")
+        );
+        Ok(())
+    }
+
+    fn loop_state(loop_id: &str, work_id: &str) -> crate::diagnostic::DiagnosticResult<LoopState> {
+        let mut dependencies = BTreeMap::new();
+        dependencies.insert(work_id.to_string(), Vec::new());
+        LoopState::new(
+            loop_id,
+            vec![work_id.to_string()],
+            vec![work_id.to_string()],
+            dependencies,
+        )
+    }
+}

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -24,55 +24,7 @@ pub fn run_event_loop(
             && let Event::Key(key) =
                 event::read().map_err(|err| super::terminal_error("read terminal event", err))?
         {
-            if key.kind != KeyEventKind::Press {
-                continue;
-            }
-
-            if matches!(key.code, KeyCode::Char('?')) {
-                app.show_help = !app.show_help;
-                continue;
-            }
-
-            if app.show_help {
-                if matches!(key.code, KeyCode::Esc) {
-                    app.show_help = false;
-                }
-                continue;
-            }
-
-            match app.view {
-                View::Dashboard => handle_dashboard_keys(app, key),
-                View::RfcList
-                | View::ClauseList
-                | View::AdrList
-                | View::WorkList
-                | View::GuardList
-                | View::ReleaseList
-                | View::TagList
-                | View::LoopList
-                | View::DiagnosticList => {
-                    if app.filter_mode {
-                        handle_filter_input(app, key);
-                    } else {
-                        handle_list_keys(app, key);
-                    }
-                }
-                View::Search => {
-                    if app.search_mode {
-                        handle_search_input(app, key);
-                    } else if app.filter_mode {
-                        handle_filter_input(app, key);
-                    } else {
-                        handle_search_keys(app, key);
-                    }
-                }
-                View::LoopDetail(_) => handle_loop_detail_keys(app, key),
-                View::RfcDetail(_) => handle_rfc_detail_keys(app, key),
-                View::AdrDetail(_)
-                | View::WorkDetail(_)
-                | View::GuardDetail(_)
-                | View::ClauseDetail(_, _) => handle_detail_keys(app, key),
-            }
+            handle_key(app, key);
         }
 
         if app.should_quit {
@@ -80,6 +32,60 @@ pub fn run_event_loop(
         }
     }
     Ok(())
+}
+
+pub(super) fn handle_key(app: &mut App, key: KeyEvent) {
+    if key.kind != KeyEventKind::Press {
+        return;
+    }
+
+    if matches!(key.code, KeyCode::Char('?')) {
+        app.show_help = !app.show_help;
+        return;
+    }
+
+    if app.show_help {
+        if matches!(key.code, KeyCode::Esc) {
+            app.show_help = false;
+        }
+        return;
+    }
+
+    match app.view {
+        View::Dashboard => handle_dashboard_keys(app, key),
+        View::RfcList
+        | View::ClauseList
+        | View::AdrList
+        | View::WorkList
+        | View::GuardList
+        | View::ReleaseList
+        | View::TagList
+        | View::LoopList
+        | View::DiagnosticList => {
+            if app.filter_mode {
+                handle_filter_input(app, key);
+            } else {
+                handle_list_keys(app, key);
+            }
+        }
+        View::Search => {
+            if app.search_mode {
+                handle_search_input(app, key);
+            } else if app.filter_mode {
+                handle_filter_input(app, key);
+            } else {
+                handle_search_keys(app, key);
+            }
+        }
+        View::LoopDetail(_) => handle_loop_detail_keys(app, key),
+        View::RfcDetail(_) => handle_rfc_detail_keys(app, key),
+        View::AdrDetail(_)
+        | View::WorkDetail(_)
+        | View::GuardDetail(_)
+        | View::ClauseDetail(_, _) => {
+            handle_detail_keys(app, key);
+        }
+    }
 }
 
 fn is_ctrl(key: &KeyEvent) -> bool {
@@ -225,5 +231,153 @@ fn handle_filter_input(app: &mut App, key: KeyEvent) {
         KeyCode::Backspace => app.pop_filter_char(),
         KeyCode::Char(ch) => app.push_filter_char(ch),
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{
+        ClauseEntry, ClauseKind, ClauseSpec, ClauseStatus, ProjectIndex, RfcIndex, RfcPhase,
+        RfcSpec, RfcStatus, WorkItemContent, WorkItemEntry, WorkItemMeta, WorkItemSpec,
+        WorkItemStatus, WorkItemVerification,
+    };
+    use std::path::PathBuf;
+
+    #[test]
+    fn handle_key_routes_dashboard_and_help_overlay() {
+        let mut app = App::new(ProjectIndex::default());
+
+        handle_key(&mut app, key(KeyCode::Char('s')));
+        assert_eq!(app.view, View::Search);
+        assert!(app.search_mode);
+
+        handle_key(&mut app, key(KeyCode::Char('?')));
+        assert!(app.show_help);
+        handle_key(&mut app, key(KeyCode::Char('q')));
+        assert!(!app.should_quit);
+        handle_key(&mut app, key(KeyCode::Esc));
+        assert!(!app.show_help);
+    }
+
+    #[test]
+    fn handle_key_routes_list_filter_and_selection() {
+        let mut app = App::new(project_index());
+        app.go_to(View::WorkList);
+
+        handle_key(&mut app, key(KeyCode::Char('j')));
+        assert_eq!(app.selected, 1);
+        handle_key(&mut app, key(KeyCode::Char('g')));
+        assert_eq!(app.selected, 0);
+        handle_key(&mut app, key(KeyCode::Char('G')));
+        assert_eq!(app.selected, 1);
+        handle_key(&mut app, key(KeyCode::Char('/')));
+        assert!(app.filter_mode);
+        handle_key(&mut app, key(KeyCode::Char('a')));
+        assert_eq!(app.filter_query, "a");
+        handle_key(&mut app, key(KeyCode::Backspace));
+        assert!(app.filter_query.is_empty());
+        handle_key(&mut app, key(KeyCode::Enter));
+        assert!(!app.filter_mode);
+        handle_key(&mut app, key(KeyCode::Enter));
+        assert_eq!(app.view, View::WorkDetail(1));
+    }
+
+    #[test]
+    fn handle_key_routes_search_modes() {
+        let mut app = App::new(ProjectIndex::default());
+        app.go_to(View::Search);
+
+        handle_key(&mut app, key(KeyCode::Char('e')));
+        assert!(app.search_mode);
+        handle_key(&mut app, key(KeyCode::Char('r')));
+        handle_key(&mut app, key(KeyCode::Char('f')));
+        assert_eq!(app.search_query, "rf");
+        handle_key(&mut app, key(KeyCode::Backspace));
+        assert_eq!(app.search_query, "r");
+        handle_key(&mut app, key(KeyCode::Esc));
+        assert!(!app.search_mode);
+        handle_key(&mut app, key(KeyCode::Esc));
+        assert_eq!(app.view, View::Dashboard);
+    }
+
+    #[test]
+    fn handle_key_routes_detail_loop_and_rfc_detail_keys() {
+        let mut app = App::new(project_index());
+        app.view = View::WorkDetail(0);
+        app.content_height = 6;
+
+        handle_key(&mut app, key(KeyCode::Char('j')));
+        assert_eq!(app.scroll, 1);
+        handle_key(&mut app, ctrl_key(KeyCode::Char('d')));
+        assert_eq!(app.scroll, 4);
+        handle_key(&mut app, key(KeyCode::Esc));
+        assert_eq!(app.view, View::WorkList);
+
+        app.view = View::RfcDetail(0);
+        handle_key(&mut app, key(KeyCode::Enter));
+        assert_eq!(app.view, View::ClauseDetail(0, 0));
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl_key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::CONTROL)
+    }
+
+    fn project_index() -> ProjectIndex {
+        ProjectIndex {
+            rfcs: vec![RfcIndex {
+                rfc: RfcSpec {
+                    rfc_id: "RFC-0001".to_string(),
+                    title: "RFC".to_string(),
+                    version: "0.1.0".to_string(),
+                    status: RfcStatus::Normative,
+                    phase: RfcPhase::Impl,
+                    owners: vec![],
+                    created: "2026-06-07".to_string(),
+                    updated: None,
+                    supersedes: None,
+                    refs: vec![],
+                    tags: vec![],
+                    sections: vec![],
+                    changelog: vec![],
+                    signature: None,
+                },
+                clauses: vec![ClauseEntry {
+                    spec: ClauseSpec {
+                        clause_id: "C-TEST".to_string(),
+                        title: "Clause".to_string(),
+                        kind: ClauseKind::Normative,
+                        status: ClauseStatus::Active,
+                        text: "Clause text".to_string(),
+                        anchors: vec![],
+                        superseded_by: None,
+                        since: None,
+                        tags: vec![],
+                    },
+                    path: PathBuf::from("gov/rfc/RFC-0001/clauses/C-TEST.toml"),
+                }],
+                path: PathBuf::from("gov/rfc/RFC-0001/rfc.toml"),
+            }],
+            adrs: vec![],
+            work_items: vec![
+                work_item("WI-2026-06-07-001", "Alpha"),
+                work_item("WI-2026-06-07-002", "Beta"),
+            ],
+        }
+    }
+
+    fn work_item(id: &str, title: &str) -> WorkItemEntry {
+        WorkItemEntry {
+            spec: WorkItemSpec {
+                govctl: WorkItemMeta::new(id, title, WorkItemStatus::Active),
+                content: WorkItemContent::default(),
+                verification: WorkItemVerification::default(),
+            },
+            path: PathBuf::from(format!("gov/work/{id}.toml")),
+        }
     }
 }

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -42,17 +42,36 @@ pub fn run_event_loop(
 
             match app.view {
                 View::Dashboard => handle_dashboard_keys(app, key),
-                View::RfcList | View::AdrList | View::WorkList => {
+                View::RfcList
+                | View::ClauseList
+                | View::AdrList
+                | View::WorkList
+                | View::GuardList
+                | View::ReleaseList
+                | View::TagList
+                | View::LoopList
+                | View::DiagnosticList => {
                     if app.filter_mode {
                         handle_filter_input(app, key);
                     } else {
                         handle_list_keys(app, key);
                     }
                 }
-                View::RfcDetail(_) => handle_rfc_detail_keys(app, key),
-                View::AdrDetail(_) | View::WorkDetail(_) | View::ClauseDetail(_, _) => {
-                    handle_detail_keys(app, key)
+                View::Search => {
+                    if app.search_mode {
+                        handle_search_input(app, key);
+                    } else if app.filter_mode {
+                        handle_filter_input(app, key);
+                    } else {
+                        handle_search_keys(app, key);
+                    }
                 }
+                View::LoopDetail(_) => handle_loop_detail_keys(app, key),
+                View::RfcDetail(_) => handle_rfc_detail_keys(app, key),
+                View::AdrDetail(_)
+                | View::WorkDetail(_)
+                | View::GuardDetail(_)
+                | View::ClauseDetail(_, _) => handle_detail_keys(app, key),
             }
         }
 
@@ -70,9 +89,29 @@ fn is_ctrl(key: &KeyEvent) -> bool {
 fn handle_dashboard_keys(app: &mut App, key: KeyEvent) {
     match key.code {
         KeyCode::Char('q') => app.should_quit = true,
+        // Implements [[RFC-0007:C-COCKPIT-VIEWS]]: dashboard entry point.
         KeyCode::Char('1') | KeyCode::Char('r') => app.go_to(View::RfcList),
-        KeyCode::Char('2') | KeyCode::Char('a') => app.go_to(View::AdrList),
-        KeyCode::Char('3') | KeyCode::Char('w') => app.go_to(View::WorkList),
+        // Implements [[RFC-0007:C-COCKPIT-VIEWS]]: dashboard entry point.
+        KeyCode::Char('2') | KeyCode::Char('c') => app.go_to(View::ClauseList),
+        // Implements [[RFC-0007:C-COCKPIT-VIEWS]]: dashboard entry point.
+        KeyCode::Char('3') | KeyCode::Char('a') => app.go_to(View::AdrList),
+        // Implements [[RFC-0007:C-COCKPIT-VIEWS]]: dashboard entry point.
+        KeyCode::Char('4') | KeyCode::Char('w') => app.go_to(View::WorkList),
+        // Implements [[RFC-0007:C-COCKPIT-VIEWS]]: dashboard entry point.
+        KeyCode::Char('5') | KeyCode::Char('g') => app.go_to(View::GuardList),
+        // Implements [[RFC-0007:C-SEARCH]]: enter search with single-focus input.
+        KeyCode::Char('6') | KeyCode::Char('s') => {
+            app.go_to(View::Search);
+            app.enter_search_mode();
+        }
+        // Implements [[RFC-0007:C-LOOP-VIEWS]]: dashboard entry point.
+        KeyCode::Char('7') | KeyCode::Char('l') => app.go_to(View::LoopList),
+        // Implements [[RFC-0007:C-DIAGNOSTICS]]: dashboard entry point.
+        KeyCode::Char('8') | KeyCode::Char('d') => app.go_to(View::DiagnosticList),
+        // Implements [[RFC-0007:C-COCKPIT-VIEWS]]: dashboard entry point.
+        KeyCode::Char('9') => app.go_to(View::ReleaseList),
+        // Implements [[RFC-0007:C-COCKPIT-VIEWS]]: dashboard entry point.
+        KeyCode::Char('t') => app.go_to(View::TagList),
         KeyCode::Esc => app.should_quit = true,
         _ => {}
     }
@@ -102,12 +141,46 @@ fn handle_list_keys(app: &mut App, key: KeyEvent) {
     }
 }
 
+fn handle_search_keys(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Char('q') => app.should_quit = true,
+        KeyCode::Char('j') | KeyCode::Down => app.select_next(),
+        KeyCode::Char('k') | KeyCode::Up => app.select_prev(),
+        KeyCode::Char('g') => app.select_top(),
+        KeyCode::Char('G') => app.select_bottom(),
+        // Implements [[RFC-0007:C-SEARCH]]: selected result opens contextual detail.
+        KeyCode::Enter => app.enter_detail(),
+        // Implements [[RFC-0007:C-SEARCH]]: search keeps a single focused input mode.
+        KeyCode::Char('/') | KeyCode::Char('e') => app.enter_search_mode(),
+        // Implements [[RFC-0007:C-HUMAN-UX]]: keyboard-only return navigation.
+        KeyCode::Esc => app.go_back(),
+        _ => {}
+    }
+}
+
+fn handle_search_input(app: &mut App, key: KeyEvent) {
+    match key.code {
+        // Implements [[RFC-0007:C-HUMAN-UX]]: leave focused input without mutating state.
+        KeyCode::Esc => app.exit_search_mode(),
+        // Implements [[RFC-0007:C-SEARCH]]: submit query through the CLI search contract.
+        KeyCode::Enter => {
+            app.exit_search_mode();
+            app.submit_search();
+        }
+        KeyCode::Backspace => app.pop_search_char(),
+        KeyCode::Char(ch) => app.push_search_char(ch),
+        _ => {}
+    }
+}
+
 fn handle_rfc_detail_keys(app: &mut App, key: KeyEvent) {
     match key.code {
         KeyCode::Char('q') => app.should_quit = true,
         KeyCode::Char('j') | KeyCode::Down => app.clause_next(),
         KeyCode::Char('k') | KeyCode::Up => app.clause_prev(),
+        // Implements [[RFC-0007:C-COCKPIT-VIEWS]]: browse from RFC to clause detail.
         KeyCode::Enter => app.enter_clause_detail(),
+        // Implements [[RFC-0007:C-HUMAN-UX]]: keyboard-only return navigation.
         KeyCode::Esc => app.go_back(),
         _ => {}
     }
@@ -122,6 +195,20 @@ fn handle_detail_keys(app: &mut App, key: KeyEvent) {
         KeyCode::Char('u') if is_ctrl(&key) => app.scroll_half_page_up(),
         KeyCode::PageDown => app.scroll_page_down(),
         KeyCode::PageUp => app.scroll_page_up(),
+        // Implements [[RFC-0007:C-HUMAN-UX]]: keyboard-only return navigation.
+        KeyCode::Esc => app.go_back(),
+        _ => {}
+    }
+}
+
+fn handle_loop_detail_keys(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Char('q') => app.should_quit = true,
+        // Implements [[RFC-0007:C-LOOP-DAG]]: selection changes preserve DAG context.
+        KeyCode::Char('j') | KeyCode::Down => app.loop_item_next(),
+        // Implements [[RFC-0007:C-LOOP-DAG]]: selection changes preserve DAG context.
+        KeyCode::Char('k') | KeyCode::Up => app.loop_item_prev(),
+        // Implements [[RFC-0007:C-HUMAN-UX]]: keyboard-only return navigation.
         KeyCode::Esc => app.go_back(),
         _ => {}
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,6 +4,8 @@
 //! RFCs, ADRs, and Work Items.
 
 mod app;
+mod dag;
+mod data;
 mod event;
 mod ui;
 
@@ -54,7 +56,7 @@ pub fn run(config: &Config) -> DiagnosticResult<()> {
         Terminal::new(backend).map_err(|err| terminal_error("initialize terminal", err))?;
 
     // Create app state
-    let mut app = App::new(index);
+    let mut app = App::with_project(config.clone(), index);
 
     // Run event loop
     let result = event::run_event_loop(&mut terminal, &mut app);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -13,7 +13,6 @@ use crate::config::Config;
 use crate::diagnostic::{Diagnostic, DiagnosticCode, DiagnosticLevel, DiagnosticResult};
 use crate::load::load_project;
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -49,7 +48,7 @@ pub fn run(config: &Config) -> DiagnosticResult<()> {
     // Setup terminal
     enable_raw_mode().map_err(|err| terminal_error("enable raw mode", err))?;
     let mut stdout = std::io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)
+    execute!(stdout, EnterAlternateScreen)
         .map_err(|err| terminal_error("enter alternate screen", err))?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal =
@@ -63,12 +62,8 @@ pub fn run(config: &Config) -> DiagnosticResult<()> {
 
     // Restore terminal
     disable_raw_mode().map_err(|err| terminal_error("disable raw mode", err))?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )
-    .map_err(|err| terminal_error("leave alternate screen", err))?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)
+        .map_err(|err| terminal_error("leave alternate screen", err))?;
     terminal
         .show_cursor()
         .map_err(|err| terminal_error("show cursor", err))?;

--- a/src/tui/ui/chrome.rs
+++ b/src/tui/ui/chrome.rs
@@ -6,8 +6,21 @@ fn breadcrumb(app: &App) -> String {
     match app.view {
         View::Dashboard => "Dashboard".to_string(),
         View::RfcList => "Dashboard > RFCs".to_string(),
+        View::ClauseList => "Dashboard > Clauses".to_string(),
         View::AdrList => "Dashboard > ADRs".to_string(),
         View::WorkList => "Dashboard > Work".to_string(),
+        View::GuardList => "Dashboard > Guards".to_string(),
+        View::ReleaseList => "Dashboard > Releases".to_string(),
+        View::TagList => "Dashboard > Tags".to_string(),
+        View::Search => "Dashboard > Search".to_string(),
+        View::LoopList => "Dashboard > Loops".to_string(),
+        View::LoopDetail(idx) => app
+            .supplement
+            .loops
+            .get(idx)
+            .map(|entry| format!("Dashboard > Loops > {}", entry.id))
+            .unwrap_or_else(|| "Dashboard > Loops".to_string()),
+        View::DiagnosticList => "Dashboard > Diagnostics".to_string(),
         View::RfcDetail(idx) => app
             .index
             .rfcs
@@ -26,6 +39,12 @@ fn breadcrumb(app: &App) -> String {
             .get(idx)
             .map(|item| format!("Dashboard > Work > {}", item.meta().id))
             .unwrap_or_else(|| "Dashboard > Work".to_string()),
+        View::GuardDetail(idx) => app
+            .supplement
+            .guards
+            .get(idx)
+            .map(|guard| format!("Dashboard > Guards > {}", guard.meta().id))
+            .unwrap_or_else(|| "Dashboard > Guards".to_string()),
         View::ClauseDetail(rfc_idx, clause_idx) => app
             .index
             .rfcs
@@ -44,12 +63,24 @@ fn breadcrumb(app: &App) -> String {
 fn header_status(app: &mut App) -> String {
     match app.view {
         View::Dashboard => format!(
-            "RFC {} | ADR {} | Work {}",
+            "RFC {} | ADR {} | Work {} | Guard {} | Loop {} | Diag {}",
             app.index.rfcs.len(),
             app.index.adrs.len(),
-            app.index.work_items.len()
+            app.index.work_items.len(),
+            app.supplement.guards.len(),
+            app.supplement.loops.len(),
+            app.supplement.diagnostics.len()
         ),
-        View::RfcList | View::AdrList | View::WorkList => {
+        View::RfcList
+        | View::ClauseList
+        | View::AdrList
+        | View::WorkList
+        | View::GuardList
+        | View::ReleaseList
+        | View::TagList
+        | View::Search
+        | View::LoopList
+        | View::DiagnosticList => {
             let total = app.list_total_len();
             let shown = app.list_len();
             let mut parts = vec![format!("Shown {}/{}", shown, total)];
@@ -61,8 +92,26 @@ fn header_status(app: &mut App) -> String {
             } else if app.filter_active() {
                 parts.push(format!("Filter: {}", app.filter_query));
             }
+            if app.view == View::Search {
+                if app.search_mode {
+                    parts.push(format!("Query: {}_", app.search_query));
+                } else if !app.search_query.is_empty() {
+                    parts.push(format!("Query: {}", app.search_query));
+                }
+            }
             parts.join(" | ")
         }
+        View::LoopDetail(idx) => app
+            .current_loop_state(idx)
+            .map(|state| {
+                format!(
+                    "{} | round {} | {}",
+                    state.loop_meta.state.as_str(),
+                    state.loop_meta.current_round,
+                    state.loop_meta.next_action.as_str()
+                )
+            })
+            .unwrap_or_else(|| "invalid loop state".to_string()),
         _ => String::new(),
     }
 }
@@ -92,12 +141,52 @@ impl<'a> Header<'a> {
 fn bindings_for_view(view: View) -> &'static [&'static str] {
     match view {
         View::Dashboard => &[
-            "1/r", "RFCs", "2/a", "ADRs", "3/w", "Work", "?", "Help", "q", "Quit",
+            "r",
+            "RFCs",
+            "c",
+            "Clauses",
+            "a",
+            "ADRs",
+            "w",
+            "Work",
+            "s",
+            "Search",
+            "l",
+            "Loops",
+            "d",
+            "Diagnostics",
+            "?",
+            "Help",
+            "q",
+            "Quit",
         ],
-        View::RfcList | View::AdrList | View::WorkList => &[
+        View::RfcList
+        | View::ClauseList
+        | View::AdrList
+        | View::WorkList
+        | View::GuardList
+        | View::ReleaseList
+        | View::TagList
+        | View::LoopList
+        | View::DiagnosticList => &[
             "j/k", "Navigate", "Enter", "View", "Esc", "Back", "/", "Filter", "g/G", "Jump", "?",
             "Help", "q", "Quit",
         ],
+        View::Search => &[
+            "e//",
+            "Edit Query",
+            "Enter",
+            "View",
+            "j/k",
+            "Navigate",
+            "Esc",
+            "Back",
+            "?",
+            "Help",
+            "q",
+            "Quit",
+        ],
+        View::LoopDetail(_) => &["j/k", "Select", "Esc", "Back", "?", "Help", "q", "Quit"],
         View::RfcDetail(_) => &[
             "j/k",
             "Navigate",
@@ -110,7 +199,10 @@ fn bindings_for_view(view: View) -> &'static [&'static str] {
             "q",
             "Quit",
         ],
-        View::AdrDetail(_) | View::WorkDetail(_) | View::ClauseDetail(_, _) => &[
+        View::AdrDetail(_)
+        | View::WorkDetail(_)
+        | View::GuardDetail(_)
+        | View::ClauseDetail(_, _) => &[
             "j/k", "Scroll", "^d/^u", "Page", "Esc", "Back", "?", "Help", "q", "Quit",
         ],
     }

--- a/src/tui/ui/chrome.rs
+++ b/src/tui/ui/chrome.rs
@@ -248,3 +248,148 @@ impl<'a> Footer<'a> {
         .render(frame, area);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{adr, clause, project_index, render_app, rfc, work_item};
+    use super::*;
+    use crate::loop_state::LoopState;
+    use crate::model::{AdrStatus, RfcPhase, RfcStatus, WorkItemStatus};
+    use crate::tui::data::TuiLoopEntry;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn breadcrumb_covers_primary_and_detail_views() -> Result<(), Box<dyn std::error::Error>> {
+        let mut app = chrome_app()?;
+
+        for (view, expected) in [
+            (View::Dashboard, "Dashboard"),
+            (View::RfcList, "Dashboard > RFCs"),
+            (View::ClauseList, "Dashboard > Clauses"),
+            (View::AdrList, "Dashboard > ADRs"),
+            (View::WorkList, "Dashboard > Work"),
+            (View::GuardList, "Dashboard > Guards"),
+            (View::ReleaseList, "Dashboard > Releases"),
+            (View::TagList, "Dashboard > Tags"),
+            (View::Search, "Dashboard > Search"),
+            (View::LoopList, "Dashboard > Loops"),
+            (View::DiagnosticList, "Dashboard > Diagnostics"),
+            (View::RfcDetail(0), "Dashboard > RFCs > RFC-0001"),
+            (View::AdrDetail(0), "Dashboard > ADRs > ADR-0001"),
+            (View::WorkDetail(0), "Dashboard > Work > WI-2026-01-01-001"),
+            (
+                View::ClauseDetail(0, 0),
+                "Dashboard > RFCs > RFC-0001 > C-TEST",
+            ),
+            (
+                View::LoopDetail(0),
+                "Dashboard > Loops > LOOP-2026-06-07-001",
+            ),
+        ] {
+            app.view = view;
+            assert_eq!(breadcrumb(&app), expected);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn header_status_covers_dashboard_list_search_and_loop()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut app = chrome_app()?;
+
+        assert!(header_status(&mut app).contains("RFC 1"));
+
+        app.go_to(View::RfcList);
+        assert!(header_status(&mut app).contains("Shown 1/1"));
+        app.enter_filter_mode();
+        app.filter_query = "rfc".to_string();
+        assert!(header_status(&mut app).contains("Filter: /rfc_"));
+
+        app.go_to(View::Search);
+        app.search_query = "work".to_string();
+        app.enter_search_mode();
+        assert!(header_status(&mut app).contains("Query: work_"));
+
+        app.view = View::LoopDetail(0);
+        assert!(header_status(&mut app).contains("start"));
+        app.view = View::LoopDetail(99);
+        assert_eq!(header_status(&mut app), "invalid loop state");
+        Ok(())
+    }
+
+    #[test]
+    fn footer_bindings_cover_all_view_groups() {
+        for view in [
+            View::Dashboard,
+            View::RfcList,
+            View::Search,
+            View::LoopDetail(0),
+            View::RfcDetail(0),
+            View::WorkDetail(0),
+        ] {
+            let line = keybind_line(bindings_for_view(view));
+            assert!(line.width() > 0);
+        }
+    }
+
+    #[test]
+    fn header_and_footer_render_visible_chrome() -> Result<(), Box<dyn std::error::Error>> {
+        let mut app = chrome_app()?;
+        app.view = View::RfcList;
+
+        let (_, rendered) = render_app(100, 6, app, |frame, app| {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(3), Constraint::Length(3)])
+                .split(frame.area());
+            Header::new(app).render(frame, chunks[0]);
+            Footer::new(app.view, Some("status")).render(frame, chunks[1]);
+        })?;
+
+        assert!(rendered.iter().any(|line| line.contains("govctl")));
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.contains("Dashboard > RFCs"))
+        );
+        assert!(rendered.iter().any(|line| line.contains("status")));
+        Ok(())
+    }
+
+    fn chrome_app() -> Result<App, Box<dyn std::error::Error>> {
+        let mut rfc = rfc(
+            "RFC-0001",
+            "RFC title",
+            RfcStatus::Normative,
+            RfcPhase::Impl,
+            &[],
+        );
+        rfc.clauses
+            .push(clause("C-TEST", "Clause title", "Clause text"));
+        let mut app = App::new(project_index(
+            vec![rfc],
+            vec![adr("ADR-0001", "ADR title", AdrStatus::Accepted, &[])],
+            vec![work_item(
+                "WI-2026-01-01-001",
+                "Work title",
+                WorkItemStatus::Active,
+                &[],
+            )],
+        ));
+
+        let work_id = "WI-2026-06-07-001";
+        let mut dependencies = BTreeMap::new();
+        dependencies.insert(work_id.to_string(), Vec::new());
+        app.supplement.loops.push(TuiLoopEntry {
+            id: "LOOP-2026-06-07-001".to_string(),
+            state: Some(LoopState::new(
+                "LOOP-2026-06-07-001",
+                vec![work_id.to_string()],
+                vec![work_id.to_string()],
+                dependencies,
+            )?),
+            diagnostic: None,
+        });
+        Ok(app)
+    }
+}

--- a/src/tui/ui/dashboard.rs
+++ b/src/tui/ui/dashboard.rs
@@ -4,18 +4,26 @@ use crate::status_counts::{count_by, counts_for_keys};
 use ratatui::{prelude::*, widgets::Paragraph};
 
 pub(super) fn draw(frame: &mut Frame, app: &App, area: Rect) {
-    let content_chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage(33),
-            Constraint::Percentage(34),
-            Constraint::Percentage(33),
-        ])
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(8), Constraint::Min(8)])
         .split(area);
 
-    frame.render_widget(rfc_stats(app), content_chunks[0]);
-    frame.render_widget(adr_stats(app), content_chunks[1]);
-    frame.render_widget(work_stats(app), content_chunks[2]);
+    let summary_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+        ])
+        .split(rows[0]);
+
+    frame.render_widget(rfc_stats(app), summary_chunks[0]);
+    frame.render_widget(adr_stats(app), summary_chunks[1]);
+    frame.render_widget(work_stats(app), summary_chunks[2]);
+    frame.render_widget(ops_stats(app), summary_chunks[3]);
+    frame.render_widget(cockpit_menu(app), rows[1]);
 }
 
 fn summary_block(
@@ -73,6 +81,110 @@ fn work_stats(app: &App) -> Paragraph<'static> {
         ],
         app.index.work_items.len(),
     )
+}
+
+fn ops_stats(app: &App) -> Paragraph<'static> {
+    let error_count = app
+        .supplement
+        .diagnostics
+        .iter()
+        .filter(|diag| diag.level == crate::diagnostic::DiagnosticLevel::Error)
+        .count();
+    let warning_count = app
+        .supplement
+        .diagnostics
+        .iter()
+        .filter(|diag| diag.level == crate::diagnostic::DiagnosticLevel::Warning)
+        .count();
+    // Diagnostics are shown below as an error/warning breakdown, not as primary Ops items.
+    let total = app.supplement.guards.len() + app.supplement.loops.len();
+
+    summary_block(
+        "Ops",
+        Color::Cyan,
+        vec![
+            SummaryMetric::new(
+                "G",
+                Color::LightBlue,
+                "Guards: ",
+                app.supplement.guards.len(),
+            ),
+            SummaryMetric::new("L", Color::Yellow, "Loops:  ", app.supplement.loops.len()),
+            SummaryMetric::new("!", Color::Red, "Errors: ", error_count),
+            SummaryMetric::new("?", Color::Yellow, "Warns:  ", warning_count),
+        ],
+        total,
+    )
+}
+
+fn cockpit_menu(app: &App) -> Paragraph<'static> {
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("Read-only cockpit", Style::default().fg(Color::Cyan).bold()),
+            Span::raw("  "),
+            Span::styled("RFC-0007", Style::default().fg(Color::DarkGray)),
+        ]),
+        Line::from(""),
+        menu_line("r", "RFCs", app.index.rfcs.len(), "governance requirements"),
+        menu_line(
+            "c",
+            "Clauses",
+            app.supplement.clauses.len(),
+            "normative obligations",
+        ),
+        menu_line("a", "ADRs", app.index.adrs.len(), "accepted decisions"),
+        menu_line("w", "Work", app.index.work_items.len(), "planned outcomes"),
+        menu_line(
+            "g",
+            "Guards",
+            app.supplement.guards.len(),
+            "verification commands",
+        ),
+        menu_line(
+            "9",
+            "Releases",
+            app.supplement.releases.len(),
+            "released artifacts",
+        ),
+        menu_line("t", "Tags", app.supplement.tags.len(), "repository tags"),
+        menu_line(
+            "s",
+            "Search",
+            app.search_results.len(),
+            "project-wide discovery",
+        ),
+        menu_line(
+            "l",
+            "Loops",
+            app.supplement.loops.len(),
+            "local execution state",
+        ),
+        menu_line(
+            "d",
+            "Diagnostics",
+            app.supplement.diagnostics.len(),
+            "check findings",
+        ),
+    ];
+    Paragraph::new(lines)
+        .block(super::rounded_block("Cockpit").border_style(Style::default().fg(Color::DarkGray)))
+}
+
+fn menu_line(
+    key: &'static str,
+    label: &'static str,
+    count: usize,
+    hint: &'static str,
+) -> Line<'static> {
+    Line::from(vec![
+        Span::raw("  "),
+        Span::styled(format!("[{key}]"), Style::default().fg(Color::Cyan).bold()),
+        Span::raw(" "),
+        Span::styled(format!("{label:<12}"), Style::default().bold()),
+        Span::styled(format!("{count:>4}"), Style::default().fg(Color::Yellow)),
+        Span::raw("  "),
+        Span::styled(hint, Style::default().fg(Color::DarkGray)),
+    ])
 }
 
 #[cfg(test)]

--- a/src/tui/ui/dashboard_tests.rs
+++ b/src/tui/ui/dashboard_tests.rs
@@ -6,13 +6,24 @@ use crate::model::{AdrStatus, RfcPhase, RfcStatus, WorkItemStatus};
 fn dashboard_draws_summary_counts() -> Result<(), Box<dyn std::error::Error>> {
     let app = App::new(dashboard_project_index());
 
-    let (_, rendered) = render_app(90, 8, app, |frame, app| draw(frame, app, frame.area()))?;
-    assert!(rendered.iter().any(|line| line.contains("Draft:      1")));
-    assert!(rendered.iter().any(|line| line.contains("Normative:  1")));
-    assert!(rendered.iter().any(|line| line.contains("Proposed:   1")));
-    assert!(rendered.iter().any(|line| line.contains("Accepted:   1")));
-    assert!(rendered.iter().any(|line| line.contains("Queue:  1")));
-    assert!(rendered.iter().any(|line| line.contains("Active: 1")));
+    let (_, rendered) = render_app(120, 24, app, |frame, app| draw(frame, app, frame.area()))?;
+    assert!(rendered.iter().any(|line| line.contains("Draft:")));
+    assert!(rendered.iter().any(|line| line.contains("Normative:")));
+    assert!(rendered.iter().any(|line| line.contains("Proposed:")));
+    assert!(rendered.iter().any(|line| line.contains("Accepted:")));
+    assert!(rendered.iter().any(|line| line.contains("Queue:")));
+    assert!(rendered.iter().any(|line| line.contains("Active:")));
+    assert!(
+        rendered
+            .iter()
+            .any(|line| line.contains("Read-only cockpit"))
+    );
+    assert!(rendered.iter().any(|line| line.contains("[s]")));
+    assert!(rendered.iter().any(|line| line.contains("Loops")));
+    assert!(rendered.iter().any(|line| line.contains("[9]")));
+    assert!(rendered.iter().any(|line| line.contains("Releases")));
+    assert!(rendered.iter().any(|line| line.contains("[t]")));
+    assert!(rendered.iter().any(|line| line.contains("Tags")));
     Ok(())
 }
 

--- a/src/tui/ui/detail.rs
+++ b/src/tui/ui/detail.rs
@@ -3,9 +3,10 @@ use super::{
     components::{ClauseListRow, SelectableList, StatusText},
     phase_style, rounded_block, wrapped_line_count,
 };
+use crate::tui::dag::dag_lines;
 use ratatui::{
     prelude::*,
-    widgets::{Paragraph, Wrap},
+    widgets::{List, ListItem, Paragraph, Wrap},
 };
 use std::borrow::Cow;
 
@@ -255,6 +256,179 @@ pub(super) fn draw_work(
     let markdown = crate::render::render_work_item(item).unwrap_or_default();
     let title = format!("📌 {}", item.meta().id);
     MarkdownDetailPanel::new(&title, Color::Yellow, app.scroll, &markdown).render(frame, area)
+}
+
+// Implements [[RFC-0007:C-COCKPIT-VIEWS]]: guard artifacts are browsable read-only.
+pub(super) fn draw_guard(
+    frame: &mut Frame,
+    app: &mut App,
+    area: Rect,
+    idx: usize,
+) -> DetailViewport {
+    let Some(guard) = app.supplement.guards.get(idx) else {
+        return DetailViewport::new(0);
+    };
+    let meta = guard.meta();
+    let mut markdown = format!(
+        "# {}\n\n**ID:** {}\n\n**Command:** `{}`\n\n**Timeout:** {} seconds\n",
+        meta.title, meta.id, guard.spec.check.command, guard.spec.check.timeout_secs
+    );
+    if let Some(pattern) = &guard.spec.check.pattern {
+        markdown.push_str(&format!("\n**Pattern:** `{pattern}`\n"));
+    }
+    if !meta.refs.is_empty() {
+        markdown.push_str(&format!("\n**References:** {}\n", meta.refs.join(", ")));
+    }
+    if !meta.tags.is_empty() {
+        markdown.push_str(&format!("\n**Tags:** `{}`\n", meta.tags.join("`, `")));
+    }
+    let title = format!("Guard {}", meta.id);
+    MarkdownDetailPanel::new(&title, Color::LightBlue, app.scroll, &markdown).render(frame, area)
+}
+
+// Implements [[RFC-0007:C-LOOP-VIEWS]] and [[RFC-0007:C-LOOP-DAG]].
+pub(super) fn draw_loop(frame: &mut Frame, app: &mut App, area: Rect, idx: usize) {
+    let Some(entry) = app.supplement.loops.get(idx) else {
+        return;
+    };
+    let Some(state) = entry.state.as_ref() else {
+        let message = entry
+            .diagnostic
+            .as_ref()
+            .map(|diag| diag.to_string())
+            .unwrap_or_else(|| "Invalid loop state".to_string());
+        frame.render_widget(
+            Paragraph::new(message)
+                .wrap(Wrap { trim: false })
+                .block(rounded_block("Loop").border_style(Style::default().fg(Color::Red))),
+            area,
+        );
+        return;
+    };
+
+    let selected = app.selected_loop_work_id(idx);
+    let chunks = if area.width >= 110 {
+        Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(58), Constraint::Percentage(42)])
+            .split(area)
+    } else {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+            .split(area)
+    };
+
+    let max_lines = chunks[0].height.saturating_sub(2) as usize;
+    let dag_items = match dag_lines(state, selected.as_deref(), max_lines) {
+        Ok(lines) => lines
+            .into_iter()
+            .map(|line| {
+                let style = if line.hidden {
+                    Style::default().fg(Color::DarkGray)
+                } else if line.selected {
+                    Style::default().fg(Color::Cyan).bold()
+                } else {
+                    Style::default()
+                };
+                ListItem::new(Line::from(Span::styled(line.text, style)))
+            })
+            .collect::<Vec<_>>(),
+        Err(diagnostic) => vec![ListItem::new(Line::from(Span::styled(
+            format!(
+                "DAG unavailable for {} (selected: {}, max lines: {}): {}",
+                state.loop_meta.id,
+                selected.as_deref().unwrap_or("-"),
+                max_lines,
+                diagnostic
+            ),
+            Style::default().fg(Color::Red),
+        )))],
+    };
+    let dag = List::new(dag_items)
+        .block(rounded_block("Dependency DAG").border_style(Style::default().fg(Color::Yellow)));
+    frame.render_widget(dag, chunks[0]);
+
+    let inspector = loop_inspector_lines(state, selected.as_deref());
+    frame.render_widget(
+        Paragraph::new(inspector)
+            .wrap(Wrap { trim: false })
+            .block(rounded_block("Selected Work").border_style(Style::default().fg(Color::Cyan))),
+        chunks[1],
+    );
+}
+
+// Implements [[RFC-0007:C-LOOP-VIEWS]]: selected loop work inspector.
+fn loop_inspector_lines<'a>(
+    state: &'a crate::loop_state::LoopState,
+    selected: Option<&'a str>,
+) -> Vec<Line<'a>> {
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled("Loop: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(state.loop_meta.id.clone()),
+        ]),
+        Line::from(vec![
+            Span::styled("State: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(state.loop_meta.state.as_str()),
+        ]),
+        Line::from(vec![
+            Span::styled("Next:  ", Style::default().fg(Color::DarkGray)),
+            Span::raw(state.loop_meta.next_action.as_str()),
+        ]),
+        Line::from(vec![
+            Span::styled("Work:  ", Style::default().fg(Color::DarkGray)),
+            Span::raw(state.loop_meta.work.join(", ")),
+        ]),
+        Line::from(""),
+    ];
+
+    let Some(work_id) = selected else {
+        lines.push(Line::from("No work item selected"));
+        return lines;
+    };
+    lines.push(Line::from(vec![
+        Span::styled("ID:     ", Style::default().fg(Color::DarkGray)),
+        Span::styled(work_id.to_string(), Style::default().bold()),
+    ]));
+    if let Some(item) = state.items.get(work_id) {
+        lines.push(Line::from(vec![
+            Span::styled("Status: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(item.status.as_str()),
+        ]));
+        lines.push(Line::from(vec![
+            Span::styled("Rounds: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(format!("{} (last {})", item.round_count, item.last_round)),
+        ]));
+    }
+    let deps = state
+        .dependencies
+        .get(work_id)
+        .filter(|deps| !deps.is_empty())
+        .map(|deps| deps.join(", "))
+        .unwrap_or_else(|| "-".to_string());
+    lines.push(Line::from(vec![
+        Span::styled("Needs:  ", Style::default().fg(Color::DarkGray)),
+        Span::raw(deps),
+    ]));
+    let dependents = state
+        .dependencies
+        .iter()
+        .filter_map(|(candidate, deps)| {
+            deps.iter()
+                .any(|dep| dep == work_id)
+                .then_some(candidate.clone())
+        })
+        .collect::<Vec<_>>();
+    lines.push(Line::from(vec![
+        Span::styled("Feeds:  ", Style::default().fg(Color::DarkGray)),
+        Span::raw(if dependents.is_empty() {
+            "-".to_string()
+        } else {
+            dependents.join(", ")
+        }),
+    ]));
+    lines
 }
 
 pub(super) fn draw_clause(

--- a/src/tui/ui/detail_tests.rs
+++ b/src/tui/ui/detail_tests.rs
@@ -1,7 +1,10 @@
 use super::super::super::app::{App, View};
 use super::super::test_support::{adr, clause, project_index, render_app, rfc, work_item};
 use super::*;
+use crate::loop_state::{LoopState, LoopWorkItemStatus};
 use crate::model::{AdrStatus, RfcPhase, RfcStatus, WorkItemStatus};
+use crate::tui::data::TuiLoopEntry;
+use std::collections::BTreeMap;
 
 #[test]
 fn detail_viewport_footer_status_clamps_scroll() {
@@ -41,6 +44,33 @@ fn detail_renderers_draw_expected_content() -> Result<(), Box<dyn std::error::Er
     assert!(rendered.iter().any(|line| line.contains("C-TEST")));
     assert!(rendered.iter().any(|line| line.contains("Clause text")));
 
+    Ok(())
+}
+
+#[test]
+fn loop_detail_renders_dag_and_inspector_on_narrow_viewport()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut app = App::new(detail_project_index());
+    app.view = View::LoopDetail(0);
+    app.loop_selected = 1;
+    app.supplement.loops.push(TuiLoopEntry {
+        id: "LOOP-2026-06-06-001".to_string(),
+        state: Some(sample_loop_state()?),
+        diagnostic: None,
+    });
+
+    let (_, rendered) = render_app(72, 24, app, |frame, app| {
+        draw_loop(frame, app, frame.area(), 0);
+    })?;
+
+    assert!(rendered.iter().any(|line| line.contains("Dependency DAG")));
+    assert!(rendered.iter().any(|line| line.contains("Selected Work")));
+    assert!(
+        rendered
+            .iter()
+            .any(|line| line.contains("WI-2026-06-06-002"))
+    );
+    assert!(rendered.iter().any(|line| line.contains("Status:")));
     Ok(())
 }
 
@@ -91,4 +121,24 @@ fn detail_project_index() -> crate::model::ProjectIndex {
             &["cleanup"],
         )],
     )
+}
+
+fn sample_loop_state() -> crate::diagnostic::DiagnosticResult<LoopState> {
+    let mut dependencies = BTreeMap::new();
+    dependencies.insert("WI-2026-06-06-001".to_string(), vec![]);
+    dependencies.insert(
+        "WI-2026-06-06-002".to_string(),
+        vec!["WI-2026-06-06-001".to_string()],
+    );
+    let mut state = LoopState::new(
+        "LOOP-2026-06-06-001",
+        vec!["WI-2026-06-06-002".to_string()],
+        vec![
+            "WI-2026-06-06-001".to_string(),
+            "WI-2026-06-06-002".to_string(),
+        ],
+        dependencies,
+    )?;
+    state.set_item_status("WI-2026-06-06-002", LoopWorkItemStatus::Active)?;
+    Ok(state)
 }

--- a/src/tui/ui/help.rs
+++ b/src/tui/ui/help.rs
@@ -106,3 +106,42 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
 
     horizontal[1]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{project_index, render_app};
+    use super::*;
+
+    #[test]
+    fn centered_rect_returns_inner_popup_area() {
+        let area = Rect::new(0, 0, 100, 40);
+        let rect = centered_rect(70, 50, area);
+
+        assert_eq!(rect.width, 70);
+        assert_eq!(rect.height, 20);
+        assert_eq!(rect.x, 15);
+        assert_eq!(rect.y, 10);
+    }
+
+    #[test]
+    fn help_overlay_renders_view_specific_sections() -> Result<(), Box<dyn std::error::Error>> {
+        for (view, expected) in [
+            (View::Dashboard, "Dashboard"),
+            (View::RfcList, "List"),
+            (View::Search, "Search"),
+            (View::LoopDetail(0), "Loop DAG"),
+            (View::RfcDetail(0), "RFC Detail"),
+            (View::WorkDetail(0), "Detail"),
+        ] {
+            let mut app = App::new(project_index(vec![], vec![], vec![]));
+            app.view = view;
+            let (_, rendered) = render_app(100, 30, app, |frame, app| {
+                draw_overlay(frame, app);
+            })?;
+
+            assert!(rendered.iter().any(|line| line.contains("Global")));
+            assert!(rendered.iter().any(|line| line.contains(expected)));
+        }
+        Ok(())
+    }
+}

--- a/src/tui/ui/help.rs
+++ b/src/tui/ui/help.rs
@@ -23,11 +23,26 @@ pub(super) fn draw_overlay(frame: &mut Frame, app: &App) {
     match app.view {
         View::Dashboard => {
             lines.push(Line::from("Dashboard"));
-            lines.push(Line::from("  1/r    RFC list"));
-            lines.push(Line::from("  2/a    ADR list"));
-            lines.push(Line::from("  3/w    Work list"));
+            lines.push(Line::from("  r      RFC list"));
+            lines.push(Line::from("  c      Clause list"));
+            lines.push(Line::from("  a      ADR list"));
+            lines.push(Line::from("  w      Work list"));
+            lines.push(Line::from("  g      Guard list"));
+            lines.push(Line::from("  s      Search"));
+            lines.push(Line::from("  l      Loop list"));
+            lines.push(Line::from("  d      Diagnostics"));
+            lines.push(Line::from("  9      Releases"));
+            lines.push(Line::from("  t      Tags"));
         }
-        View::RfcList | View::AdrList | View::WorkList => {
+        View::RfcList
+        | View::ClauseList
+        | View::AdrList
+        | View::WorkList
+        | View::GuardList
+        | View::ReleaseList
+        | View::TagList
+        | View::LoopList
+        | View::DiagnosticList => {
             lines.push(Line::from("List"));
             lines.push(Line::from("  j/k    Move selection"));
             lines.push(Line::from("  Enter  View detail"));
@@ -36,13 +51,28 @@ pub(super) fn draw_overlay(frame: &mut Frame, app: &App) {
             lines.push(Line::from("  n/p    Next/Prev match (when filtered)"));
             lines.push(Line::from("  Esc    Back (or clear filter in filter mode)"));
         }
+        View::Search => {
+            lines.push(Line::from("Search"));
+            lines.push(Line::from("  e or / Edit query"));
+            lines.push(Line::from("  Enter  View selected result"));
+            lines.push(Line::from("  j/k    Move selection"));
+            lines.push(Line::from("  Esc    Back"));
+        }
+        View::LoopDetail(_) => {
+            lines.push(Line::from("Loop DAG"));
+            lines.push(Line::from("  j/k    Select work item"));
+            lines.push(Line::from("  Esc    Back"));
+        }
         View::RfcDetail(_) => {
             lines.push(Line::from("RFC Detail"));
             lines.push(Line::from("  j/k    Move clause selection"));
             lines.push(Line::from("  Enter  View clause"));
             lines.push(Line::from("  Esc    Back"));
         }
-        View::AdrDetail(_) | View::WorkDetail(_) | View::ClauseDetail(_, _) => {
+        View::AdrDetail(_)
+        | View::WorkDetail(_)
+        | View::GuardDetail(_)
+        | View::ClauseDetail(_, _) => {
             lines.push(Line::from("Detail"));
             lines.push(Line::from("  j/k      Scroll line"));
             lines.push(Line::from("  Ctrl+d/u Half-page"));

--- a/src/tui/ui/lists.rs
+++ b/src/tui/ui/lists.rs
@@ -2,7 +2,12 @@ use super::super::app::App;
 use super::components::{
     PhaseCell, ResourceListRow, ResourceTable, ResourceTableSpec, StatusText, TagsCell,
 };
-use ratatui::{prelude::*, widgets::Row};
+use super::rounded_block;
+use crate::diagnostic::DiagnosticLevel;
+use ratatui::{
+    prelude::*,
+    widgets::{Paragraph, Row, Wrap},
+};
 
 pub(super) fn draw_rfc(frame: &mut Frame, app: &mut App, area: Rect) {
     let indices = app.list_indices();
@@ -98,6 +103,273 @@ pub(super) fn draw_work(frame: &mut Frame, app: &mut App, area: Rect) {
         },
     )
     .render(frame, area, &mut app.table_state);
+}
+
+// Implements [[RFC-0007:C-COCKPIT-VIEWS]]: clause browsing view.
+pub(super) fn draw_clause(frame: &mut Frame, app: &mut App, area: Rect) {
+    let indices = app.list_indices();
+    ResourceTable::from_indexed_items(
+        &app.supplement.clauses,
+        &indices,
+        ResourceTableSpec {
+            widths: vec![
+                Constraint::Length(10),
+                Constraint::Length(18),
+                Constraint::Min(30),
+                Constraint::Length(12),
+                Constraint::Min(12),
+            ],
+            headers: &["RFC", "Clause", "Title", "Status", "Tags"],
+            header_color: Color::Magenta,
+            title: "Clauses",
+            border_color: Color::Magenta,
+        },
+        |entry| {
+            let clause = &entry.clause.spec;
+            Row::new(vec![
+                Line::from(entry.rfc_id.clone()),
+                Line::from(clause.clause_id.clone()),
+                Line::from(clause.title.clone()),
+                StatusText::new(clause.status.as_ref()).render(),
+                TagsCell::new(&clause.tags).render(),
+            ])
+        },
+    )
+    .render(frame, area, &mut app.table_state);
+}
+
+// Implements [[RFC-0007:C-COCKPIT-VIEWS]]: guard browsing view.
+pub(super) fn draw_guard(frame: &mut Frame, app: &mut App, area: Rect) {
+    let indices = app.list_indices();
+    ResourceTable::from_indexed_items(
+        &app.supplement.guards,
+        &indices,
+        ResourceTableSpec {
+            widths: vec![
+                Constraint::Length(18),
+                Constraint::Min(30),
+                Constraint::Length(10),
+                Constraint::Min(24),
+            ],
+            headers: &["ID", "Title", "Timeout", "Command"],
+            header_color: Color::LightBlue,
+            title: "Guards",
+            border_color: Color::LightBlue,
+        },
+        |guard| {
+            Row::new(vec![
+                Line::from(guard.meta().id.clone()),
+                Line::from(guard.meta().title.clone()),
+                Line::from(format!("{}s", guard.spec.check.timeout_secs)),
+                Line::from(guard.spec.check.command.clone()),
+            ])
+        },
+    )
+    .render(frame, area, &mut app.table_state);
+}
+
+// Implements [[RFC-0007:C-COCKPIT-VIEWS]]: release browsing view.
+pub(super) fn draw_release(frame: &mut Frame, app: &mut App, area: Rect) {
+    let indices = app.list_indices();
+    ResourceTable::from_indexed_items(
+        &app.supplement.releases,
+        &indices,
+        ResourceTableSpec {
+            widths: vec![
+                Constraint::Length(12),
+                Constraint::Length(12),
+                Constraint::Length(8),
+                Constraint::Min(30),
+            ],
+            headers: &["Version", "Date", "Refs", "Work Items"],
+            header_color: Color::Cyan,
+            title: "Releases",
+            border_color: Color::Cyan,
+        },
+        |release| {
+            Row::new(vec![
+                Line::from(release.version.clone()),
+                Line::from(release.date.clone()),
+                Line::from(release.refs.len().to_string()),
+                Line::from(release.refs.join(", ")),
+            ])
+        },
+    )
+    .render(frame, area, &mut app.table_state);
+}
+
+// Implements [[RFC-0007:C-COCKPIT-VIEWS]]: tag browsing view.
+pub(super) fn draw_tag(frame: &mut Frame, app: &mut App, area: Rect) {
+    let indices = app.list_indices();
+    ResourceTable::from_indexed_items(
+        &app.supplement.tags,
+        &indices,
+        ResourceTableSpec {
+            widths: vec![Constraint::Min(20), Constraint::Length(8)],
+            headers: &["Tag", "Count"],
+            header_color: Color::Magenta,
+            title: "Tags",
+            border_color: Color::Magenta,
+        },
+        |tag| {
+            Row::new(vec![
+                Line::from(tag.name.clone()),
+                Line::from(tag.count.to_string()),
+            ])
+        },
+    )
+    .render(frame, area, &mut app.table_state);
+}
+
+// Implements [[RFC-0007:C-LOOP-VIEWS]]: loop list view.
+pub(super) fn draw_loop(frame: &mut Frame, app: &mut App, area: Rect) {
+    let indices = app.list_indices();
+    ResourceTable::from_indexed_items(
+        app.loop_entries(),
+        &indices,
+        ResourceTableSpec {
+            widths: vec![
+                Constraint::Length(22),
+                Constraint::Length(12),
+                Constraint::Length(8),
+                Constraint::Length(8),
+                Constraint::Length(16),
+                Constraint::Min(28),
+            ],
+            headers: &["ID", "State", "Items", "Rounds", "Action", "Work"],
+            header_color: Color::Yellow,
+            title: "Loops",
+            border_color: Color::Yellow,
+        },
+        |entry| {
+            if let Some(state) = &entry.state {
+                Row::new(vec![
+                    Line::from(entry.id.clone()),
+                    Line::from(state.loop_meta.state.as_str()),
+                    Line::from(state.loop_meta.resolved.len().to_string()),
+                    Line::from(
+                        state
+                            .items
+                            .values()
+                            .map(|item| item.round_count)
+                            .sum::<u32>()
+                            .to_string(),
+                    ),
+                    Line::from(state.loop_meta.next_action.as_str()),
+                    Line::from(state.loop_meta.work.join(", ")),
+                ])
+            } else {
+                Row::new(vec![
+                    Line::from(entry.id.clone()),
+                    Line::from("invalid"),
+                    Line::from("-"),
+                    Line::from("-"),
+                    Line::from("-"),
+                    Line::from(
+                        entry
+                            .diagnostic
+                            .as_ref()
+                            .map(|diag| diag.message.clone())
+                            .unwrap_or_default(),
+                    ),
+                ])
+            }
+        },
+    )
+    .render(frame, area, &mut app.table_state);
+}
+
+// Implements [[RFC-0007:C-SEARCH]]: search results view.
+pub(super) fn draw_search(frame: &mut Frame, app: &mut App, area: Rect) {
+    if let Some(diagnostic) = &app.search_error {
+        let message = Text::from(vec![
+            Line::from(vec![
+                Span::styled("Search failed: ", Style::default().fg(Color::Red).bold()),
+                Span::raw(diagnostic.message.clone()),
+            ]),
+            Line::from(""),
+            Line::from(vec![
+                Span::styled("Code:   ", Style::default().fg(Color::DarkGray)),
+                Span::raw(diagnostic.code.code()),
+            ]),
+            Line::from(vec![
+                Span::styled("Target: ", Style::default().fg(Color::DarkGray)),
+                Span::raw(diagnostic.file.clone()),
+            ]),
+        ]);
+        frame.render_widget(
+            Paragraph::new(message)
+                .wrap(Wrap { trim: false })
+                .block(rounded_block("Search").border_style(Style::default().fg(Color::Red))),
+            area,
+        );
+        return;
+    }
+
+    let indices = app.list_indices();
+    ResourceTable::from_indexed_items(
+        &app.search_results,
+        &indices,
+        ResourceTableSpec {
+            widths: vec![
+                Constraint::Length(8),
+                Constraint::Length(18),
+                Constraint::Min(28),
+                Constraint::Min(36),
+            ],
+            headers: &["Kind", "ID", "Title", "Snippet"],
+            header_color: Color::Green,
+            title: "Search",
+            border_color: Color::Green,
+        },
+        |result| {
+            Row::new(vec![
+                Line::from(result.kind.clone()),
+                Line::from(result.id.clone()),
+                Line::from(result.title.clone()),
+                Line::from(result.snippet.clone()),
+            ])
+        },
+    )
+    .render(frame, area, &mut app.table_state);
+}
+
+// Implements [[RFC-0007:C-DIAGNOSTICS]]: check diagnostics view.
+pub(super) fn draw_diagnostics(frame: &mut Frame, app: &mut App, area: Rect) {
+    let indices = app.list_indices();
+    ResourceTable::from_indexed_items(
+        &app.supplement.diagnostics,
+        &indices,
+        ResourceTableSpec {
+            widths: vec![
+                Constraint::Length(9),
+                Constraint::Length(8),
+                Constraint::Min(44),
+                Constraint::Min(24),
+            ],
+            headers: &["Level", "Code", "Message", "Target"],
+            header_color: Color::Red,
+            title: "Diagnostics",
+            border_color: Color::Red,
+        },
+        |diagnostic| {
+            Row::new(vec![
+                Line::from(level_label(diagnostic.level)),
+                Line::from(diagnostic.code.code()),
+                Line::from(diagnostic.message.clone()),
+                Line::from(diagnostic.file.clone()),
+            ])
+        },
+    )
+    .render(frame, area, &mut app.table_state);
+}
+
+fn level_label(level: DiagnosticLevel) -> &'static str {
+    match level {
+        DiagnosticLevel::Error => "error",
+        DiagnosticLevel::Warning => "warning",
+        DiagnosticLevel::Info => "info",
+    }
 }
 
 #[cfg(test)]

--- a/src/tui/ui/lists_tests.rs
+++ b/src/tui/ui/lists_tests.rs
@@ -4,8 +4,11 @@ use super::*;
 use crate::cmd::search::SearchResult;
 use crate::diagnostic::{Diagnostic, DiagnosticCode};
 use crate::loop_state::LoopState;
-use crate::model::{AdrStatus, RfcPhase, RfcStatus, WorkItemStatus};
-use crate::tui::data::TuiLoopEntry;
+use crate::model::{
+    AdrStatus, GuardCheck, GuardEntry, GuardMeta, GuardSpec, Release, RfcPhase, RfcStatus,
+    WorkItemStatus,
+};
+use crate::tui::data::{TuiClauseEntry, TuiLoopEntry, TuiTagSummary};
 use std::collections::BTreeMap;
 
 #[test]
@@ -91,6 +94,74 @@ fn cockpit_list_renderers_draw_search_loop_and_diagnostic_rows()
     Ok(())
 }
 
+#[test]
+fn supplemental_list_renderers_draw_clause_guard_release_and_tag_rows()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut app = App::new(list_project_index());
+    app.view = View::ClauseList;
+    app.supplement.clauses.push(TuiClauseEntry {
+        rfc_id: "RFC-0001".to_string(),
+        clause: super::super::test_support::clause("C-LIST", "Clause row", "Clause body"),
+    });
+    let rendered = render_list_app(app, draw_clause)?;
+    assert!(rendered.iter().any(|line| line.contains("C-LIST")));
+    assert!(rendered.iter().any(|line| line.contains("Clause row")));
+
+    let mut app = App::new(list_project_index());
+    app.view = View::GuardList;
+    app.supplement.guards.push(guard_entry());
+    let rendered = render_list_app(app, draw_guard)?;
+    assert!(rendered.iter().any(|line| line.contains("GUARD-LIST")));
+    assert!(rendered.iter().any(|line| line.contains("cargo test")));
+
+    let mut app = App::new(list_project_index());
+    app.view = View::ReleaseList;
+    app.supplement.releases.push(Release {
+        version: "0.9.2".to_string(),
+        date: "2026-06-05".to_string(),
+        refs: vec!["WI-2026-01-01-001".to_string()],
+    });
+    let rendered = render_list_app(app, draw_release)?;
+    assert!(rendered.iter().any(|line| line.contains("0.9.2")));
+    assert!(
+        rendered
+            .iter()
+            .any(|line| line.contains("WI-2026-01-01-001"))
+    );
+
+    let mut app = App::new(list_project_index());
+    app.view = View::TagList;
+    app.supplement.tags.push(TuiTagSummary {
+        name: "release".to_string(),
+        count: 3,
+    });
+    let rendered = render_list_app(app, draw_tag)?;
+    assert!(rendered.iter().any(|line| line.contains("release")));
+    assert!(rendered.iter().any(|line| line.contains("3")));
+    Ok(())
+}
+
+#[test]
+fn loop_list_renderer_draws_invalid_loop_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
+    let mut app = App::new(list_project_index());
+    app.view = View::LoopList;
+    app.supplement.loops.push(TuiLoopEntry {
+        id: "LOOP-2026-06-06-002".to_string(),
+        state: None,
+        diagnostic: Some(Diagnostic::new(
+            DiagnosticCode::E1201LoopStateInvalid,
+            "bad loop state",
+            ".govctl/loops/LOOP-2026-06-06-002/state.toml",
+        )),
+    });
+
+    let rendered = render_list_app(app, draw_loop)?;
+
+    assert!(rendered.iter().any(|line| line.contains("invalid")));
+    assert!(rendered.iter().any(|line| line.contains("bad loop state")));
+    Ok(())
+}
+
 fn render_list(
     view: View,
     draw: fn(&mut Frame, &mut App, Rect),
@@ -146,4 +217,18 @@ fn loop_state() -> crate::diagnostic::DiagnosticResult<LoopState> {
     )?;
     state.loop_meta.next_action = crate::loop_state::LoopNextAction::Continue;
     Ok(state)
+}
+
+fn guard_entry() -> GuardEntry {
+    GuardEntry {
+        spec: GuardSpec {
+            govctl: GuardMeta::new("GUARD-LIST", "Guard row"),
+            check: GuardCheck {
+                command: "cargo test".to_string(),
+                timeout_secs: 30,
+                pattern: None,
+            },
+        },
+        path: "gov/guard/GUARD-LIST.toml".into(),
+    }
 }

--- a/src/tui/ui/lists_tests.rs
+++ b/src/tui/ui/lists_tests.rs
@@ -1,7 +1,12 @@
 use super::super::super::app::View;
 use super::super::test_support::{adr, project_index, render_app, rfc, work_item};
 use super::*;
+use crate::cmd::search::SearchResult;
+use crate::diagnostic::{Diagnostic, DiagnosticCode};
+use crate::loop_state::LoopState;
 use crate::model::{AdrStatus, RfcPhase, RfcStatus, WorkItemStatus};
+use crate::tui::data::TuiLoopEntry;
+use std::collections::BTreeMap;
 
 #[test]
 fn list_renderers_draw_table_rows() -> Result<(), Box<dyn std::error::Error>> {
@@ -26,6 +31,66 @@ fn list_renderers_draw_table_rows() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn cockpit_list_renderers_draw_search_loop_and_diagnostic_rows()
+-> Result<(), Box<dyn std::error::Error>> {
+    let mut app = App::new(list_project_index());
+    app.view = View::Search;
+    app.search_results.push(SearchResult {
+        kind: "rfc".to_string(),
+        id: "RFC-0001".to_string(),
+        title: "RFC title".to_string(),
+        path: "gov/rfc/RFC-0001/rfc.toml".to_string(),
+        snippet: "human cockpit".to_string(),
+        score: None,
+        status: Some("normative".to_string()),
+    });
+    let rendered = render_list_app(app, draw_search)?;
+    assert!(rendered.iter().any(|line| line.contains("human cockpit")));
+
+    let mut app = App::new(list_project_index());
+    app.view = View::LoopList;
+    app.supplement.loops.push(TuiLoopEntry {
+        id: "LOOP-2026-06-06-001".to_string(),
+        state: Some(loop_state()?),
+        diagnostic: None,
+    });
+    let rendered = render_list_app(app, draw_loop)?;
+    assert!(
+        rendered
+            .iter()
+            .any(|line| line.contains("LOOP-2026-06-06-001"))
+    );
+    assert!(rendered.iter().any(|line| line.contains("continue")));
+
+    let mut app = App::new(list_project_index());
+    app.view = View::DiagnosticList;
+    app.supplement.diagnostics.push(Diagnostic::new(
+        DiagnosticCode::E0901IoError,
+        "diagnostic for humans",
+        "gov/work/WI-2026-01-01-001.toml",
+    ));
+    let rendered = render_list_app(app, draw_diagnostics)?;
+    assert!(rendered.iter().any(|line| line.contains("E0901")));
+    assert!(
+        rendered
+            .iter()
+            .any(|line| line.contains("diagnostic for humans"))
+    );
+
+    let mut app = App::new(list_project_index());
+    app.view = View::Search;
+    app.search_error = Some(Diagnostic::new(
+        DiagnosticCode::E0806InvalidPattern,
+        "invalid search syntax",
+        "search",
+    ));
+    let rendered = render_list_app(app, draw_search)?;
+    assert!(rendered.iter().any(|line| line.contains("Search failed")));
+    assert!(rendered.iter().any(|line| line.contains("E0806")));
+    Ok(())
+}
+
 fn render_list(
     view: View,
     draw: fn(&mut Frame, &mut App, Rect),
@@ -34,6 +99,14 @@ fn render_list(
     app.view = view;
 
     let (_, rendered) = render_app(110, 8, app, |frame, app| draw(frame, app, frame.area()))?;
+    Ok(rendered)
+}
+
+fn render_list_app(
+    app: App,
+    draw: fn(&mut Frame, &mut App, Rect),
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let (_, rendered) = render_app(120, 10, app, |frame, app| draw(frame, app, frame.area()))?;
     Ok(rendered)
 }
 
@@ -59,4 +132,18 @@ fn list_project_index() -> crate::model::ProjectIndex {
             &["cleanup"],
         )],
     )
+}
+
+fn loop_state() -> crate::diagnostic::DiagnosticResult<LoopState> {
+    let work_id = "WI-2026-06-06-001";
+    let mut dependencies = BTreeMap::new();
+    dependencies.insert(work_id.to_string(), Vec::new());
+    let mut state = LoopState::new(
+        "LOOP-2026-06-06-001",
+        vec![work_id.to_string()],
+        vec![work_id.to_string()],
+        dependencies,
+    )?;
+    state.loop_meta.next_action = crate::loop_state::LoopNextAction::Continue;
+    Ok(state)
 }

--- a/src/tui/ui/mod.rs
+++ b/src/tui/ui/mod.rs
@@ -64,12 +64,44 @@ fn draw_content(frame: &mut Frame, app: &mut App, area: Rect) -> Option<DetailVi
             lists::draw_rfc(frame, app, area);
             None
         }
+        View::ClauseList => {
+            lists::draw_clause(frame, app, area);
+            None
+        }
         View::AdrList => {
             lists::draw_adr(frame, app, area);
             None
         }
         View::WorkList => {
             lists::draw_work(frame, app, area);
+            None
+        }
+        View::GuardList => {
+            lists::draw_guard(frame, app, area);
+            None
+        }
+        View::ReleaseList => {
+            lists::draw_release(frame, app, area);
+            None
+        }
+        View::TagList => {
+            lists::draw_tag(frame, app, area);
+            None
+        }
+        View::Search => {
+            lists::draw_search(frame, app, area);
+            None
+        }
+        View::LoopList => {
+            lists::draw_loop(frame, app, area);
+            None
+        }
+        View::LoopDetail(idx) => {
+            detail::draw_loop(frame, app, area, idx);
+            None
+        }
+        View::DiagnosticList => {
+            lists::draw_diagnostics(frame, app, area);
             None
         }
         View::RfcDetail(idx) => {
@@ -84,6 +116,7 @@ fn draw_content(frame: &mut Frame, app: &mut App, area: Rect) -> Option<DetailVi
             // Implements [[RFC-0003:C-DETAIL]]
             Some(detail::draw_work(frame, app, area, idx))
         }
+        View::GuardDetail(idx) => Some(detail::draw_guard(frame, app, area, idx)),
         View::ClauseDetail(rfc_idx, clause_idx) => {
             // Implements [[RFC-0003:C-DETAIL]]
             Some(detail::draw_clause(frame, app, area, rfc_idx, clause_idx))


### PR DESCRIPTION
Implement TUI v2 as a human-first read-only cockpit with search, diagnostics, loop state browsing, and loop dependency DAG visualization.

Add RFC-0007 and ADR-0049 to specify the first-phase TUI boundary and architecture, plus rendered RFC docs and changelog output from the completed work item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TUI v2 read-only cockpit (v0.2.0): dashboard, artifact browsing, integrated search, loops list/detail with deterministic dependency DAG and inspector, diagnostics view, keyboard-first UX, cockpit menu with Ops stats; added guard, release, and tag views plus guard detail.

* **Bug Fixes**
  * govctl check no longer prints a misleading checked-count summary before schema/load diagnostics.
  * Improved list ordering, search cache/invalidation, loop diagnostics visibility, DAG fallback behavior, and Ops summary consistency.

* **Documentation**
  * Added RFC-0007, ADR-0049, and work items specifying the read-only cockpit, responsibility boundaries, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->