### PR TITLE
fix(skills): quote argument-hint so Copilot CLI 1.0.65 parses it as string

### DIFF
--- a/.claude/skills/adr-writer/SKILL.md
+++ b/.claude/skills/adr-writer/SKILL.md
@@ -2,7 +2,7 @@
 name: adr-writer
 description: "Write effective Architecture Decision Records. Use when: (1) Creating a new ADR, (2) Recording a design decision, (3) User mentions ADR, decision, trade-off, or alternatives"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
-argument-hint: [optional ADR topic]
+argument-hint: "[optional ADR topic]"
 ---
 
 # ADR Writer

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -2,7 +2,7 @@
 name: commit
 description: "Commit changes with govctl integration — check work item status, preserve durable notes only when needed, and run govctl check"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
-argument-hint: [optional commit message hint]
+argument-hint: "[optional commit message hint]"
 ---
 
 # /commit — Commit with Govctl Integration

--- a/.claude/skills/detach/SKILL.md
+++ b/.claude/skills/detach/SKILL.md
@@ -2,7 +2,7 @@
 name: detach
 description: "Remove govctl governance from a project. Archives artifacts, removes skills/agents, strips code references. Use when: (1) User wants to stop using govctl, (2) User mentions detach, opt-out, remove governance, or uninstall"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
-argument-hint: [optional scope hint]
+argument-hint: "[optional scope hint]"
 ---
 
 # /detach — Remove govctl Governance

--- a/.claude/skills/guard-writer/SKILL.md
+++ b/.claude/skills/guard-writer/SKILL.md
@@ -2,7 +2,7 @@
 name: guard-writer
 description: "Write well-structured Verification Guards. Use when: (1) Creating a new guard, (2) Editing guard check commands or patterns, (3) User mentions guard, verification, or check"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
-argument-hint: [optional guard topic]
+argument-hint: "[optional guard topic]"
 ---
 
 # Guard Writer

--- a/.claude/skills/init/SKILL.md
+++ b/.claude/skills/init/SKILL.md
@@ -2,7 +2,7 @@
 name: init
 description: "Set up govctl in the current project. Installs the binary if missing, initializes governance structure."
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
-argument-hint: [optional setup scope]
+argument-hint: "[optional setup scope]"
 ---
 
 # /init - Set Up Govctl

--- a/.claude/skills/migrate/SKILL.md
+++ b/.claude/skills/migrate/SKILL.md
@@ -2,7 +2,7 @@
 name: migrate
 description: "Adopt govctl in an existing project. Discovers undocumented decisions, backfills ADRs/RFCs, annotates source code. Use when: (1) Project has no governance yet, (2) User mentions migrate, adopt, onboard, or brownfield"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
-argument-hint: [optional scope hint, e.g. "focus on database decisions"]
+argument-hint: '[optional scope hint, e.g. "focus on database decisions"]'
 ---
 
 # /migrate — Adopt govctl in an Existing Project

--- a/.claude/skills/rfc-writer/SKILL.md
+++ b/.claude/skills/rfc-writer/SKILL.md
@@ -2,7 +2,7 @@
 name: rfc-writer
 description: "Write well-structured RFCs with normative clauses. Use when: (1) Creating a new RFC, (2) Adding or editing RFC clauses, (3) User mentions RFC, specification, or normative requirements"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
-argument-hint: [optional RFC topic]
+argument-hint: "[optional RFC topic]"
 ---
 
 # RFC Writer

--- a/.claude/skills/wi-writer/SKILL.md
+++ b/.claude/skills/wi-writer/SKILL.md
@@ -2,7 +2,7 @@
 name: wi-writer
 description: "Write well-structured work items with proper acceptance criteria. Use when: (1) Creating work items, (2) Adding acceptance criteria, (3) User mentions work item, task, WI, or ticket"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, TodoWrite
-argument-hint: [optional work-item topic]
+argument-hint: "[optional work-item topic]"
 ---
 
 # Work Item Writer


### PR DESCRIPTION
## Summary

Eight `.claude/skills/*/SKILL.md` files declare `argument-hint:` with an unquoted bracketed value, e.g.:

```yaml
argument-hint: [optional ADR topic]
```

YAML parses unquoted `[...]` as a **flow sequence**, so this field is loaded as an array (`["optional ADR topic"]`) rather than a string.

## Why this matters now

- **Copilot CLI 1.0.65** tightened its skill/command schema to require `argument-hint` to be a **string**. It now rejects the array form outright, so any user running these skills through the Copilot CLI sees the skill fail to load.
- **Claude Code** currently tolerates the array form, but the same root cause is tracked upstream in [anthropics/claude-code#22161](https://github.com/anthropics/claude-code/issues/22161) and could be tightened at any time.

## Fix

Quote each affected value so YAML parses it as a plain string. Rendered hint text is unchanged.

| File | Before | After |
| --- | --- | --- |
| `adr-writer/SKILL.md` | `[optional ADR topic]` | `"[optional ADR topic]"` |
| `commit/SKILL.md` | `[optional commit message hint]` | `"[optional commit message hint]"` |
| `detach/SKILL.md` | `[optional scope hint]` | `"[optional scope hint]"` |
| `guard-writer/SKILL.md` | `[optional guard topic]` | `"[optional guard topic]"` |
| `init/SKILL.md` | `[optional setup scope]` | `"[optional setup scope]"` |
| `migrate/SKILL.md` | `[optional scope hint, e.g. "focus on database decisions"]` | `'[optional scope hint, e.g. "focus on database decisions"]'` |
| `rfc-writer/SKILL.md` | `[optional RFC topic]` | `"[optional RFC topic]"` |
| `wi-writer/SKILL.md` | `[optional work-item topic]` | `"[optional work-item topic]"` |

`migrate/SKILL.md` uses **single**-quoted YAML because the value contains inner double quotes; single quotes avoid the need for escapes and keep the rendered text byte-for-byte identical.

The four skills that use angle-bracket placeholders (`discuss`, `gov`, `quick`, `spec`, e.g. `argument-hint: <what-to-do>`) are already valid YAML plain scalars and are intentionally left alone. `decision-analysis/SKILL.md` has no `argument-hint` and is unaffected.

## Test plan

- [x] Full-tree scan (`grep -rHn '^argument-hint:' --include='*.md'`) enumerates all 12 SKILL.md files with the field.
- [x] Parse each SKILL.md's frontmatter with a YAML parser and assert `type(argument-hint) is str` — passes for all 12 after this change (was failing for the 8 files above).
- [x] Rendered hint text is unchanged; only the YAML type flips from sequence to string.
- [x] Load a fixed skill under Copilot CLI 1.0.65 and confirm it no longer errors on the `argument-hint` field.
- [x] Load a fixed skill under current Claude Code and confirm it still works (regression check).

## References

- Copilot CLI 1.0.65 schema tightening — string required for `argument-hint`
- [anthropics/claude-code#22161](https://github.com/anthropics/claude-code/issues/22161) — latent same-cause issue on Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized several skill metadata hints to use quoted text, improving consistency and reliability when optional prompts are displayed or parsed.
  * Updated multiple workflow templates without changing their behavior or commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
